### PR TITLE
clean temp folder before generating a new sdk

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -445,6 +445,7 @@ export async function deployClasses(
   ) {
     const localPath = await createLocalTempFolder(
       `${projectConfiguration.name}-${projectConfiguration.region}`,
+      true
     );
     await writeSdkToDisk(
       sdkResponse,

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -255,6 +255,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
         if (!sdkPath) {
           sdkPath = await createLocalTempFolder(
             `${yamlProjectConfiguration.name}-${yamlProjectConfiguration.region}`,
+            true,
           );
         }
         const localConfiguration = await YamlLocalConfiguration.create({
@@ -356,6 +357,15 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
           cloudUrl: `http://127.0.0.1:${options.port}/${c.className}`,
         })),
       );
+      if (
+        projectConfiguration.sdk.language === Language.ts ||
+        projectConfiguration.sdk.language === Language.js
+      ) {
+        createLocalTempFolder(
+          `${yamlProjectConfiguration.name}-${yamlProjectConfiguration.region}`,
+          true,
+        );
+      }
       await writeSdkToDisk(
         sdk,
         projectConfiguration.sdk.language,

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -13,9 +13,10 @@ import { debugLogger } from "./logging.js";
 import { EnvironmentVariable } from "../models/environmentVariables.js";
 import dotenv from "dotenv";
 import { execSync } from "child_process";
+import fsExtra from "fs-extra";
 
 export async function getAllFilesRecursively(
-  folderPath: string
+  folderPath: string,
 ): Promise<string[]> {
   let files: string[] = [];
   const items = await fsPromises.readdir(folderPath, { withFileTypes: true });
@@ -75,14 +76,14 @@ export async function getAllFilesFromCurrentPath(): Promise<FileDetails[]> {
           };
         });
         resolve(fileDetails);
-      }
+      },
     );
   });
 }
 
 export async function zipDirectory(
   sourceDir: string,
-  outPath: string
+  outPath: string,
 ): Promise<void> {
   const archive = archiver("zip", { zlib: { level: 9 } });
   const stream = fs.createWriteStream(outPath);
@@ -101,7 +102,7 @@ export async function zipDirectory(
 export async function zipDirectoryToDestinationPath(
   sourceDir: string,
   destinationPath: string,
-  outPath: string
+  outPath: string,
 ): Promise<void> {
   const archive = archiver("zip", { zlib: { level: 9 } });
   const stream = fs.createWriteStream(outPath);
@@ -132,7 +133,7 @@ export async function fileExists(filePath: string): Promise<boolean> {
 }
 
 export async function isDirectoryEmpty(
-  directoryPath: string
+  directoryPath: string,
 ): Promise<boolean> {
   return new Promise((resolve) => {
     fs.readdir(directoryPath, (error, files) => {
@@ -146,7 +147,7 @@ export async function isDirectoryEmpty(
 }
 
 export async function directoryContainsHtmlFiles(
-  directoryPath: string
+  directoryPath: string,
 ): Promise<boolean> {
   return new Promise((resolve, reject) => {
     fs.readdir(directoryPath, (error, files) => {
@@ -172,19 +173,19 @@ export async function getFileSize(filePath: string): Promise<number> {
 }
 
 export async function getBundleFolderSizeLimit(
-  directoryPath: string
+  directoryPath: string,
 ): Promise<number> {
   const files = await getAllFilesRecursively(directoryPath);
   const totalSize = files.reduce(
     (acc, file) => acc + fs.statSync(file).size,
-    0
+    0,
   );
   debugLogger.debug(`Total size of the bundle: ${totalSize} bytes`);
   return totalSize;
 }
 
 export async function directoryContainsIndexHtmlFiles(
-  directoryPath: string
+  directoryPath: string,
 ): Promise<boolean> {
   return new Promise((resolve, reject) => {
     fs.readdir(directoryPath, (error, files) => {
@@ -220,7 +221,7 @@ export async function cleanupTemporaryFolders() {
  */
 export async function createTemporaryFolder(
   name?: string,
-  shouldDeleteContents?: boolean
+  shouldDeleteContents?: boolean,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const folderName = `genezio-${process.pid}`;
@@ -256,7 +257,7 @@ export async function createTemporaryFolder(
 
 export async function createLocalTempFolder(
   name?: string,
-  shouldDeleteContents?: boolean
+  shouldDeleteContents?: boolean,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const folderName = `local-genezio`;
@@ -268,7 +269,7 @@ export async function createLocalTempFolder(
     // install @types/node in root folder to be accessible by all projects
     if (
       !fs.existsSync(
-        path.join(os.tmpdir(), folderName, "node_modules", "@types/node")
+        path.join(os.tmpdir(), folderName, "node_modules", "@types/node"),
       )
     ) {
       execSync("npm install @types/node", {
@@ -284,20 +285,13 @@ export async function createLocalTempFolder(
     const tempFolder = path.join(os.tmpdir(), folderName, name);
     if (fs.existsSync(tempFolder)) {
       if (shouldDeleteContents) {
-        fs.rmSync(tempFolder, { recursive: true });
+        fsExtra.emptyDirSync(tempFolder);
+        resolve(tempFolder);
       } else {
         resolve(tempFolder);
         return;
       }
     }
-
-    fs.mkdir(tempFolder, (error: any) => {
-      if (error) {
-        reject(error);
-      }
-
-      resolve(tempFolder);
-    });
   });
 }
 
@@ -334,7 +328,7 @@ export function writeToFile(
   folderPath: string,
   filename: string,
   content: any,
-  createPathIfNeeded = false
+  createPathIfNeeded = false,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const fullPath = path.join(folderPath, filename);
@@ -375,7 +369,7 @@ export async function validateYamlFile() {
 
   if (configurationFileContent.classes.length === 0) {
     log.info(
-      "You don't have any classes in your genezio.yaml file. You can add classes using the 'genezio addClass <className> <classType>' command."
+      "You don't have any classes in your genezio.yaml file. You can add classes using the 'genezio addClass <className> <classType>' command.",
     );
     exit(1);
   }
@@ -388,7 +382,7 @@ export async function validateYamlFile() {
       if (method.type === "cron") {
         if (method.cronString === undefined) {
           log.warn(
-            `You need to specify a cronString for the method ${elem.path}.${method.name}.`
+            `You need to specify a cronString for the method ${elem.path}.${method.name}.`,
           );
           exit(1);
         } else {
@@ -396,7 +390,7 @@ export async function validateYamlFile() {
             const cron = awsCronParser.parse(method.cronString);
           } catch (error: any) {
             log.error(
-              `The cronString ${method.cronString} for the method ${elem.path}.${method.name} is not valid.`
+              `The cronString ${method.cronString} for the method ${elem.path}.${method.name} is not valid.`,
             );
             log.error("You must use a 6-part cron expression.");
             log.error(error.toString());
@@ -409,7 +403,7 @@ export async function validateYamlFile() {
 }
 
 export async function readEnvironmentVariablesFile(
-  envFilePath: string
+  envFilePath: string,
 ): Promise<EnvironmentVariable[]> {
   const envVars = new Array<EnvironmentVariable>();
 


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🧑‍💻 Improvement

## Description

Remove contents of temp folder which stores the npm sdk before building a new version. There were certain edge cases where one would need to manually delete the folder in order to get a working sdk

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
