### PR TITLE
Ignore files that come from 'node_modules' when checking for relative requires

### DIFF
--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -135,8 +135,15 @@ export class NodeJsBundler implements BundlerInterface {
             }
           }
 
+          const relativePath = path.relative(cwd!, args.path)
+          const components = relativePath.split(path.sep)
           const contents = await fs.promises.readFile(args.path, "utf8");
           const loader = getLoader(args.path.split(".").pop()!);
+
+          // Check if file comes from node_modules
+          if (components.length >= 1 && components[0] === "node_modules") {
+              return { contents, loader }
+          }
 
           // Check if file doesn't use require()
           if (!contents.includes("require(")) {

--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -135,7 +135,8 @@ export class NodeJsBundler implements BundlerInterface {
             }
           }
 
-          const relativePath = path.relative(cwd!, args.path)
+          const _cwd = cwd ?? process.cwd()
+          const relativePath = path.relative(_cwd, args.path)
           const components = relativePath.split(path.sep)
           const contents = await fs.promises.readFile(args.path, "utf8");
           const loader = getLoader(args.path.split(".").pop()!);


### PR DESCRIPTION

# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description

We don't support relative requires in genezio. Because of this we added a plugin in esbuild that checks if user is using a relative require and gives and informative error if it finds one. The problem occured when a dependency (one that is using a relative require) was bundled together with the user's code. This can happen if the user has installed the dependency as a `devDenpendecy` or if the dependency is not found in `package.json` but it exists in `node_modules` (we are using `nodeExternalsPlugin` to avoid bundling all the dependencies).

Now, we are checking if the file that will be bundled comes from `node_modules` folder and if this is the case, we don't check for relative requires anymore.


## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
