### PR TITLE
replace all backslashes in path with forward slashes

### DIFF
--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -65,7 +65,7 @@ export class AstGenerator implements AstGeneratorInterface {
         const typeAtLocation = typeChecker.getTypeAtLocation((type as any).typeName);
         const typeAtLocationPath = (typeAtLocation.aliasSymbol as any).declarations?.[0].getSourceFile().symbol.escapedName;
         const trimmedPath = typeAtLocationPath.substring(1, typeAtLocationPath.length - 1);
-        const pathFile = path.relative(process.cwd(), trimmedPath);
+        const pathFile = path.relative(process.cwd(), trimmedPath).replace(/\\/g, "/");
         if (!this.isDeclarationInList(escapedText, pathFile, declarations)) {
           let declaredNode: StructLiteral | TypeAlias | Enum;
           if (typeAtLocation.aliasSymbol?.declarations?.[0].kind === typescript.SyntaxKind.TypeAliasDeclaration) {

--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -529,7 +529,7 @@ class SdkGenerator implements SdkGeneratorInterface {
       }
       if (!currentView.imports.find((e: any) => e.path === relativePath)) {
         currentView.imports.push({
-          path: relativePath,
+          path: relativePath.replace(/\\/g, "/"),
           models: [{ name: (externalType as any).name }]
         });
       }


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] 🍕 New feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Breaking change
- [ ] 🧑‍💻 Improvement
- [ ] 📝 Documentation Update

## Description

Replace backslashes (`\`) with forward slashes (`/`) in import paths. This generated a bug on windows which would use invalid paths.

## Checklist

- [ ] My code follows the contributor guidelines of this project;
- [ ] I have updated the documentation;
- [ ] I have added tests;
- [ ] New and existing unit tests pass locally with my changes;
