### PR TITLE
GNZ-774 Throw an error for unsupported built-in dart:core types

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,3 +16,5 @@ Error: \`dartaotruntime\` not found
 
 Please ensure that \`dartaotruntime\` is installed and its binary is added to your system's PATH environment variable. Check the Dart documentation for more information: https://dart.dev/get-dart.`;
 export const GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART = `We don't currently support Optional types. We will soon add support for this feature.`;
+
+export const GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE = `Our AST doesn't currently support this specific Dart built-in type. Check the documentation for more details https://docs.genez.io/genezio-documentation/programming-languages/dart\n\nPlease add a Github issue to https://github.com/Genez-io/genezio/issues describing your use case for this type or feel free to contribute yourself with an improvement.`;


### PR DESCRIPTION
# Pull Request Template

## Description

Created a list with all the types/errors that genezio AST is not currently supporting.
If a type is on this list, the tool will throw an error.

The list was created by looking into the official documentation from [dart:core ](https://api.dart.dev/be/180791/dart-core/dart-core-library.html#classes)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Manually by running genezio locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
