### PR TITLE
Bump `aws_lambda_dart_runtime` to ^1.1.0 to make it work with Dart 3

### DIFF
--- a/src/bundlers/dart/dartBundler.ts
+++ b/src/bundlers/dart/dartBundler.ts
@@ -162,7 +162,7 @@ export class DartBundler implements BundlerInterface {
     }
 
     async #addLambdaRuntimeDepenendecy(path: string) {
-        const success = await runNewProcess("dart pub add aws_lambda_dart_runtime:'^1.0.3+2'", path, false);
+        const success = await runNewProcess("dart pub add aws_lambda_dart_runtime:'^1.1.0'", path, false);
 
         if (!success) {
             throw new Error("Error while adding aws_lambda_dart_runtime dependency");


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 🍕 New feature
- [ ] 🐛 Bug Fix
- [ ] 🔥 Breaking change
- [x] 🧑‍💻 Improvement
- [ ] 📝 Documentation Update

## Description
`aws_lambda_dart_runtime` 1.0.3 is no longer supported for Dart 3.0. Bump the dependency version to ensure program compiles.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [ ] I have updated the documentation;
- [ ] I have added tests;
- [ ] New and existing unit tests pass locally with my changes;
