### PR TITLE
Rework temporary folder system so that `genezio local` does not copy …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "fs": "^0.0.1-security",
         "fs-extra": "^11.1.1",
         "glob": "^8.0.3",
+        "hash-it": "^6.0.0",
         "json5": "~2.2.3",
         "loglevel": "^1.8.1",
         "loglevel-plugin-prefix": "^0.8.4",
@@ -7881,6 +7882,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/hash-it": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-6.0.0.tgz",
+      "integrity": "sha512-KHzmSFx1KwyMPw0kXeeUD752q/Kfbzhy6dAZrjXV9kAIXGqzGvv8vhkUqj+2MGZldTo0IBpw6v7iWE7uxsvH0w=="
     },
     "node_modules/hash.js": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "fs": "^0.0.1-security",
     "fs-extra": "^11.1.1",
     "glob": "^8.0.3",
+    "hash-it": "^6.0.0",
     "json5": "~2.2.3",
     "loglevel": "^1.8.1",
     "loglevel-plugin-prefix": "^0.8.4",

--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -84,7 +84,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
 
     async deployFrontend(projectName: string, projectRegion: string, frontend: YamlFrontend): Promise<string> {
         const archivePath = path.join(
-            await createTemporaryFolder("genezio-"),
+            await createTemporaryFolder(),
             `${frontend.subdomain}.zip`
         );
         debugLogger.debug("Creating temporary folder", archivePath);

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -33,6 +33,7 @@ import { DartBundler } from "../bundlers/dart/localDartBundler.js";
 import axios, { AxiosResponse } from "axios";
 import { findAvailablePort } from "../utils/findAvailablePort.js";
 import { YamlProjectConfiguration } from "../models/yamlProjectConfiguration.js";
+import hash from 'hash-it';
 
 type ClassProcess = {
   process: ChildProcess;
@@ -235,8 +236,9 @@ async function startProcesses(
     )!.program;
 
     debugLogger.log("Start bundling...");
-    // TODO: Is it worth the extra complexity of maintaining the folder?
-    return createTemporaryFolder(classInfo.name).then(async (tmpFolder) => {
+    return createTemporaryFolder(
+      `${classInfo.name}-${hash(classInfo.path)}`
+    ).then(async (tmpFolder) => {
       const bundlerOutput = await bundler.bundle({
         projectConfiguration,
         path: classInfo.path,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,15 @@
 #! /usr/bin/env node
 
 import program from "./genezio.js";
+import { cleanupTemporaryFolders } from "./utils/file.js";
+
+// Set-up SIGINT and exit handlers that clean up the temporary folder structure
+process.on('SIGINT', async () => {
+    await cleanupTemporaryFolders();
+    process.exit();
+});
+process.on('exit', async (code) => {
+    await cleanupTemporaryFolders();
+});
 
 program.parse();


### PR DESCRIPTION
<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->


- [x] 🐛 Bug Fix
- [x] 🧑‍💻 Improvement

## Description

The new system has a root folder named `genezio-${PID}` which contains all temporary folders. At the end of the program we delete this folder for clean up.

The class folders will be named after their class name. This way node_modules is copied only the first time the class is loaded. Other folders will have a random 6 letter character name.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
