### PR TITLE
Gnz 1030 bundle issue

### DIFF
--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -137,6 +137,7 @@ export class NodeJsBundler implements BundlerInterface {
             return { contents, loader };
           }
 
+          // Check if file uses require() for relative paths
           const regex = /require\(['"]\.\.?(?:\/[\w.-]+)+['"]\);?/g;
           const matches = contents.match(regex);
 

--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -137,6 +137,17 @@ export class NodeJsBundler implements BundlerInterface {
             return { contents, loader };
           }
 
+          const regex = /require\(['"]\.\.?(?:\/[\w.-]+)+['"]\);?/g;
+          const matches = contents.match(regex);
+
+          if (matches) {
+            return {
+              errors: [{
+                text: `genezio does not support require() for relative paths. Please use import statements instead.`
+              }]
+            }
+          }
+
           return {
             contents: `import { createRequire } from 'module';
             const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug Fix

## Description

Require using relative paths was broken due to esbuild not supporting `createRrequire` (we used to textually replace `require` with `createRequire` to be able to use this in ESM context). Because required code couldn't be bundled, paths became incorrect and would generate errors.

Solution was to remove support for require with relative paths. Users will still be able to use `require` to import from `node_modules`. For relative paths, we will output an error suggesting to switch to import statements. 

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [ ] I have updated the documentation;
- [ ] I have added tests;
- [x] New and existing unit tests pass locally with my changes;
