### PR TITLE
Improve unit tests CI/CD

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -2,8 +2,13 @@ name: Unit Tests
 
 on:
   push:
+    branches:
+      - master
+      - dev
+    paths-ignore:
+      - '**/*.md'
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "./scripts/lint",
     "checkChangesInVariables": "./scripts/checkConstants",
     "release": "npm run build && npm publish",
-    "test": "jest"
+    "test": "jest --testPathPattern tests"
   },
   "files": [
     "/build"


### PR DESCRIPTION
I fixed `jest` picking on some Angular unit tests from the `examples` folder (this behavior is reproducible only locally because in the CI/CD we are not fetching the submodules).

The CI/CD was run twice at every PR (once for the generic `push` trigger and once for the `pull_request` trigger). I fixed it by explicitly running the action only for pushing to `dev` or `master`. For all of the other pushes, the action will be triggered from the `pull_request` trigger. 