### PR TITLE
Fixes for genezio usage

### DIFF
--- a/examples/blockchain/README.md
+++ b/examples/blockchain/README.md
@@ -4,7 +4,10 @@ In this example, we have implemented a class that queries periodically using Bla
 
 The class is implemented in the `blockchainServer.js` file.
 
-Run `npm install` in both `backend/` and `frontend/` folders.
+## Initialization
+
+1. Run `npm install` in the `backend/` folder to install the dependencies.
+2. Run `npm install` in the `frontend/` folder to install the dependencies.
 
 ## Run the example locally
 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -6,6 +6,10 @@ The class is implemented in the `hello.js` file.
 
 To deploy and test it run `genezio deploy`. Once the command was successfully executed you can run `node test-hello-sdk.js`.
 
+## Initialization
+
+1. Run `npm install` to install the dependencies.
+
 ## Run the example locally
 
 1. Run `genezio local`. This will generate the SDK and start a local web server that listens for requests.

--- a/examples/todo-list/README.md
+++ b/examples/todo-list/README.md
@@ -10,10 +10,10 @@ This is an example of a todo application with users, auth and tasks that uses Re
 
 ## Run the example locally
 
-1. Run `genezio local` in the project's folder to start the local server.
+1. Run `genezio local` in the `backend/` folder to start the local server.
 2. Start the React app by going to the `frontend/` folder and run `npm start`.
 
 ## Deploy the example in the Genezio infrastructure
 
-1. Run `genezio deploy` in the project's root folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
+1. Run `genezio deploy` in the `backend/` folder that contains also the `genezio.yaml` file. This will deploy your code in the Genezio infrastructure and it will also create an SDK that can be used to call the methods remotely.
 2. Start the React app by going to the `frontend/` folder and run `npm start`.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,7 +128,7 @@ export async function addNewClass(classPath: string, classType: string) {
     return;
   }
 
-  const projectConfiguration = await getProjectConfiguration();
+  const projectConfiguration = await getProjectConfiguration()
 
   const className = classPath.split(path.sep).pop();
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,7 +128,7 @@ export async function addNewClass(classPath: string, classType: string) {
     return;
   }
 
-  const projectConfiguration = await getProjectConfiguration()
+  const projectConfiguration = await getProjectConfiguration();
 
   const className = classPath.split(path.sep).pop();
 
@@ -225,6 +225,12 @@ export async function deployClasses() {
 
   const promisesDeploy: any = configuration.classes.map(
     async (element: any) => {
+      if (!(await fileExists(element.path))) {
+        throw new Error(
+          `\`${element.path}\` file does not exist at the indicated path.`
+        );
+      }
+
       switch (element.language) {
         case ".js": {
           const bundler = new NodeJsBundler();
@@ -279,7 +285,7 @@ export async function deployClasses() {
 
   reportSuccess(classesInfo, configuration);
   
-  let projectId = classesInfo[0].projectId
+  const projectId = classesInfo[0].projectId
   console.log(`Your project has been deployed and is available at ${REACT_APP_BASE_URL}/project/${projectId}`)
 }
 

--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -8,6 +8,7 @@ import { ProjectConfiguration } from "./models/projectConfiguration";
 import { NodeJsBundler } from "./bundlers/javascript/nodeJsBundler";
 import LocalEnvInputParameters from "./models/localEnvInputParams";
 import log from "loglevel";
+import { fileExists } from "./utils/file";
 
 export function getEventObjectFromRequest(request: any) {
   return {
@@ -157,7 +158,13 @@ export async function prepareForLocalEnvironment(
     functionUrl: string;
   }[] = [];
 
-  const promises = projectConfiguration.classes.map((element) => {
+  const promises = projectConfiguration.classes.map(async (element: any) => {
+    if (!(await fileExists(element.path))) {
+      throw new Error(
+        `\`${element.path}\` file does not exist at the indicated path.`
+      );
+    }
+
     switch (element.language) {
       case ".js": {
         const bundler = new NodeJsBundler();

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -98,12 +98,6 @@ export class ClassConfiguration {
     if (!classConfigurationYaml.path) {
       throw new Error("Path is missing from class.")
     }
-
-    if (!(await fileExists(classConfigurationYaml.path))) {
-      throw new Error(
-        `\`${classConfigurationYaml.path}\` file does not exist at the indicated path.`
-      );
-    }
     
     if (classConfigurationYaml.type && !TriggerType[classConfigurationYaml.type as keyof typeof TriggerType]) {
       throw new Error("The type is incorrect.")

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import yaml from "yaml";
-import { getFileDetails, writeToFile } from '../utils/file';
+import { fileExists, getFileDetails, writeToFile } from '../utils/file';
 
 export enum TriggerType {
   jsonrpc = "jsonrpc",
@@ -99,6 +99,12 @@ export class ClassConfiguration {
       throw new Error("Path is missing from class.")
     }
 
+    if (!(await fileExists(classConfigurationYaml.path))) {
+      throw new Error(
+        `\`${classConfigurationYaml.path}\` file does not exist at the indicated path.`
+      );
+    }
+    
     if (classConfigurationYaml.type && !TriggerType[classConfigurationYaml.type as keyof typeof TriggerType]) {
       throw new Error("The type is incorrect.")
     }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,4 +1,4 @@
 export const REACT_APP_BASE_URL = "https://dev.app.genez.io";
-export const BACKEND_ENDPOINT = "http://localhost:8080";
+export const BACKEND_ENDPOINT = "https://dev.api.genez.io";
 export const GENERATE_SDK_API_URL = "https://dev-sdk-api.genez.io";
 export const PORT_LOCAL_ENVIRONMENT = 8083;


### PR DESCRIPTION
Bugs fixed:
* GNZ-250 - `genezio` will show help and return code 0 when executed without any options/commands
* GNZ-251 - Checked examples/README.md to contain `npm install` where needed
* GNZ-252 - Added nice info for unknown commands/options when using `genezio`
* GNZ-277 - Exit gracefully when user is not logged and executes `genezio local`
* GNZ-278 - Added check if classes exists at the path mentioned in `genezio.yaml`. Affects `genezio local`, `genezio deploy` and `genezio addClass`.