### PR TITLE
Add `nodeVersion` field to the genezio-analytics request

### DIFF
--- a/src/telemetry/sdk/analyticsHandler.sdk.ts
+++ b/src/telemetry/sdk/analyticsHandler.sdk.ts
@@ -18,6 +18,7 @@ export type AnalyticsData = {
     genezioVersion?: string;
     commandOptions?: string;
     isCI?: boolean;
+    nodeVersion?: string;
 };
 
 export class AnalyticsHandler {

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -99,6 +99,7 @@ export class GenezioTelemetry {
             genezioVersion: version,
             commandOptions: eventRequest.commandOptions || "",
             isCI: process.env.CI ? true : false,
+            nodeVersion: process.version,
         };
 
         await AnalyticsHandler.sendEvent(analyticsData).catch((err) => {


### PR DESCRIPTION
<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 New feature

## Description

We want to send the node version as an analytic because we want to know when is safe to drop an old (deprecated) NodeJS version.

# Prerequisites
- [x] Update the `genezio-analytics` code: https://github.com/Genez-io/genezio-analytics/pull/5

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
