### PR TITLE
fix monorepo windows sdk bug

### DIFF
--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -304,10 +304,12 @@ class SdkGenerator implements SdkGeneratorInterface {
             )
           ) {
             currentView = view;
-            if (
-              currentView &&
-              !classInfo.classConfiguration.path.includes(externalType.path)
-            ) {
+            // replace \ with /
+            const classPath = classInfo.classConfiguration.path.replace(
+              "\\",
+              "/",
+            );
+            if (currentView && !classPath.includes(externalType.path)) {
               this.addImportToCurrentView(currentView, externalType);
             }
           }
@@ -571,7 +573,7 @@ class SdkGenerator implements SdkGeneratorInterface {
         currentView.path || ".",
         externalType.path || ".",
       );
-      if (relativePath.substring(0, 3) == "../") {
+      while (relativePath.substring(0, 3) == "../") {
         relativePath = relativePath.substring(3);
       }
       if (!currentView.imports.find((e: any) => e.path === relativePath)) {

--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -290,10 +290,11 @@ class SdkGenerator implements SdkGeneratorInterface {
                 classInfo,
               );
             }
-            if (
-              currentView &&
-              !classInfo.classConfiguration.path.includes(externalType.path)
-            ) {
+            const classPath = classInfo.classConfiguration.path.replace(
+              /\\/g,
+              "/",
+            );
+            if (currentView && !classPath.includes(externalType.path)) {
               this.addImportToCurrentView(currentView, externalType);
             }
           }
@@ -304,9 +305,9 @@ class SdkGenerator implements SdkGeneratorInterface {
             )
           ) {
             currentView = view;
-            // replace \ with /
+            // replace all \ with /
             const classPath = classInfo.classConfiguration.path.replace(
-              "\\",
+              /\\/g,
               "/",
             );
             if (currentView && !classPath.includes(externalType.path)) {
@@ -641,7 +642,8 @@ class SdkGenerator implements SdkGeneratorInterface {
       }
     }
     if (!found) {
-      if (!classInfo.classConfiguration.path.includes(type.path)) {
+      const classPath = classInfo.classConfiguration.path.replace(/\\/g, "/");
+      if (!classPath.includes(type.path)) {
         currentView = {
           path: type.path || "",
           externalTypes: [],

--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -305,7 +305,6 @@ class SdkGenerator implements SdkGeneratorInterface {
             )
           ) {
             currentView = view;
-            // replace all \ with /
             const classPath = classInfo.classConfiguration.path.replace(
               /\\/g,
               "/",


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug Fix

## Description

SDK generation on windows from root of monorepo with decorators failed because of different file separators
