### PR TITLE
add ast version to deploy payload

### DIFF
--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -40,6 +40,7 @@ export class ClassConfiguration {
     language: string;
     methods: MethodConfiguration[];
     types: any[];
+    version: string;
 
     constructor(
         name: string,
@@ -47,7 +48,8 @@ export class ClassConfiguration {
         type: TriggerType,
         language: string,
         methods: MethodConfiguration[],
-        types: any[]
+        types: any[],
+        version: string
     ) {
         this.name = name;
         this.path = path;
@@ -55,6 +57,7 @@ export class ClassConfiguration {
         this.methods = methods;
         this.language = language;
         this.types = types;
+        this.version = version;
     }
 }
 
@@ -120,7 +123,8 @@ export class ProjectConfiguration {
                 type: yamlClass?.type ?? TriggerType.jsonrpc,
                 language: yamlClass.language,
                 methods: methods,
-                types: c.types
+                types: c.types,
+                version: this.astSummary.version
             }
         });
     }


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

- [x ] 🐛 Bug Fix

## Description

Solved a bug that would've broken the test-interface for deployments with older versions of the CLI. The AST version was hardcoded in the backend. This fix sends the AST version in the request payload.

## Checklist

- [ ] My code follows the contributor guidelines of this project;
- [ ] I have updated the documentation;
- [ ] I have added tests;
- [ ] New and existing unit tests pass locally with my changes;
