### PR TITLE
Generate dependency list only when `genezio deploy` is ran

### DIFF
--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -316,7 +316,7 @@ export class NodeJsBundler implements BundlerInterface {
         temporaryFolder,
       ),
       mode === "development" ? this.#copyDependencies(undefined, temporaryFolder, mode) : Promise.resolve(),
-      this.#getDependenciesInfo(input.configuration.path, input)
+      mode === "production" ? this.#getDependenciesInfo(input.configuration.path, input) : Promise.resolve(),
     ]);
 
     debugLogger.debug(`[NodeJSBundler] Copy non js files and node_modules for file ${input.path}.`)


### PR DESCRIPTION


<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🧑‍💻 Improvement

## Description

    
In `genezio local` we copy all available dependencies once, so a list of dependencies is not needed in development mode.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
