### PR TITLE
GNZ-817 Auto-delete `/tmp` folders for dart projects and `genezio local`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "genezio",
-  "version": "0.3.12",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genezio",
-      "version": "0.3.12",
+      "version": "0.4.0",
       "license": "GPL-3",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.315.0",
@@ -52,7 +52,7 @@
         "path": "^0.12.7",
         "terminal-overwrite": "^2.0.1",
         "ts-loader": "^9.4.1",
-        "typescript": "^5.0.4",
+        "typescript": "^5.1.3",
         "typescript-parser": "^2.6.1",
         "unique-names-generator": "^4.7.1",
         "webpack": "^5.74.0",
@@ -11739,15 +11739,15 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-parser": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "path": "^0.12.7",
     "terminal-overwrite": "^2.0.1",
     "ts-loader": "^9.4.1",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.3",
     "typescript-parser": "^2.6.1",
     "unique-names-generator": "^4.7.1",
     "webpack": "^5.74.0",

--- a/src/bundlers/dart/dartBundler.ts
+++ b/src/bundlers/dart/dartBundler.ts
@@ -152,11 +152,13 @@ export class DartBundler implements BundlerInterface {
         const archiveDirectoryOutput = await createTemporaryFolder();
         const archivePath = path.join(archiveDirectoryOutput, archiveName);
 
-        await zipDirectory(userCodeFolderPath, archivePath);
-        await uploadContentToS3(presignedUrlResult.presignedURL, archivePath)
-
-        // remove temporary folder
-        await deleteFolder(archiveDirectoryOutput);
+        try {
+            await zipDirectory(userCodeFolderPath, archivePath);
+            await uploadContentToS3(presignedUrlResult.presignedURL, archivePath)
+        } finally {
+            // remove temporary folder
+            await deleteFolder(archiveDirectoryOutput);
+        }
 
         return archiveName;
     }
@@ -203,44 +205,54 @@ export class DartBundler implements BundlerInterface {
         // Create a temporary folder were we copy user code to prepare everything.
         const folderPath = input.genezioConfigurationFilePath;
         const inputTemporaryFolder = await createTemporaryFolder(input.configuration.name);
-        await fsExtra.copy(folderPath, inputTemporaryFolder);
-        debugLogger.debug(`Copy files in temp folder ${inputTemporaryFolder}`);
+        let temporaryFolder: string | undefined = undefined;
 
-        // Create the router class
-        const userClass = input.projectConfiguration.classes.find((c: ClassConfiguration) => c.path == input.path)!;
-        this.#createRouterFileForClass(userClass, input.ast, inputTemporaryFolder);
+        try {
+            await fsExtra.copy(folderPath, inputTemporaryFolder);
+            debugLogger.debug(`Copy files in temp folder ${inputTemporaryFolder}`);
 
-        // Check if dart is installed
-        await checkIfDartIsInstalled();
+            // Create the router class
+            const userClass = input.projectConfiguration.classes.find((c: ClassConfiguration) => c.path == input.path)!;
+            this.#createRouterFileForClass(userClass, input.ast, inputTemporaryFolder);
 
-        await this.#addLambdaRuntimeDepenendecy(inputTemporaryFolder);
+            // Check if dart is installed
+            await checkIfDartIsInstalled();
 
-        await this.#analyze(inputTemporaryFolder);
+            await this.#addLambdaRuntimeDepenendecy(inputTemporaryFolder);
 
-        const archiveName = await this.#uploadUserCodeToS3(input.projectConfiguration.name, userClass.name, inputTemporaryFolder);
+            await this.#analyze(inputTemporaryFolder);
 
-        // Compile the Dart code on the server
-        debugLogger.debug("Compiling Dart...")
-        const s3Zip: any = await this.#compile(archiveName)
-        debugLogger.debug("Compiling Dart finished.")
+            const archiveName = await this.#uploadUserCodeToS3(input.projectConfiguration.name, userClass.name, inputTemporaryFolder);
 
-        if (s3Zip.success === false) {
-            throw new Error("Failed to upload code for compiling.");
+            // Compile the Dart code on the server
+            debugLogger.debug("Compiling Dart...")
+            const s3Zip: any = await this.#compile(archiveName)
+            debugLogger.debug("Compiling Dart finished.")
+
+            if (s3Zip.success === false) {
+                throw new Error("Failed to upload code for compiling.");
+            }
+
+            temporaryFolder = await createTemporaryFolder()
+
+            try {
+                debugLogger.debug(`Copy all non dart files to folder ${temporaryFolder}...`);
+                await this.#copyNonDartFiles(temporaryFolder);
+                debugLogger.debug("Copy all non dart files to folder done.");
+    
+    
+                debugLogger.debug("Downloading compiled code...")
+                await this.#downloadAndUnzipFromS3ToFolder(s3Zip.downloadUrl, temporaryFolder)
+                debugLogger.debug("Finished downloading compiled code...")
+            } catch (error) {
+                await deleteFolder(temporaryFolder);
+                throw error;
+            }
+        } finally {
+            // remove temporary folder
+            await deleteFolder(inputTemporaryFolder);
         }
-
-        const temporaryFolder = await createTemporaryFolder()
-
-        debugLogger.debug(`Copy all non dart files to folder ${temporaryFolder}...`);
-        await this.#copyNonDartFiles(temporaryFolder);
-        debugLogger.debug("Copy all non dart files to folder done.");
-
-
-        debugLogger.debug("Downloading compiled code...")
-        await this.#downloadAndUnzipFromS3ToFolder(s3Zip.downloadUrl, temporaryFolder)
-        debugLogger.debug("Finished downloading compiled code...")
-
-        // remove temporary folder
-        await deleteFolder(inputTemporaryFolder);
+        
 
         return {
             ...input,

--- a/src/bundlers/dart/localDartBundler.ts
+++ b/src/bundlers/dart/localDartBundler.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import Mustache from "mustache";
-import { createTemporaryFolder, writeToFile } from "../../utils/file";
+import { createTemporaryFolder, deleteFolder, writeToFile } from "../../utils/file";
 import { BundlerInput, BundlerInterface, BundlerOutput } from "../bundler.interface";
 import { checkIfDartIsInstalled } from "../../utils/dart";
 import { debugLogger } from "../../utils/logging";
@@ -20,6 +20,10 @@ export class DartBundler implements BundlerInterface {
 
         if (result.status != 0) {
             log.info(result.stdout.toString().split("\n").slice(1).join("\n"));
+
+            // Delete the temporary folder if the compilation fails
+            await deleteFolder(path);
+
             throw new Error("Compilation error! Please check your code and try again.");
         }
     }
@@ -99,6 +103,10 @@ export class DartBundler implements BundlerInterface {
         if (result.status != 0) {
             log.info(result.stderr.toString());
             log.info(result.stdout.toString());
+
+            // Delete the temporary folder if the compilation fails
+            await deleteFolder(folderPath);
+
             throw new Error("Compilation error! Please check your code and try again.");
         }
     }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -158,7 +158,7 @@ export async function directoryContainsIndexHtmlFiles(directoryPath: string): Pr
   });
 }
 
-export async function createTemporaryFolder(name = "foo-"): Promise<string> {
+export async function createTemporaryFolder(name = "genezio-"): Promise<string> {
   return new Promise((resolve, reject) => {
     fs.mkdtemp(path.join(os.tmpdir(), name), (error: any, folder: string) => {
       if (error) {


### PR DESCRIPTION
# Auto-delete `/tmp` folders for dart projects and genezio local

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description
Previously, there were a lot of temporary folders created if dart projects were deployed using `genezio deploy` or if any kind of project was tested with `genezio local`.

Fixed this by removing all those folders in case of errors.

Also, updated the name of the temporary folders to start with `genezio-` prefix, instead of `foo-`.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [ ] I have added tests;
