### PR TITLE
Fix path separator for windows

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -48,24 +48,29 @@ export async function getAllFilesFromCurrentPath(): Promise<FileDetails[]> {
   genezioIgnore = genezioIgnore.map((p) => ensureRelativePaths(p))
 
   return new Promise((resolve, reject) => {
-    glob(`./**/*`, {
-      dot: true,
-      ignore: genezioIgnore
-    }, (err, files) => {
-      if (err) {
-        reject(err);
-      }
+    const pattern = `.` + path.sep + `**` + path.sep + `*`;
+    glob(
+      pattern,
+      {
+        dot: true,
+        ignore: genezioIgnore,
+      },
+      (err, files) => {
+        if (err) {
+          reject(err);
+        }
 
-      const fileDetails: FileDetails[] = files.map((file: string) => {
-        return {
-          name: path.parse(file).name,
-          extension: path.parse(file).ext,
-          path: file,
-          filename: file
-        };
-      });
-      resolve(fileDetails);
-    });
+        const fileDetails: FileDetails[] = files.map((file: string) => {
+          return {
+            name: path.parse(file).name,
+            extension: path.parse(file).ext,
+            path: file,
+            filename: file,
+          };
+        });
+        resolve(fileDetails);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 🍕 New feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Breaking change
- [ ] 🧑‍💻 Improvement
- [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

A non-generic path separator was breaking `genezio local` and `genezio deploy` on Windows because the paths/folders were not retrieved correctly.

## Checklist

- [x] My code follows the contributor guidelines of this project;
