### PR TITLE
Convert non-standard crons to standard crons for local deployment

### DIFF
--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -188,6 +188,8 @@ export async function stopCronJobs(cronHandlers: LocalEnvCronHandler[]) {
   }
 }
 
+// Converts non-standard cron strings of the type X/Y * * * * to standard X-59/Y * * * *,
+// applied to all fields.
 export function rectifyCronString(cronString: string): string {
   const parts = cronString.split(' ');
   const minutes = parts[0].replace(/^(\d+)\/(\d+)$/, '$1-59/$2');

--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -196,8 +196,11 @@ export function rectifyCronString(cronString: string): string {
   const hours = parts[1].replace(/^(\d+)\/(\d+)$/, '$1-23/$2');
   const dom = parts[2].replace(/^(\d+)\/(\d+)$/, '$1-31/$2');
   const month = parts[3].replace(/^(\d+)\/(\d+)$/, '$1-12/$2');
+  // for the day-of-week field, since 0 is Sunday, and strings like 2/1 go from Tuesday to Sunday
+  // the holistic approach would be to convert it into a comma separated list of days, as a range
+  // representation would be a bit heavy
   const dow = parts[4].replace(/^(\d+)\/(\d+)$/, (_, start, step) => {
-    const end = 6; // Set the end value to 6 for weekday fields
+    const end = 7; s// set the end value to 6 for weekday fields
     const range = [];
     for (let i = parseInt(start); i <= end; i += parseInt(step)) {
       range.push(i);

--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -100,7 +100,7 @@ export async function listenForChanges(
   const cwd = process.cwd();
 
   let sdkPath: any = null;
-  
+
   if (sdkPathRelative) {
     sdkPath = path.join(cwd, sdkPathRelative);
   }
@@ -188,6 +188,12 @@ export async function stopCronJobs(cronHandlers: LocalEnvCronHandler[]) {
   }
 }
 
+export function rectifyCronString(cronString: string): string {
+  const parts = cronString.split(' ');
+  const minutes = parts[0].replace(/^(\d+)\/(\d+)$/, '$1-59/$2');
+  return minutes + ' ' + parts.slice(1).join(' ');
+}
+
 export async function prepareCronHandlers(
   classesInfo: any,
   handlers: any
@@ -200,7 +206,7 @@ export async function prepareCronHandlers(
         const cronHandler: LocalEnvCronHandler = {
           className: classElement.className,
           methodName: method.name,
-          cronString: method.cronString,
+          cronString: rectifyCronString(method.cronString),
           path: handlers[classElement.className].path,
           cronObject: null,
           module: handlers[classElement.className].module

--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -191,7 +191,12 @@ export async function stopCronJobs(cronHandlers: LocalEnvCronHandler[]) {
 export function rectifyCronString(cronString: string): string {
   const parts = cronString.split(' ');
   const minutes = parts[0].replace(/^(\d+)\/(\d+)$/, '$1-59/$2');
-  return minutes + ' ' + parts.slice(1).join(' ');
+  const hours = parts[1].replace(/^(\d+)\/(\d+)$/, '$1-23/$2');
+  const dom = parts[2].replace(/^(\d+)\/(\d+)$/, '$1-31/$2');
+  const month = parts[3].replace(/^(\d+)\/(\d+)$/, '$1-12/$2');
+  const dow = parts[4].replace(/^(\d+)\/(\d+)$/, '$1-7/$2').replace('7', '0');
+
+  return `${minutes} ${hours} ${dom} ${month} ${dow}`;
 }
 
 export async function prepareCronHandlers(

--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -196,7 +196,7 @@ export function rectifyCronString(cronString: string): string {
   const hours = parts[1].replace(/^(\d+)\/(\d+)$/, '$1-23/$2');
   const dom = parts[2].replace(/^(\d+)\/(\d+)$/, '$1-31/$2');
   const month = parts[3].replace(/^(\d+)\/(\d+)$/, '$1-12/$2');
-  const dow = parts[4].replace(/^(\d+)\/(\d+)$/, '$1-7/$2').replace('7', '0');
+  const dow = parts[4].replace(/^(\d+)\/(\d+)$/, '$0-6/$2');
 
   return `${minutes} ${hours} ${dom} ${month} ${dow}`;
 }

--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -196,8 +196,14 @@ export function rectifyCronString(cronString: string): string {
   const hours = parts[1].replace(/^(\d+)\/(\d+)$/, '$1-23/$2');
   const dom = parts[2].replace(/^(\d+)\/(\d+)$/, '$1-31/$2');
   const month = parts[3].replace(/^(\d+)\/(\d+)$/, '$1-12/$2');
-  const dow = parts[4].replace(/^(\d+)\/(\d+)$/, '$0-6/$2');
-
+  const dow = parts[4].replace(/^(\d+)\/(\d+)$/, (_, start, step) => {
+    const end = 6; // Set the end value to 6 for weekday fields
+    const range = [];
+    for (let i = parseInt(start); i <= end; i += parseInt(step)) {
+      range.push(i);
+    }
+    return range.join(',') + '/' + step;
+  }).replace('7', '0');
   return `${minutes} ${hours} ${dom} ${month} ${dow}`;
 }
 

--- a/src/localEnvironment.ts
+++ b/src/localEnvironment.ts
@@ -200,7 +200,7 @@ export function rectifyCronString(cronString: string): string {
   // the holistic approach would be to convert it into a comma separated list of days, as a range
   // representation would be a bit heavy
   const dow = parts[4].replace(/^(\d+)\/(\d+)$/, (_, start, step) => {
-    const end = 7; s// set the end value to 6 for weekday fields
+    const end = 7; // set the end value to 6 for weekday fields
     const range = [];
     for (let i = parseInt(start); i <= end; i += parseInt(step)) {
       range.push(i);

--- a/tests/projectConfiguration.test.ts
+++ b/tests/projectConfiguration.test.ts
@@ -3,7 +3,7 @@ import {
   YamlProjectConfiguration,
   TriggerType
 } from "../src/models/yamlProjectConfiguration";
-
+import { rectifyCronString } from "../src/localEnvironment";
 
 describe("project configuration", () => {
   test("missing name should throw error", async () => {
@@ -32,7 +32,7 @@ describe("project configuration", () => {
       };
       await YamlProjectConfiguration.create(yaml);
     }).rejects.toThrowError("The sdk.language property is missing.");
-  }); 
+  });
 
   test("missing sdk.path should throw error", async () => {
     await expect(async () => {
@@ -431,5 +431,13 @@ describe("project configuration", () => {
     expect(configuration.classes[0].methods[2].type).toEqual(TriggerType.cron);
     expect(configuration.classes[0].methods[2].name).toEqual("method3");
     return {};
+  });
+
+  test("convert nonstandard cron strings", async () => {
+    expect(rectifyCronString("* * * * *")).toEqual("* * * * *");
+    expect(rectifyCronString("2/1 * * * *")).toEqual("2-59/1 * * * *");
+    expect(rectifyCronString("1 * * * *")).toEqual("1 * * * *");
+    expect(rectifyCronString("2-59/5 * * * *")).toEqual("2-59/5 * * * *");
+    expect(rectifyCronString("2/1 2/1 2/1 2/1 2/1")).toEqual("2-59/1 2-23/1 2-31/1 2-12/1 2-6/1");
   });
 });

--- a/tests/projectConfiguration.test.ts
+++ b/tests/projectConfiguration.test.ts
@@ -438,6 +438,6 @@ describe("project configuration", () => {
     expect(rectifyCronString("2/1 * * * *")).toEqual("2-59/1 * * * *");
     expect(rectifyCronString("1 * * * *")).toEqual("1 * * * *");
     expect(rectifyCronString("2-59/5 * * * *")).toEqual("2-59/5 * * * *");
-    expect(rectifyCronString("2/1 2/1 2/1 2/1 2/1")).toEqual("2-59/1 2-23/1 2-31/1 2-12/1 2-6/1");
+    expect(rectifyCronString("2/1 2/1 2/1 2/1 2/1")).toEqual("2-59/1 2-23/1 2-31/1 2-12/1 2,3,4,5,6,0/1");
   });
 });


### PR DESCRIPTION
`2/5 * * * *` is a non-standard cron string as per https://crontab.guru/#2/5_*_*_*_* . The `node-cron` library doesn't support this format, although both Windows, Linux and AWS Lambda support it. The easiest solution was to detect these strings when deploying locally, and convert them to standard cron strings that have the same meaning:

`2/5 * * * *` == `2-59/5`

Rinse and repeat for all fields.