### PR TITLE
Add `calculateBiggestFiles` typing

### DIFF
--- a/src/cloudAdapter/cloudAdapter.ts
+++ b/src/cloudAdapter/cloudAdapter.ts
@@ -1,27 +1,16 @@
 import { DeployCodeMethodResponse } from "../models/deployCodeResponse.js";
 import { MethodConfiguration, ProjectConfiguration } from "../models/projectConfiguration.js";
 import { YamlFrontend } from "../models/yamlProjectConfiguration.js";
+import { Dependency } from "../bundlers/bundler.interface.js";
+import FileDetails from "../models/fileDetails.js";
 
 export type GenezioCloudInput = {
     name: string;
     archivePath: string;
     filePath: string;
     methods: MethodConfiguration[];
-    dependenciesInfo: {
-        name: string;
-        path: string;
-    };
-    allNonJsFilesPaths: {
-        name: string;
-        extension: string;
-        path: string;
-        filePath: string;
-    };
-    filesSize: {
-        name: string;
-        totalSize: number;
-    };
-
+    dependenciesInfo?: Dependency[];
+    allNonJsFilesPaths?: FileDetails[];
     unzippedBundleSize: number;
 };
 

--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -51,7 +51,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
 
             if (element.unzippedBundleSize > BUNDLE_SIZE_LIMIT) {
                 // Throw this error if bundle size is too big and the user is not using js or ts files.
-                if (!dependenciesInfo) {
+                if (!dependenciesInfo || !allNonJsFilesPaths) {
                     throw new Error(
                         `Your class ${element.name} is too big: ${element.unzippedBundleSize} bytes. The maximum size is 250MB. Try to reduce the size of your class.`,
                     );

--- a/src/utils/calculateBiggestProjectFiles.ts
+++ b/src/utils/calculateBiggestProjectFiles.ts
@@ -1,5 +1,7 @@
 import fs from "fs";
 import { getBundleFolderSizeLimit } from "./file.js";
+import { Dependency } from "../bundlers/bundler.interface.js";
+import FileDetails from "../models/fileDetails.js";
 
 type PackageInfo = {
     name: string;
@@ -13,11 +15,14 @@ function getTop5LargestPackages(packages: PackageInfo[]): string[] {
     return formatedSizes;
 }
 
-export async function calculateBiggestFiles(dependencies: any, allNonJsFilesPaths: any) {
+export async function calculateBiggestFiles(
+    dependencies: Dependency[],
+    allNonJsFilesPaths: FileDetails[],
+) {
     const fileSizes: { name: string; totalSize: number }[] = [];
     const nodeModulesData: { name: string; totalSize: number }[] = [];
 
-    const promises = dependencies.map(async (file: { name: string; path: string }) => {
+    const promises = dependencies.map(async (file) => {
         const depSize: number = await getBundleFolderSizeLimit(file.path);
         const moduleData = {
             name: file.name,


### PR DESCRIPTION


<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

The `calculateBiggestFiles` function was having `any` types for it's parameters. That introduced some bugs because the expected typing was not the actual typing in other contexts. This change fixes it.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
