### PR TITLE
Use the original path instead of using the path of the temp folder path

### DIFF
--- a/src/bundlers/javascript/nodeJsBundler.ts
+++ b/src/bundlers/javascript/nodeJsBundler.ts
@@ -201,6 +201,7 @@ export class NodeJsBundler implements BundlerInterface {
       ...input,
       path: temporaryFolder,
       extra: {
+        originalPath: input.path,
         dependenciesInfo: input.extra!.dependenciesInfo
       }
     };

--- a/src/bundlers/javascript/nodeJsDependenciesBundler.ts
+++ b/src/bundlers/javascript/nodeJsDependenciesBundler.ts
@@ -52,12 +52,13 @@ export class NodeJsDependenciesBundler implements BundlerInterface {
   }
 
   async bundle(input: BundlerInput): Promise<BundlerOutput> {
-    const dependenciesInfo = await this.#getNodeModulesJs(input.path)
+    const dependenciesInfo = await this.#getNodeModulesJs(input.extra!.originalPath)
 
     return {
       ...input,
       extra: {
         ...input.extra,
+        originalPath: input.path,
         dependenciesInfo
       }
     };

--- a/src/bundlers/typescript/nodeTsBundler.ts
+++ b/src/bundlers/typescript/nodeTsBundler.ts
@@ -223,6 +223,7 @@ export class NodeTsBundler implements BundlerInterface {
             ...input,
             path: temporaryFolder,
             extra: {
+                originalPath: input.path,
                 dependenciesInfo: input.extra?.dependenciesInfo
             }
         };

--- a/src/bundlers/typescript/nodeTsDependenciesBundler.ts
+++ b/src/bundlers/typescript/nodeTsDependenciesBundler.ts
@@ -52,12 +52,13 @@ export class NodeTsDependenciesBundler implements BundlerInterface {
   }
 
   async bundle(input: BundlerInput): Promise<BundlerOutput> {
-    const dependenciesInfo = await this.#getNodeModulesTs(input.path)
+    const dependenciesInfo = await this.#getNodeModulesTs(input.extra!.originalPath)
 
     return {
       ...input,
       extra: {
         ...input.extra,
+        originalPath: input.path,
         dependenciesInfo
       }
     };


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description

Temporarily, we've removed the logic that selects only the dependencies needed by a class because of some bugs with CommonJS and ESModule. However, this caused a problem with the binary dependencies. I was using the wrong path in the bundler.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] I have added tests;
- [x] New and existing unit tests pass locally with my changes;
