### PR TITLE
[WIP] Clean up all resources on SIGINT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,35 @@
 import program from "./genezio.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "./telemetry/telemetry.js";
 import { cleanupTemporaryFolders } from "./utils/file.js";
-
+import { spawn } from 'child_process';
+import log from "loglevel";
+import { debugLogger } from "./utils/logging.js";
 
 // Set-up SIGINT and exit handlers that clean up the temporary folder structure
 process.on('SIGINT', async () => {
     GenezioTelemetry.sendEvent({eventType: TelemetryEventTypes.GENEZIO_CANCEL, errorTrace: "", commandOptions: ""});
     await cleanupTemporaryFolders();
+
+    // Kill the entire process family
+    const killCmd = process.platform === 'win32' ? 'taskkill' : 'kill';
+    const signal = 'SIGINT';
+
+    // Spawn a new process to kill the process family
+    const killProcess = spawn(killCmd, [signal, `-${process.pid}`]);
+
+    // Handle any errors during process termination
+    killProcess.on('error', (err) => {
+        debugLogger.debug('Error killing process family:', err);
+    });
+
+    // Listen for the process to exit
+    killProcess.on('exit', (code, signal) => {
+        debugLogger.debug('Process family killed with code:', code, 'and signal:', signal);
+    });
+
     process.exit();
 });
-process.on('exit', async (code) => {
+process.on('exit', async () => {
     await cleanupTemporaryFolders();
 });
 


### PR DESCRIPTION
Signed-off-by: Andreia Ocanoaia <>

# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

If `genezio local` is killed by simply sending SIGINT, the children processes spawned by `genezio local` are not cleaned and the ports used are not freed.

This problem appears when `genezio local` is killed programmatically. For example, in the integration tests when calling `process.kill()`.

I think this might cause flaky behavior from time to time (random ports not freed).

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
