### PR TITLE
[HOT FIX ] Update dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,4 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: Europe/Bucharest
+    versioning-strategy: increase


### PR DESCRIPTION
Force update on both `package.json` and package-lock.json`.

Right now, there are commits where only `package-lock.json` was modified and that is not persistent to `npm install`.

The `dependabot.yaml` has to be changed on master, otherwise, the changes are not taking effect.