### PR TITLE
  Restarting process does not load the env variables

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -58,6 +58,7 @@ type ClassProcess = {
     startingCommand: string;
     parameters: string[];
     listeningPort: number;
+    envVars: dotenv.DotenvPopulateInput;
 };
 
 type BundlerRestartResponse = {
@@ -795,6 +796,7 @@ async function startClassProcess(
         listeningPort: availablePort,
         startingCommand: startingCommand,
         parameters: parameters,
+        envVars: envVars,
     });
 }
 
@@ -813,6 +815,7 @@ async function communicateWithProcess(
                 localProcess.parameters,
                 className,
                 processForClasses,
+                localProcess.envVars,
             );
         }
         throw error;


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] 🐛 Bug Fix

## Description

During `genezio local`, if a class fails and crashes, the next request will restart the class process. However, before this fix, the env variables associated with that class where not passed correctly to the newly started process.
