### PR TITLE
Wait until the ts config file is written successfully

### DIFF
--- a/src/bundlers/node/typeCheckerBundler.ts
+++ b/src/bundlers/node/typeCheckerBundler.ts
@@ -11,7 +11,7 @@ export class TypeCheckerBundler implements BundlerInterface {
     // Call this class only once
     static used = false;
 
-    #generateTsconfigJson() {
+    async #generateTsconfigJson() {
         if (fs.existsSync("tsconfig.json")) {
             return;
         } else {
@@ -19,7 +19,7 @@ export class TypeCheckerBundler implements BundlerInterface {
             tsconfig.compilerOptions.rootDir = ".";
             tsconfig.compilerOptions.outDir = path.join(".", "build");
             tsconfig.include = [path.join(".", "**/*")];
-            writeToFile(process.cwd(), "tsconfig.json", JSON.stringify(tsconfig, null, 4));
+            await writeToFile(process.cwd(), "tsconfig.json", JSON.stringify(tsconfig, null, 4));
         }
     }
 
@@ -33,7 +33,7 @@ export class TypeCheckerBundler implements BundlerInterface {
         }
         TypeCheckerBundler.used = true;
 
-        this.#generateTsconfigJson();
+        await this.#generateTsconfigJson();
 
         const configFile = ts.readConfigFile("tsconfig.json", ts.sys.readFile);
         const config = ts.parseJsonConfigFileContent(configFile.config, ts.sys, process.cwd());

--- a/src/utils/configs.ts
+++ b/src/utils/configs.ts
@@ -1,19 +1,27 @@
 export const tsconfig = {
   compilerOptions: {
-    target: "es6",
-    lib: ["es6", "dom"],
-    outDir: "build",
-    rootDir: ".",
-    strict: true,
-    noImplicitAny: true,
-    esModuleInterop: true,
-    resolveJsonModule: true,
-    allowJs: true,
-    types: ["node"]
+      target: "ES2020",
+      module: "commonjs",
+      lib: [
+          "es6",
+          "dom"
+      ],
+      outDir: "build",
+      rootDir: ".",
+      strict: true,
+      noImplicitAny: true,
+      esModuleInterop: true,
+      resolveJsonModule: true,
+      allowJs: true,
+      types: [
+          "node"
+      ]
   },
-  //files: ["hello.ts"],
-  include: [""]
-};
+  include: [
+      "**/*"
+  ],
+}
+;
 
 export const regions = [
   "us-east-1",

--- a/src/utils/configs.ts
+++ b/src/utils/configs.ts
@@ -1,7 +1,8 @@
 export const tsconfig = {
   compilerOptions: {
       target: "ES2020",
-      module: "commonjs",
+      module: "ES2020",
+      moduleResolution: "node",
       lib: [
           "es6",
           "dom"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] 🐛 Bug Fix

## Description

If a tsconfig file does not exist in the project, the code would try to write the default tsconfig content to the file, but we did not wait for its completion.

Moreover, we had to use target "ES2020" in tsconfig to have support for `import.meta`.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] I have added tests;
- [x] New and existing unit tests pass locally with my changes;
