### PR TITLE
Run all `npm install` commands sequentially

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/body": "^5.1.1",
         "@types/webpack-node-externals": "^3.0.0",
         "archiver": "^5.3.1",
+        "async-mutex": "^0.4.0",
         "await-exec": "^0.1.2",
         "aws-cron-parser": "^1.1.12",
         "axios": "^1.4.0",
@@ -6326,6 +6327,14 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/body": "^5.1.1",
     "@types/webpack-node-externals": "^3.0.0",
     "archiver": "^5.3.1",
+    "async-mutex": "^0.4.0",
     "await-exec": "^0.1.2",
     "aws-cron-parser": "^1.1.12",
     "axios": "^1.4.0",

--- a/src/bundlers/node/dependencyInstaller.ts
+++ b/src/bundlers/node/dependencyInstaller.ts
@@ -1,0 +1,65 @@
+import { Mutex } from 'async-mutex'
+import { debugLogger } from '../../utils/logging.js';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import exec from 'await-exec';
+
+/**
+ * The `DependencyInstaller` class provides a thread-safe way to install dependencies for a Node.js project.
+ * It keeps track of which dependencies have already been installed and only installs each dependency once.
+ */
+class DependencyInstaller {
+    alreadyInstalled: Set<string> = new Set();
+    mutex = new Mutex();
+
+    static instance: DependencyInstaller = new DependencyInstaller();
+
+    constructor() {
+        return DependencyInstaller.instance;
+    }
+
+    /**
+     * Installs the specified dependencies if they have not been installed yet.
+     * This method is thread-safe and will only install dependencies once.
+     * @param {string[]} dependencyList - The list of dependencies to install.
+     * @param {boolean} [noSave] - If true, the installed dependencies will not be saved to the package.json file.
+     * @returns {Promise<void>} A promise that resolves when all specified dependencies have been installed.
+     */
+    async install(dependencyList: string[], noSave?: boolean): Promise<void> {
+        const toBeInstalled: string[] = [];
+
+        await this.mutex.runExclusive(async () => {
+            dependencyList.forEach((dependency) => {
+                if (!this.alreadyInstalled.has(dependency)) {
+                    this.alreadyInstalled.add(dependency);
+                    toBeInstalled.push(dependency);
+                }
+            })
+
+            if (toBeInstalled.length === 0) {
+                return;
+            }
+
+            const command = "npm install " + (noSave ? "--no-save " : "") + toBeInstalled.join(" ");
+            debugLogger.debug("Running command: " + command);
+
+            await exec(command);
+        })
+    }
+
+    /**
+     * Installs all dependencies that have not been installed yet.
+     * This method is thread-safe and will only install dependencies once.
+     * @returns {Promise<void>} A promise that resolves when all dependencies have been installed.
+     */
+    async installAll(): Promise<void> {
+        await this.mutex.runExclusive(async () => {
+            const command = "npm install";
+            debugLogger.debug("Running command: " + command);
+
+            await exec(command);
+        })
+    }
+}
+
+export { DependencyInstaller };


### PR DESCRIPTION


<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description
Running multiple npm install commands at once can lead to race conditions. I have implemented a singleton class that handles all installs and orders them sequentially.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
