### PR TITLE
Remove the leading / from the cloud url to avoid double // in the URL

### DIFF
--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -144,6 +144,10 @@ export class GenezioCloudAdapter implements CloudAdapter {
 
 function getFunctionUrl(baseUrl: string, methodType: string, className: string, methodName: string): string {
     if (methodType === "http") {
+        // trim the last slash of baseUrl if it exists
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.slice(0, -1);
+        }
         return `${baseUrl}/${className}/${methodName}`;
     } else {
         return `${baseUrl}/${className}`;


### PR DESCRIPTION
Signed-off-by: Andreia Ocanoaia <>

# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR removes the double `//` from the webhook URL that are printed on `genezio deploy`.

Before the PR:
```
HTTP Methods Deployed:
  - HelloWorldHttpExample.handleSimpleTextRequest: https://cloudurlfunction//HelloWorld/hello
```

After the PR:
```
HTTP Methods Deployed:
  - HelloWorldHttpExample.handleSimpleTextRequest: https://cloudurlfunction/HelloWorld/hello
```
## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
