### PR TITLE
Fix newline to be os-specific when reading from files

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -37,6 +37,7 @@ import hash from 'hash-it';
 import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js";
 import dotenv from 'dotenv';
 import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
+import { EOL } from "os";
 
 type ClassProcess = {
   process: ChildProcess;
@@ -545,8 +546,8 @@ async function listenForChanges(sdkPathRelative: any | undefined) {
   if (await fileExists(ignoreFilePath)) {
     // read the file as a string
     const ignoreFile = await readUTF8File(ignoreFilePath);
-    // split the string by new line \n
-    const ignoreFileLines = ignoreFile.split("\n");
+    // split the string by newline - CRLF or LF
+    const ignoreFileLines = ignoreFile.split(EOL);
     // remove empty lines
     const ignoreFileLinesWithoutEmptyLines = ignoreFileLines.filter(
       (line) => line !== "" && !line.startsWith("#")
@@ -575,7 +576,6 @@ async function listenForChanges(sdkPathRelative: any | undefined) {
     if (sdkPath) {
       ignoredPaths = [
         "**/node_modules/*",
-        // "**/node_modules/**/*",
         sdkPath + "/**/*",
         sdkPath + "/*",
         ...ignoredPathsFromGenezioIgnore

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -42,7 +42,7 @@ export async function getAllFilesFromCurrentPath(): Promise<FileDetails[]> {
   const genezioIgnorePath = path.join(process.cwd(), ".genezioignore");
   if (fs.existsSync(genezioIgnorePath)) {
     const genezioIgnoreContent = await readUTF8File(genezioIgnorePath);
-    genezioIgnore = genezioIgnoreContent.split("\n").filter(
+    genezioIgnore = genezioIgnoreContent.split(os.EOL).filter(
       (line) => line !== "" && !line.startsWith("#")
     )
   }
@@ -357,7 +357,7 @@ export async function readEnvironmentVariablesFile(envFilePath: string): Promise
   const envVars = new Array<EnvironmentVariable>();
 
   const envFileContent = await readUTF8File(envFilePath);
-  const envFileLines = envFileContent.split("\n");
+  const envFileLines = envFileContent.split(os.EOL);
 
   for (const line of envFileLines) {
     if (line === "") {


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR changes `\n` to `EOL` which is os-specific.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] New and existing unit tests pass locally with my changes;
