### PR TITLE
Only one genezio.yaml configuration file for workspaces.

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -597,7 +597,8 @@ export async function deployFrontend(
       );
     }
     // check if the build folder exists
-    const frontendPath = path.join(cwd, configuration.frontend?.path);
+    // const frontendPath = path.join(cwd, configuration.frontend?.path);
+    const frontendPath = configuration.frontend?.path
     if (!(await fileExists(frontendPath))) {
       throw new Error(
         `The build folder does not exist. Please run the build command first or add a preFrontendDeploy script in the genezio.yaml file.`,
@@ -626,7 +627,7 @@ export async function deployFrontend(
       configuration.frontend.subdomain = generateRandomSubdomain();
 
       // write the configuration in yaml file
-      await configuration.addSubdomain(configuration.frontend.subdomain, cwd);
+      await configuration.addSubdomain(configuration.frontend.subdomain);
     }
 
     configuration.frontend.path = path.join(cwd, configuration.frontend.path);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -597,7 +597,6 @@ export async function deployFrontend(
       );
     }
     // check if the build folder exists
-    // const frontendPath = path.join(cwd, configuration.frontend?.path);
     const frontendPath = configuration.frontend?.path
     if (!(await fileExists(frontendPath))) {
       throw new Error(

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -181,6 +181,7 @@ async function generateRemoteSdkHandler(
           methods: [],
           language: path.extname(c.ast.path),
           getMethodType: () => TriggerType.jsonrpc,
+          fromDecorator: false,
         },
         fileName: path.basename(c.ast.path),
       })

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -191,10 +191,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
       ]);
       yamlProjectConfiguration.packageManager =
         optionalPackageManager.packageManager;
-      await yamlProjectConfiguration.writeToFile(
-        "./genezio.yaml",
-        YamlProjectConfigurationType.ROOT,
-      );
+      await yamlProjectConfiguration.writeToFile();
     }
 
     let sdkConfiguration = yamlProjectConfiguration.sdk

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -164,7 +164,6 @@ export async function getProjectConfiguration(
   const projectConfiguration = await YamlProjectConfiguration.create(
     configurationFileContent
   );
-  
 
   const result = await tryToReadClassInformationFromDecorators(projectConfiguration)
 
@@ -197,7 +196,7 @@ export async function getProjectConfiguration(
                 }
             }
 
-            projectConfiguration.classes.push(new YamlClassConfiguration(classInfo[0].path, type, ".js", methods))
+            projectConfiguration.classes.push(new YamlClassConfiguration(classInfo[0].path, type, ".js", methods, undefined, true))
         }
      }
   });


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🍕 New feature

## Description

Instead of having a `genezio.yaml` in the root of the workspace and two `genezio.yaml`s in the server and client, now we are having only one `genezio.yaml` in the root that contains information about both server and client.

I removed some of the code that was parsing the root `genezio.yaml` in a different way than the other two yamls. Also, I've modified the writeToFile method that was having different behaviours based on what type of yaml it is.



