### PR TITLE
Install @types modules that are required by TS if they are not already installed.

### DIFF
--- a/src/bundlers/node/dependencyInstaller.ts
+++ b/src/bundlers/node/dependencyInstaller.ts
@@ -40,7 +40,8 @@ class DependencyInstaller {
                 return;
             }
 
-            const command = "npm install " + (noSave ? "--no-save " : "") + toBeInstalled.join(" ");
+            const baseCommand = this.getInstallPackageCommand(noSave);
+            const command = baseCommand + " " + toBeInstalled.join(" ");
             debugLogger.debug("Running command: " + command);
 
             await exec(command);
@@ -54,11 +55,41 @@ class DependencyInstaller {
      */
     async installAll(): Promise<void> {
         await this.mutex.runExclusive(async () => {
-            const command = "npm install";
+            const command = this.getInstallCommand();
             debugLogger.debug("Running command: " + command);
 
             await exec(command);
         })
+    }
+
+    getInstallPackageCommand(noSave?: boolean): string {
+        const dependencyManager = process.env.GENEZIO_DEPENDENCY_MANAGER || "npm";
+
+        switch (dependencyManager) {
+            case "npm":
+                return "npm install " + (noSave ? "--no-save " : "");
+            case "yarn":
+                return "yarn add";
+            case "pnpm":
+                return "pnpm add";
+            default:
+                return "npm install";
+        }
+    }
+
+    getInstallCommand(): string {
+        const dependencyManager = process.env.GENEZIO_DEPENDENCY_MANAGER || "npm";
+
+        switch (dependencyManager) {
+            case "npm":
+                return "npm install";
+            case "yarn":
+                return "yarn install";
+            case "pnpm":
+                return "pnpm install";
+            default:
+                return "npm install";
+        }
     }
 }
 

--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -60,7 +60,7 @@ export class NodeJsBundler implements BundlerInterface {
           file.extension !== ".tsx" &&
           file.extension !== ".jsx" &&
           !file.path.includes("node_modules") &&
-          !file.path.includes(".git") && 
+          !file.path.includes(".git") &&
           !fs.lstatSync(file.path).isDirectory()
         );
       }

--- a/src/bundlers/node/typescriptRequiredDepsBundler.ts
+++ b/src/bundlers/node/typescriptRequiredDepsBundler.ts
@@ -1,0 +1,18 @@
+import { BundlerInput, BundlerInterface, BundlerOutput } from "../bundler.interface.js";
+import { fileExists } from "../../utils/file.js";
+import { DependencyInstaller } from "./dependencyInstaller.js";
+
+// Ensures that all dependencies required by the Typescript compiler are installed.
+export class TsRequiredDepsBundler implements BundlerInterface {
+
+    async bundle(input: BundlerInput): Promise<BundlerOutput> {
+        const exists = await fileExists("node_modules/@types/node")
+
+        // Install @types/node for typescript if it is not already installed
+        if (!exists) {
+          await new DependencyInstaller().install(["@types/node"], true);
+        }
+
+        return input;
+    }
+}

--- a/src/commands/addClass.ts
+++ b/src/commands/addClass.ts
@@ -6,6 +6,7 @@ import { GenezioTelemetry } from "../telemetry/telemetry.js";
 import { getProjectConfiguration } from "../utils/configuration.js";
 import { fileExists, writeToFile } from "../utils/file.js";
 import { supportedExtensions } from "../utils/languages.js";
+import { DependencyInstaller } from "../bundlers/node/dependencyInstaller.js";
 
 export async function addClassCommand(classPath: string, classType: string) {
   GenezioTelemetry.sendEvent({eventType: "GENEZIO_ADD_CLASS"});
@@ -35,7 +36,7 @@ export async function addClassCommand(classPath: string, classType: string) {
   if (!classExtension || className.split(".").length < 2) {
     throw new Error("Please provide a class name with a valid class extension.");
   }
-  
+
   // check if class is supported
   if (!supportedExtensions.includes(classExtension)) {
     const supportedExtensionsString = supportedExtensions

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -41,6 +41,7 @@ import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
 import { TypeCheckerBundler } from "../bundlers/node/typeCheckerBundler.js";
 import { GenezioDeployOptions } from "../models/commandOptions.js";
 import { GenezioTelemetry } from "../telemetry/telemetry.js";
+import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
 
 export async function deployCommand(options: GenezioDeployOptions) {
   let configuration
@@ -223,10 +224,11 @@ export async function deployClasses(configuration: YamlProjectConfiguration, clo
 
       switch (element.language) {
         case ".ts": {
+          const requiredDepsBundler = new TsRequiredDepsBundler();
           const typeCheckerBundler = new TypeCheckerBundler();
           const standardBundler = new NodeJsBundler();
           const binaryDepBundler = new NodeJsBinaryDependenciesBundler();
-          bundler = new BundlerComposer([typeCheckerBundler, standardBundler, binaryDepBundler]);
+          bundler = new BundlerComposer([requiredDepsBundler, typeCheckerBundler, standardBundler, binaryDepBundler]);
           break;
         }
         case ".js": {

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -36,6 +36,7 @@ import { YamlProjectConfiguration } from "../models/yamlProjectConfiguration.js"
 import hash from 'hash-it';
 import { GenezioTelemetry } from "../telemetry/telemetry.js";
 import dotenv from 'dotenv';
+import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
 
 type ClassProcess = {
   process: ChildProcess;
@@ -294,7 +295,13 @@ function getBundler(
 ): BundlerInterface | undefined {
   let bundler: BundlerInterface | undefined;
   switch (classConfiguration.language) {
-    case ".ts":
+    case ".ts": {
+      const requiredDepsBundler = new TsRequiredDepsBundler();
+      const nodeJsBundler = new NodeJsBundler();
+      const localBundler = new NodeJsLocalBundler();
+      bundler = new BundlerComposer([requiredDepsBundler, nodeJsBundler, localBundler]);
+      break;
+    }
     case ".js": {
       const nodeJsBundler = new NodeJsBundler();
       const localBundler = new NodeJsLocalBundler();


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] 🐛 Bug Fix

## Description

If you create a project with `genezio init` and you add a typescript class, you will receive an error because @types/node module is missing. We install it during `genezio local` or `genezio deploy`.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] I have added tests;
- [x] New and existing unit tests pass locally with my changes;
