### PR TITLE
fix: return status code 1 instead of status code 0 for already used p…

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -414,6 +414,7 @@ async function startServerHttp(
       }
 
       reject(error);
+      process.exit(1);
     });
   });
 }


### PR DESCRIPTION


- [ ] 🐛 Bug Fix

## Description
return status code 1 instead of status code 0 for already used ports

