### PR TITLE
GNZ-989: Fix genezio init bugs

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,11 +10,20 @@ import {cyan, red} from "../utils/strings.js";
 
 export async function initCommand() {
   let projectName = "";
-  while (projectName.length === 0) {
+  let projectNameValidated = false
+  while (!projectNameValidated) {
     projectName = await askQuestion(`What is the name of the project: `);
     if (projectName.length === 0) {
       log.error(red, "The project name can't be empty. Please provide one.");
+      continue;
     }
+
+    if (!projectName.match(/^[a-zA-Z][-a-zA-Z0-9]*$/)) {
+      log.error(red, "The project name can only contain letters, numbers, and dashes and must start with a letter.");
+      continue;
+    }
+
+    projectNameValidated = true;
   }
 
   let region = "";
@@ -62,7 +71,7 @@ export async function initCommand() {
   const doc = new Document(configFile);
   const yamlConfigurationFileContent = doc.toString();
 
-  await writeToFile(".", "genezio.yaml", yamlConfigurationFileContent).catch(
+  await writeToFile(`./${projectName}`, "genezio.yaml", yamlConfigurationFileContent, true).catch(
     (error) => {
       GenezioTelemetry.sendEvent({eventType: "GENEZIO_INIT_ERROR", errorTrace: error.toString()});
       log.error(red, error.toString());

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -54,7 +54,7 @@ describe("init", () => {
 
     expect(mockedWriteToFile).toBeCalledTimes(1);
     expect(mockedAskQuestion).toBeCalledTimes(4);
-    expect(mockedWriteToFile).toBeCalledWith(".", "genezio.yaml", yamlConfigurationFileContent)
+    expect(mockedWriteToFile).toBeCalledWith("./project-name", "genezio.yaml", yamlConfigurationFileContent, true)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(1, `What is the name of the project: `)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(2, `What region do you want to deploy your project to? [default value: us-east-1]: `, "us-east-1")
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(3, `In what programming language do you want your SDK? (${languages}) [default value: ts]: `, "ts")
@@ -92,7 +92,7 @@ describe("init", () => {
     expect(mockedLogError).toBeCalledWith(red, `The project name can't be empty. Please provide one.`);
     expect(mockedWriteToFile).toBeCalledTimes(1);
     expect(mockedAskQuestion).toBeCalledTimes(5);
-    expect(mockedWriteToFile).toBeCalledWith(".", "genezio.yaml", yamlConfigurationFileContent)
+    expect(mockedWriteToFile).toBeCalledWith("./project-name", "genezio.yaml", yamlConfigurationFileContent, true)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(1, `What is the name of the project: `)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(2, `What is the name of the project: `)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(3, `What region do you want to deploy your project to? [default value: us-east-1]: `, "us-east-1")
@@ -131,7 +131,7 @@ describe("init", () => {
     expect(mockedLogError).toBeCalledWith(red, `The region is invalid. Please use a valid region.\n Region list: ${regions}`);
     expect(mockedWriteToFile).toBeCalledTimes(1);
     expect(mockedAskQuestion).toBeCalledTimes(5);
-    expect(mockedWriteToFile).toBeCalledWith(".", "genezio.yaml", yamlConfigurationFileContent)
+    expect(mockedWriteToFile).toBeCalledWith("./project-name", "genezio.yaml", yamlConfigurationFileContent, true)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(1, `What is the name of the project: `)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(2, `What region do you want to deploy your project to? [default value: us-east-1]: `, "us-east-1")
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(3, `What region do you want to deploy your project to? [default value: us-east-1]: `, "us-east-1")
@@ -170,7 +170,7 @@ describe("init", () => {
     expect(mockedLogError).toBeCalledWith(red, `We don't currently support the ${notSupported} language. You can open an issue ticket at https://github.com/Genez-io/genezio/issues.`);
     expect(mockedWriteToFile).toBeCalledTimes(1);
     expect(mockedAskQuestion).toBeCalledTimes(5);
-    expect(mockedWriteToFile).toBeCalledWith(".", "genezio.yaml", yamlConfigurationFileContent)
+    expect(mockedWriteToFile).toBeCalledWith("./project-name", "genezio.yaml", yamlConfigurationFileContent, true)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(1, `What is the name of the project: `)
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(2, `What region do you want to deploy your project to? [default value: us-east-1]: `, "us-east-1")
     expect(mockedAskQuestion).toHaveBeenNthCalledWith(3, `In what programming language do you want your SDK? (${languages}) [default value: ts]: `, "ts")


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] 🐛 Bug Fix

## Description

When we initialize a new project with `genezio init`, we should create a new folder that has the name of the project. Also, we should validate that the name is correct.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] I have added tests;
- [x] New and existing unit tests pass locally with my changes;
