### PR TITLE
remove index from old sdk generation and skip classes without jsonrpc methods

### DIFF
--- a/src/generateSdk/generateSdkApi.ts
+++ b/src/generateSdk/generateSdkApi.ts
@@ -5,6 +5,7 @@ import { getGenerateAstInputs } from "./utils/getFiles.js";
 import {
   SdkGeneratorInput,
   SdkGeneratorOutput,
+  SdkVersion,
 } from "../models/genezioModels.js";
 import path from "path";
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
@@ -62,6 +63,7 @@ export async function sdkGeneratorApiHandler(
   const sdkOutput: SdkGeneratorOutput = await generateSdk(
     sdkGeneratorInput,
     projectConfiguration.plugins?.sdkGenerator,
+    projectConfiguration.sdk ? SdkVersion.OLD_SDK : SdkVersion.NEW_SDK,
   );
 
   return {

--- a/src/generateSdk/sdkGenerator/DartSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/DartSdkGenerator.ts
@@ -11,6 +11,7 @@ import {
     Node,
     MapType,
     SdkFileClass,
+    SdkVersion,
 } from "../../models/genezioModels.js";
 import { TriggerType, YamlClassConfiguration } from "../../models/yamlProjectConfiguration.js";
 import { dartSdk } from "../templates/dartSdk.js";
@@ -158,7 +159,8 @@ class {{{className}}} {
 
 class SdkGenerator implements SdkGeneratorInterface {
     async generateSdk(
-        sdkGeneratorInput: SdkGeneratorInput
+        sdkGeneratorInput: SdkGeneratorInput,
+        sdkVersion: SdkVersion,
     ): Promise<SdkGeneratorOutput> {
         const generateSdkOutput: SdkGeneratorOutput = {
             files: []

--- a/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
@@ -6,6 +6,7 @@ import {
   SdkGeneratorInput,
   SdkGeneratorOutput,
   IndexModel,
+  SdkVersion,
 } from "../../models/genezioModels.js";
 import { nodeSdkJs } from "../templates/nodeSdkJs.js";
 import Mustache from "mustache";
@@ -44,6 +45,7 @@ export class {{{className}}} {
 class SdkGenerator implements SdkGeneratorInterface {
   async generateSdk(
     sdkGeneratorInput: SdkGeneratorInput,
+    sdkVersion: SdkVersion,
   ): Promise<SdkGeneratorOutput> {
     const generateSdkOutput: SdkGeneratorOutput = {
       files: [],
@@ -72,8 +74,6 @@ class SdkGenerator implements SdkGeneratorInterface {
       if (classDefinition === undefined) {
         continue;
       }
-
-      this.addClassToIndex(indexModel, classDefinition.name);
 
       const view: any = {
         className: classDefinition.name,
@@ -124,6 +124,8 @@ class SdkGenerator implements SdkGeneratorInterface {
         continue;
       }
 
+      this.addClassToIndex(indexModel, classDefinition.name);
+
       const rawSdkClassName = `${classDefinition.name}.sdk.js`;
       const sdkClassName =
         rawSdkClassName.charAt(0).toLowerCase() + rawSdkClassName.slice(1);
@@ -143,14 +145,16 @@ class SdkGenerator implements SdkGeneratorInterface {
     });
 
     // generate index.js
-    if (indexModel.exports.length > 0) {
-      indexModel.exports[indexModel.exports.length - 1].last = true;
+    if (sdkVersion === SdkVersion.NEW_SDK) {
+      if (indexModel.exports.length > 0) {
+        indexModel.exports[indexModel.exports.length - 1].last = true;
+      }
+      generateSdkOutput.files.push({
+        className: "index",
+        path: "index.js",
+        data: Mustache.render(indexTemplate, indexModel),
+      });
     }
-    generateSdkOutput.files.push({
-      className: "index",
-      path: "index.js",
-      data: Mustache.render(indexTemplate, indexModel),
-    });
 
     return generateSdkOutput;
   }

--- a/src/generateSdk/sdkGenerator/KotlinSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/KotlinSdkGenerator.ts
@@ -10,6 +10,7 @@ import {
     PromiseType,
     Node,
     MapType,
+    SdkVersion,
 } from "../../models/genezioModels.js";
 import { TriggerType } from "../../models/yamlProjectConfiguration.js";
 import { kotlinSdk } from "../templates/kotlinSdk.js";
@@ -153,7 +154,8 @@ class {{{className}}} {
 
 class SdkGenerator implements SdkGeneratorInterface {
   async generateSdk(
-      sdkGeneratorInput: SdkGeneratorInput
+      sdkGeneratorInput: SdkGeneratorInput,
+      sdkVersion: SdkVersion,
   ): Promise<SdkGeneratorOutput> {
       const generateSdkOutput: SdkGeneratorOutput = {
           files: []

--- a/src/generateSdk/sdkGenerator/PythonSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/PythonSdkGenerator.ts
@@ -19,7 +19,8 @@ import {
   TypeLiteral,
   ParameterDefinition,
   MethodDefinition,
-  ModelView
+  ModelView,
+  SdkVersion
 } from "../../models/genezioModels.js";
 import { TriggerType } from "../../models/yamlProjectConfiguration.js";
 import { pythonSdk } from "../templates/pythonSdk.js";
@@ -108,7 +109,8 @@ class {{{className}}}:
 
 class SdkGenerator implements SdkGeneratorInterface {
   async generateSdk(
-    sdkGeneratorInput: SdkGeneratorInput
+    sdkGeneratorInput: SdkGeneratorInput,
+    sdkVersion: SdkVersion,
   ): Promise<SdkGeneratorOutput> {
 
     const generateSdkOutput: SdkGeneratorOutput = {

--- a/src/generateSdk/sdkGeneratorHandler.ts
+++ b/src/generateSdk/sdkGeneratorHandler.ts
@@ -7,6 +7,7 @@ import KotlinSdkGenerator from "./sdkGenerator/KotlinSdkGenerator.js";
 import {
   SdkGeneratorInput,
   SdkGeneratorOutput,
+  SdkVersion,
 } from "../models/genezioModels.js";
 import log from "loglevel";
 import { exit } from "process";
@@ -21,7 +22,8 @@ import { exit } from "process";
  */
 export async function generateSdk(
   sdkGeneratorInput: SdkGeneratorInput,
-  plugins: string[] | undefined
+  plugins: string[] | undefined,
+  sdkVersion: SdkVersion,
 ): Promise<SdkGeneratorOutput> {
   let pluginsImported: any = [];
 
@@ -29,7 +31,7 @@ export async function generateSdk(
     pluginsImported = plugins?.map(async (plugin) => {
       return await import(plugin).catch((err: any) => {
         log.error(
-          `Plugin(${plugin}) not found. Install it with npm install ${plugin}`
+          `Plugin(${plugin}) not found. Install it with npm install ${plugin}`,
         );
         exit(1);
       });
@@ -49,11 +51,11 @@ export async function generateSdk(
 
   if (!sdkGeneratorElem && sdkGeneratorInput.sdk) {
     throw new Error(
-      `SDK language(${sdkGeneratorInput.sdk.language}) not supported`
+      `SDK language(${sdkGeneratorInput.sdk.language}) not supported`,
     );
   }
 
   const sdkGeneratorClass = new sdkGeneratorElem.SdkGenerator();
 
-  return await sdkGeneratorClass.generateSdk(sdkGeneratorInput);
+  return await sdkGeneratorClass.generateSdk(sdkGeneratorInput, sdkVersion);
 }

--- a/src/models/genezioModels.ts
+++ b/src/models/genezioModels.ts
@@ -2,7 +2,7 @@ import { YamlClassConfiguration } from "./yamlProjectConfiguration.js";
 
 export enum GenezioCommandTemplates {
   FULLSTACK = "Fullstack",
-  BACKEND = "Backend-Only"
+  BACKEND = "Backend-Only",
 }
 
 export type ModelView = {
@@ -347,11 +347,17 @@ export type SdkGeneratorOutput = {
   files: SdkFileClass[];
 };
 
+export enum SdkVersion {
+  OLD_SDK,
+  NEW_SDK,
+}
+
 /**
  * A class implementing this interface will create the sdk for a given language.
  */
 export interface SdkGeneratorInterface {
   generateSdk: (
-    sdkGeneratorInput: SdkGeneratorInput
+    sdkGeneratorInput: SdkGeneratorInput,
+    sdkVersion: SdkVersion,
   ) => Promise<SdkGeneratorOutput>;
 }


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description

The index file used for the node_module version of the SDK was problematic in the old context of generating the SDK. This PR assures that classes with no JSON-RPC methods are not included in the SDK or index file, and the index file will not be added in the old way of generating the SDK.

## Checklist

- [x] New and existing unit tests pass locally with my changes;
