### PR TITLE
Add account display command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -266,4 +266,26 @@ program
       });
   });
 
+program
+  .command("account")
+  .description("Display currently logged in account.")
+  .action(
+    async () => {
+      keytar
+        .findCredentials("genez.io")
+        .then(async (credentials) => {
+          if (Array.isArray(credentials) && credentials.length) {
+            credentials.forEach(async (credential) => {
+              console.log("Logged in as: " + credential.account);
+            })
+          } else {
+            console.log("Unauthorized. You are not logged in.")
+          }
+        })
+        .catch(() => {
+          console.log("Cannot access keychain.")
+        })
+    }
+  );
+
 program.parse();


### PR DESCRIPTION
Add command to display the logged in account in CLI.

If no account is in the keychain, displays `Unauthorized. You are not logged in.`.