### PR TITLE
GNZ-816 Fix deprecation warning related to `fs.rmdir`

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -55,7 +55,7 @@ export async function deployCommand(options: any) {
   }
 
   let configuration
-  
+
   try {
     configuration = await getProjectConfiguration();
   } catch (error: any) {
@@ -387,7 +387,7 @@ export async function deployFrontend(configuration: YamlProjectConfiguration) {
     );
     debugLogger.debug("Uploaded to S3.");
     await createFrontendProject(configuration.frontend.subdomain, configuration.name, configuration.region)
-    
+
     // clean up temporary folder
     await deleteFolder(path.dirname(archivePath));
   } else {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -141,7 +141,7 @@ export async function createTemporaryFolder(name = "foo-"): Promise<string> {
 
 export async function deleteFolder(folderPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    fs.rmdir(folderPath, { recursive: true }, (error) => {
+    fs.rm(folderPath, { recursive: true , force: true}, (error) => {
       if (error) {
         reject(error);
       }
@@ -206,7 +206,6 @@ export async function validateYamlFile() {
   const configurationFileContentUTF8 = await readUTF8File("./genezio.yaml");
 
   let configurationFileContent = null;
-    
   try {
     configurationFileContent = await parse(configurationFileContentUTF8);
   }


### PR DESCRIPTION
# Pull Request Template

## Description

`fs.rmdir` is deprecate. Node is advising to use `fs.rm` instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
