### PR TITLE
basic folder structure

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -425,7 +425,16 @@ classes:
 
   const yamlConfigurationFileContent = doc.toString();
 
-  await writeToFile(".", "genezio.yaml", yamlConfigurationFileContent).catch(
+  if (!fs.existsSync(`./${projectName}`)) {
+    fs.mkdirSync(projectName);
+  }
+  if (!fs.existsSync(`./${projectName}/server`)) {
+    fs.mkdirSync(`./${projectName}/server`);
+  }
+  if (!fs.existsSync(`./${projectName}/client`)) {
+    fs.mkdirSync(`./${projectName}/client`);
+  }
+  await writeToFile(`./${projectName}/server`, "genezio.yaml", yamlConfigurationFileContent).catch(
     (error) => {
       log.error(error.toString());
     }


### PR DESCRIPTION
Created basic folder structure for genezio init.
project_name
|_server
|   |_genezio.yaml
|_client

Things to think about:
- what should we add as an example? option: HelloWorldClass in server and simple test with arraw function in client
- where do we generate SDK? normally, default should be ../client, but this folder does not exist at the time the user runs genezio init.