### PR TITLE
Filter directories when parsing the files hierarchy for decorators

### DIFF
--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -154,11 +154,14 @@ async function tryToReadClassInformationFromDecorators(
     projectConfiguration: YamlProjectConfiguration,
 ) {
     const cwd = projectConfiguration.workspace?.backend || process.cwd();
+
     const allJsFilesPaths = (await getAllFilesFromPath(cwd)).filter((file: FileDetails) => {
+        const folderPath = path.join(cwd, file.path);
         return (
             (file.extension === ".js" || file.extension === ".ts") &&
             !file.path.includes("node_modules") &&
-            !file.path.includes(".git")
+            !file.path.includes(".git") &&
+            !fs.lstatSync(folderPath).isDirectory()
         );
     });
 


### PR DESCRIPTION


# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix


## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

When parsing the cwd files hierarchy to parse the files for genezio decorators we should skip directories.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] I have updated the documentation;
- [x] New and existing unit tests pass locally with my changes;
