### PR TITLE
Don't assume that package json exists

### DIFF
--- a/src/bundlers/node/nodeJsBinaryDependenciesBundler.ts
+++ b/src/bundlers/node/nodeJsBinaryDependenciesBundler.ts
@@ -44,16 +44,18 @@ export class NodeJsBinaryDependenciesBundler implements BundlerInterface {
                 }
             } else {
                 const packageJsonPath = path.join(dependencyPath, "package.json");
-                const packageJson = JSON.parse(
-                    fs.readFileSync(packageJsonPath, "utf8")
-                );
+                if (await fileExists(packageJsonPath)) {
+                    const packageJson = JSON.parse(
+                        fs.readFileSync(packageJsonPath, "utf8")
+                    );
 
-                // check if package.json has binary property
-                if (packageJson.binary) {
-                    binaryDependencies.push({
-                        path: dependencyPath,
-                        name: dependency.name
-                    });
+                    // check if package.json has binary property
+                    if (packageJson.binary) {
+                        binaryDependencies.push({
+                            path: dependencyPath,
+                            name: dependency.name
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] 🐛 Bug Fix

## Description

We were assuming that `node_modules/<module/package.json` always exists. I've added a check because this was not true for `.prisma/client`.

## Checklist

- [ ] My code follows the contributor guidelines of this project;
- [ ] I have updated the documentation;
- [ ] I have added tests;
- [ ] New and existing unit tests pass locally with my changes;
