### PR TITLE
Ts ignore fetch line in SDK

### DIFF
--- a/src/generateSdk/templates/nodeSdkTs.ts
+++ b/src/generateSdk/templates/nodeSdkTs.ts
@@ -18,6 +18,7 @@ async function importModules() {
 }
 
 async function makeRequestBrowser(request: any, url: any) {
+    // @ts-ignore
     const response = await fetch(\`\${url}\`, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] 🍕 New feature
- [x] 🐛 Bug Fix
- [x] 🔥 Breaking change
- [x] 🧑‍💻 Improvement
- [x] 📝 Documentation Update

## Description

Typescript will return an error if we use `fetch` in a NodeJS client. To avoid that, we tell typescript to ignore that line.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] I have added tests;
- [x] New and existing unit tests pass locally with my changes;
