### PR TITLE
GNZ-927 Add --env <envFile> to `genezio deploy`

### DIFF
--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -53,14 +53,18 @@ export class NodeJsBundler implements BundlerInterface {
   async #copyNonJsFiles(tempFolderPath: string) {
     const allNonJsFilesPaths = (await getAllFilesFromCurrentPath()).filter(
       (file: FileDetails) => {
+        // create a regex to match any .env files
+        const envFileRegex = new RegExp(/\.env(\..+)?$/);
+
         // filter js files, node_modules and folders
         return (
-          file.extension !== ".ts" &&
-          file.extension !== ".js" &&
-          file.extension !== ".tsx" &&
-          file.extension !== ".jsx" &&
-          !file.path.includes("node_modules") &&
-          !file.path.includes(".git") &&
+          file.extension !== '.ts' &&
+          file.extension !== '.js' &&
+          file.extension !== '.tsx' &&
+          file.extension !== '.jsx' &&
+          !file.path.includes('node_modules') &&
+          !file.path.includes('.git') &&
+          !envFileRegex.test(file.path) &&
           !fs.lstatSync(file.path).isDirectory()
         );
       }

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -101,8 +101,9 @@ program
   .option("--frontend", "Deploy only the frontend application.")
   .option("--logLevel <logLevel>", "Show debug logs to console. Possible levels: trace/debug/info/warn/error.")
   .option("--install-deps", "Automatically install missing dependencies.", false)
+  .option("--env <envFile>", "Load environment variables from a given file.", undefined)
   .option("--stage <stage>", "Stage to deploy to. Default: 'production'.")
-  .description(`Deploy your project to the genezio infrastructure. Use --frontend to deploy only the frontend application. 
+  .description(`Deploy your project to the genezio infrastructure. Use --frontend to deploy only the frontend application.
 Use --backend to deploy only the backend application.`)
   .action(async (options: GenezioDeployOptions) => {
     setDebuggingLoggerLogLevel(options.logLevel);
@@ -144,7 +145,7 @@ program
   )
   .option(
     "--env <envFile>",
-    "Set a custom environment variables file.",
+    "Load environment variables from a given .env file.",
     undefined
   )
   .option("--install-deps", "Automatically install missing dependencies.", false)

--- a/src/models/commandOptions.ts
+++ b/src/models/commandOptions.ts
@@ -10,5 +10,6 @@ export type GenezioDeployOptions = {
     frontend?: boolean,
     logLevel?: string,
     installDeps: boolean,
+    env: string,
     stage: string,
 }

--- a/src/models/environmentVariables.ts
+++ b/src/models/environmentVariables.ts
@@ -1,0 +1,6 @@
+export type EnvironmentVariable = {
+    name: string,
+    value: string,
+    lastAccessedAt?: string,
+    type?: string,
+}

--- a/src/requests/setEnvironmentVariables.ts
+++ b/src/requests/setEnvironmentVariables.ts
@@ -1,0 +1,46 @@
+import axios from './axios.js';
+import { getAuthToken } from '../utils/accounts.js';
+import { BACKEND_ENDPOINT } from '../constants.js';
+import version from '../utils/version.js';
+import { EnvironmentVariable } from '../models/environmentVariables.js';
+
+export async function setEnvironmentVariables(
+  projectId: string,
+  environmentVariablesData: EnvironmentVariable[],
+) {
+  // validate parameters
+  if (!projectId) {
+    throw new Error('Missing required parameters');
+  }
+
+  // Check if user is authenticated
+  const authToken = await getAuthToken();
+  if (!authToken) {
+    throw new Error(
+      "You are not logged in. Run 'genezio login' before you deploy your function.",
+    );
+  }
+
+  const data = JSON.stringify({environmentVariables: environmentVariablesData});
+
+  const response: any = await axios({
+    method: 'POST',
+    url: `${BACKEND_ENDPOINT}/projects/${projectId}/environment-variables`,
+    data: data,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Accept-Version': `genezio-cli/${version}`,
+    },
+  }).catch((error: Error) => {
+    throw error;
+  });
+
+  if (response.data.status === 'error') {
+    throw new Error(response.data.message);
+  }
+
+  if (response.data?.error?.message) {
+    throw new Error(response.data.error.message);
+  }
+
+}


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🧑‍💻 Improvement

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR adds the following `--env <envFile>` to `genezio deploy`.
This will load the environment variable from the given file. If no filename is given, the default `env` is going to be used. 

With this feature in place, there is no need to use `dotenv` anymore to load environment variables.
Both for `genezio local` and `genezio deploy` --env <envFile>` loads the env vars.

Any file that starts with `.env` will not be bundled.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] New and existing unit tests pass locally with my changes;
