### PR TITLE
Add `--subdomain` option for genezio deploy

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -573,14 +573,14 @@ export async function deployFrontend(
             log.info("WARNING: No index.html file found in the build folder");
         }
 
+        configuration.frontend.subdomain = options.subdomain || configuration.frontend.subdomain;
         if (!configuration.frontend.subdomain) {
             log.info(
-                "No subdomain specified in the genezio.yaml configuration file. We will provide a random one for you.",
+                "No subdomain specified in the genezio.yaml configuration file or as an option flag. We will provide a random one for you.",
             );
-            configuration.frontend.subdomain = generateRandomSubdomain();
 
             // write the configuration in yaml file
-            await configuration.addSubdomain(configuration.frontend.subdomain);
+            await configuration.addSubdomain(generateRandomSubdomain());
         }
 
         const url = await cloudAdapter.deployFrontend(

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -146,6 +146,11 @@ program
     .option("--install-deps", "Automatically install missing dependencies.", false)
     .option("--env <envFile>", "Load environment variables from a given file.", undefined)
     .option("--stage <stage>", "Stage to deploy to. Default: 'production'.")
+    .option(
+        "--subdomain <subdomain>",
+        "Subdomain of your frontend deplyoment. If not set, the subdomain will be randomly generated.",
+        undefined,
+    )
     .description(
         `Deploy your project to the genezio infrastructure. Use --frontend to deploy only the frontend application.
 Use --backend to deploy only the backend application.`,

--- a/src/models/commandOptions.ts
+++ b/src/models/commandOptions.ts
@@ -14,4 +14,5 @@ export type GenezioDeployOptions = {
     installDeps: boolean;
     env?: string;
     stage?: string;
+    subdomain?: string;
 };

--- a/src/models/yamlProjectConfiguration.ts
+++ b/src/models/yamlProjectConfiguration.ts
@@ -189,7 +189,7 @@ export class YamlClassConfiguration {
 
 export type YamlFrontend = {
     path: string;
-    subdomain: string;
+    subdomain: string | undefined;
 };
 
 export class YamlScriptsConfiguration {


### PR DESCRIPTION


<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 New feature

## Description
This change adds a new `--subdomain` option flag. This option overrides the `genezio.yaml` configuration file subdomain entry.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
