### PR TITLE
GNZ-818 Disable fatal warnings for dart analyzer

### DIFF
--- a/src/bundlers/dart/dartBundler.ts
+++ b/src/bundlers/dart/dartBundler.ts
@@ -28,7 +28,7 @@ export class DartBundler implements BundlerInterface {
     }
 
     async #analyze(path: string) {
-        const result = spawnSync("dart", ["analyze"], { cwd: path });
+        const result = spawnSync("dart", ["analyze", "--no-fatal-warnings"], { cwd: path });
 
         if (result.status != 0) {
             log.info(result.stdout.toString().split("\n").slice(1).join("\n"));

--- a/src/bundlers/dart/localDartBundler.ts
+++ b/src/bundlers/dart/localDartBundler.ts
@@ -15,6 +15,15 @@ import { castArrayRecursivelyInitial, castMapRecursivelyInitial } from "../../ut
 
 export class DartBundler implements BundlerInterface {
 
+    async #analyze(path: string) {
+        const result = spawnSync("dart", ["analyze", "--no-fatal-warnings"], { cwd: path });
+
+        if (result.status != 0) {
+            log.info(result.stdout.toString().split("\n").slice(1).join("\n"));
+            throw new Error("Compilation error! Please check your code and try again.");
+        }
+    }
+
     #castParameterToPropertyType(node: Node, variableName: string): string {
         let implementation = "";
 
@@ -107,6 +116,9 @@ export class DartBundler implements BundlerInterface {
 
         // Check if dart is installed
         await checkIfDartIsInstalled();
+
+        // Analyze the Dart code on the server
+        await this.#analyze(inputTemporaryFolder);
 
         // Compile the Dart code on the server
         debugLogger.info("Compiling Dart...")


### PR DESCRIPTION
# Pull Request Template

## Description

Disabling fatal warnings for dart analyzer. This will relax the conditions of bundling dart projects for now.

Also, I added the analyzing step for the local environment. Otherwise the local and the production environments are not in-sync anymore.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
