### PR TITLE
Remove npm link

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -27,6 +27,7 @@ import {
     getBundleFolderSizeLimit,
     readEnvironmentVariablesFile,
     createLocalTempFolder,
+    interruptLocalProcesses,
 } from "../utils/file.js";
 import { printAdaptiveLog, debugLogger } from "../utils/logging.js";
 import { runNewProcess } from "../utils/process.js";
@@ -45,12 +46,15 @@ import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js
 import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
 import { setEnvironmentVariables } from "../requests/setEnvironmentVariables.js";
 import colors from "colors";
+import os from "os";
+import fs from "fs/promises";
 import { getEnvironmentVariables } from "../requests/getEnvironmentVariables.js";
 import { getNodeModulePackageJson } from "../generateSdk/templates/packageJson.js";
 import { getProjectEnvFromProject } from "../requests/getProjectInfo.js";
 import { compileSdk } from "../generateSdk/utils/compileSdk.js";
 
 export async function deployCommand(options: GenezioDeployOptions) {
+    await interruptLocalProcesses();
     let configuration;
 
     try {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -27,7 +27,6 @@ import {
     getBundleFolderSizeLimit,
     readEnvironmentVariablesFile,
     createLocalTempFolder,
-    interruptLocalProcesses,
 } from "../utils/file.js";
 import { printAdaptiveLog, debugLogger } from "../utils/logging.js";
 import { runNewProcess } from "../utils/process.js";
@@ -46,12 +45,11 @@ import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js
 import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
 import { setEnvironmentVariables } from "../requests/setEnvironmentVariables.js";
 import colors from "colors";
-import os from "os";
-import fs from "fs/promises";
 import { getEnvironmentVariables } from "../requests/getEnvironmentVariables.js";
 import { getNodeModulePackageJson } from "../generateSdk/templates/packageJson.js";
 import { getProjectEnvFromProject } from "../requests/getProjectInfo.js";
 import { compileSdk } from "../generateSdk/utils/compileSdk.js";
+import { interruptLocalProcesses } from "../utils/localInterrupt.js";
 
 export async function deployCommand(options: GenezioDeployOptions) {
     await interruptLocalProcesses();

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,15 +1,23 @@
 import { getProjectConfiguration } from "../utils/configuration.js";
-import { deleteLinkPathForProject, setLinkPathForProject } from "../utils/linkDatabase.js";
+import {
+    deleteLinkPathForProject,
+    deleteAllLinkPaths,
+    setLinkPathForProject,
+} from "../utils/linkDatabase.js";
 
 export async function linkCommand() {
     const cwd = process.cwd();
-    const projectConfiguration = await getProjectConfiguration();
+    const projectConfiguration = await getProjectConfiguration("./genezio.yaml", true);
 
-    setLinkPathForProject(projectConfiguration.name, projectConfiguration.region, cwd);
+    await setLinkPathForProject(projectConfiguration.name, projectConfiguration.region, cwd);
 }
 
-export async function unlinkCommand() {
-    const projectConfiguration = await getProjectConfiguration();
+export async function unlinkCommand(unlinkAll: boolean) {
+    if (unlinkAll) {
+        await deleteAllLinkPaths();
+        return;
+    }
+    const projectConfiguration = await getProjectConfiguration("./genezio.yaml", true);
 
-    deleteLinkPathForProject(projectConfiguration.name, projectConfiguration.region);
+    await deleteLinkPathForProject(projectConfiguration.name, projectConfiguration.region);
 }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -5,19 +5,38 @@ import {
     setLinkPathForProject,
 } from "../utils/linkDatabase.js";
 
-export async function linkCommand() {
+export async function linkCommand(
+    projectName: string | undefined,
+    projectRegion: string | undefined,
+) {
     const cwd = process.cwd();
-    const projectConfiguration = await getProjectConfiguration("./genezio.yaml", true);
+    let name = projectName;
+    let region = projectRegion;
+    if (!name || !region) {
+        const projectConfiguration = await getProjectConfiguration("./genezio.yaml", true);
+        name = projectConfiguration.name;
+        region = projectConfiguration.region;
+    }
 
-    await setLinkPathForProject(projectConfiguration.name, projectConfiguration.region, cwd);
+    await setLinkPathForProject(name, region, cwd);
 }
 
-export async function unlinkCommand(unlinkAll: boolean) {
+export async function unlinkCommand(
+    unlinkAll: boolean,
+    projectName: string | undefined,
+    projectRegion: string | undefined,
+) {
     if (unlinkAll) {
         await deleteAllLinkPaths();
         return;
     }
-    const projectConfiguration = await getProjectConfiguration("./genezio.yaml", true);
+    let name = projectName;
+    let region = projectRegion;
+    if (!name || !region) {
+        const projectConfiguration = await getProjectConfiguration("./genezio.yaml", true);
+        name = projectConfiguration.name;
+        region = projectConfiguration.region;
+    }
 
-    await deleteLinkPathForProject(projectConfiguration.name, projectConfiguration.region);
+    await deleteLinkPathForProject(name, region);
 }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,0 +1,15 @@
+import { getProjectConfiguration } from "../utils/configuration.js";
+import { deleteLinkPathForProject, setLinkPathForProject } from "../utils/linkDatabase.js";
+
+export async function linkCommand() {
+    const cwd = process.cwd();
+    const projectConfiguration = await getProjectConfiguration();
+
+    setLinkPathForProject(projectConfiguration.name, projectConfiguration.region, cwd);
+}
+
+export async function unlinkCommand() {
+    const projectConfiguration = await getProjectConfiguration();
+
+    deleteLinkPathForProject(projectConfiguration.name, projectConfiguration.region);
+}

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -435,7 +435,10 @@ async function writeSdkToNodeModules(
     originSdkPath: string,
 ) {
     const writeSdk = async (from: string, toTemp: string, toFinal: string) => {
-        // Check if it's a symbolic link
+        // Firstly, we copy the SDK to a temporary folder
+        // we remove any existing SDK from node_modules and then we rename the temporary folder to the final name
+        //
+        // This is done to avoid any race condition issues with npm install or npm update
         await fsExtra.copy(from, toTemp, { overwrite: true });
 
         if (fs.existsSync(toFinal)) {

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -60,6 +60,7 @@ import { runNewProcess } from "../utils/process.js";
 import { exit } from "process";
 import { getLinkPathsForProject } from "../utils/linkDatabase.js";
 import log from "loglevel";
+import { interruptLocalPath } from "../utils/localInterrupt.js";
 
 type ClassProcess = {
     process: ChildProcess;
@@ -379,7 +380,7 @@ async function watchNodeModules(
     // - node_modules/@genezio-sdk/<projectName>_<region>/package.json: this file is used to determine if the SDK was changed (by a npm install or npm update)
     // - node_modules/.package-lock.json: this file is used by npm to determine if it should update the packages or not. We are removing this file while "genezio local"
     // is running, because we are modifying node_modules folder manual (reference: https://github.com/npm/cli/blob/653769de359b8d24f0d17b8e7e426708f49cadb8/docs/content/configuring-npm/package-lock-json.md#hidden-lockfiles)
-    const watchPaths: string[] = [path.join(os.homedir(), ".geneziointerrupt")];
+    const watchPaths: string[] = [interruptLocalPath];
     const sdkName = `${yamlProjectConfiguration.name}_${yamlProjectConfiguration.region}`;
     const nodeModulesPath = path.join("node_modules", "@genezio-sdk", sdkName);
     if (yamlProjectConfiguration.workspace) {
@@ -438,7 +439,7 @@ async function watchNodeModules(
             }
 
             // if the file is .geneziointerrupt, stop the process
-            if (components[components.length - 1] === ".geneziointerrupt") {
+            if (components[components.length - 1] === "geneziointerrupt") {
                 log.info("A deployment is in progress. Stopping local environment...");
                 exit(0);
             }

--- a/src/generateSdk/templates/packageJson.ts
+++ b/src/generateSdk/templates/packageJson.ts
@@ -1,6 +1,6 @@
 export const getNodeModulePackageJsonLocal = (projectName: string, region: string): string => `{
   "name": "@genezio-sdk/${projectName}_${region}",
-  "version": "1.0.0",
+  "version": "1.0.0-local",
   "description": "",
   "main": "./cjs/index.js",
   "module": "./esm/index.js"

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -75,12 +75,6 @@ export async function compileSdk(
     const modulePath = path.resolve(sdkPath, "..", "genezio-sdk");
     const writePackagePromise = writeToFile(modulePath, "package.json", packageJson, true);
     workers.push(writePackagePromise);
-    if (environment === GenezioCommand.local) {
-        const commandPromise = asyncExec(packageManager + " link", {
-            cwd: modulePath,
-        });
-        workers.push(commandPromise);
-    }
     await Promise.all(workers);
     if (environment === GenezioCommand.deploy) {
         await asyncExec(packageManager + " publish", {

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -48,7 +48,7 @@ if (ENABLE_DEBUG_LOGS_BY_DEFAULT) {
 
 // setup package manager
 try {
-    const configuration = await getProjectConfiguration();
+    const configuration = await getProjectConfiguration("./genezio.yaml", true);
     if (configuration.packageManager) {
         if (!Object.keys(PackageManagerType).includes(configuration.packageManager)) {
             log.warn(

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -347,21 +347,54 @@ program
         "--logLevel <logLevel>",
         "Show debug logs to console. Possible levels: trace/debug/info/warn/error.",
     )
+    .option(
+        "--projectName <projectName>",
+        "The name of the project that you want to communicate with.",
+    )
+    .option("--region <region>", "The region of the project that you want to communicate with.")
     .description(
         "Set this path as the spot for your frontend app within a project that uses multiple repositories. Doing this helps 'genezio local' figure out by itself where to create the SDK.",
     )
-    .action(async () => {
-        await linkCommand();
+    .action(async (options: any) => {
+        await linkCommand(options.projectName, options.region).catch((error: Error) => {
+            log.error(error.message);
+            log.error(
+                "Error: Command execution failed. Please ensure you are running this command from a directory containing 'genezio.yaml' or provide the '--projectName <name>' and '--region <region>' flags.",
+            );
+            exit(1);
+        });
+        log.info("Successfully linked the path to your genezio project.");
     });
 
 program
     .command("unlink")
     .option("--all", "Remove all links.")
+    .option(
+        "--projectName <projectName>",
+        "The name of the project that you want to communicate with. If --all is used, this option is ignored.",
+    )
+    .option(
+        "--region <region>",
+        "The region of the project that you want to communicate with. If --all is used, this option is ignored.",
+    )
     .description(
         "Clear the previously set path for your frontend app, which is useful when managing a project with multiple repositories. This reset allows 'genezio local' to stop automatically generating the SDK in that location.",
     )
     .action(async (options: any) => {
-        await unlinkCommand(options.all);
+        await unlinkCommand(options.all, options.projectName, options.region).catch(
+            (error: Error) => {
+                log.error(error.message);
+                log.error(
+                    "Error: Command execution failed. Please ensure you are running this command from a directory containing 'genezio.yaml' or provide the '--projectName <name>' and '--region <region>' flags.",
+                );
+                exit(1);
+            },
+        );
+        if (options.all) {
+            log.info("Successfully unlinked all paths to your genezio projects.");
+            return;
+        }
+        log.info("Successfully unlinked the path to your genezio project.");
     });
 
 export default program;

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -321,12 +321,27 @@ program
         await logOutdatedVersion();
     });
 
-program.command("link").action(() => {
-    linkCommand();
-});
+program
+    .command("link")
+    .option(
+        "--logLevel <logLevel>",
+        "Show debug logs to console. Possible levels: trace/debug/info/warn/error.",
+    )
+    .description(
+        "Set this path as the spot for your frontend app within a project that uses multiple repositories. Doing this helps 'genezio local' figure out by itself where to create the SDK.",
+    )
+    .action(async () => {
+        await linkCommand();
+    });
 
-program.command("unlink").action(() => {
-    unlinkCommand();
-});
+program
+    .command("unlink")
+    .option("--all", "Remove all links.")
+    .description(
+        "Clear the previously set path for your frontend app, which is useful when managing a project with multiple repositories. This reset allows 'genezio local' to stop automatically generating the SDK in that location.",
+    )
+    .action(async (options: any) => {
+        await unlinkCommand(options.all);
+    });
 
 export default program;

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -19,6 +19,7 @@ import { GenezioDeployOptions, GenezioLocalOptions } from "./models/commandOptio
 import currentGenezioVersion, { logOutdatedVersion } from "./utils/version.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "./telemetry/telemetry.js";
 import { genezioCommand } from "./commands/superGenezio.js";
+import { linkCommand, unlinkCommand } from "./commands/link.js";
 
 const program = new Command();
 
@@ -319,5 +320,13 @@ program
         });
         await logOutdatedVersion();
     });
+
+program.command("link").action(() => {
+    linkCommand();
+});
+
+program.command("unlink").action(() => {
+    unlinkCommand();
+});
 
 export default program;

--- a/src/telemetry/session.ts
+++ b/src/telemetry/session.ts
@@ -5,7 +5,7 @@ import { debugLogger } from "../utils/logging.js";
 
 export async function getTelemetrySessionId(): Promise<string | undefined> {
     const homeDirectory = os.homedir();
-    const loginConfigFilePath = path.join(homeDirectory, ".geneziotelemetryrc");
+    const loginConfigFilePath = path.join(homeDirectory, ".genezio", "geneziotelemetryrc");
     try {
         const result = await readUTF8File(loginConfigFilePath);
         return result.trim();
@@ -16,8 +16,8 @@ export async function getTelemetrySessionId(): Promise<string | undefined> {
 }
 
 export async function saveTelemetrySessionId(token: string) {
-    const homeDirectory = os.homedir();
-    const loginConfigFile = ".geneziotelemetryrc";
+    const configDirectory = path.join(os.homedir(), ".genezio");
+    const loginConfigFile = "geneziotelemetryrc";
 
-    await writeToFile(homeDirectory, loginConfigFile, token, true);
+    await writeToFile(configDirectory, loginConfigFile, token, true);
 }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -182,6 +182,7 @@ async function tryToReadClassInformationFromDecorators(
 
 export async function getProjectConfiguration(
     configurationFilePath = "./genezio.yaml",
+    skipClassScan = false,
 ): Promise<YamlProjectConfiguration> {
     if (!(await checkYamlFileExists(configurationFilePath))) {
         throw new Error("The configuration file does not exist.");
@@ -199,6 +200,9 @@ export async function getProjectConfiguration(
 
     const projectConfiguration = await YamlProjectConfiguration.create(configurationFileContent);
 
+    if (skipClassScan) {
+        return projectConfiguration;
+    }
     const result = await tryToReadClassInformationFromDecorators(projectConfiguration);
 
     result.forEach((classInfo) => {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import fsPromise from "fs/promises";
 import os from "os";
 import path from "path";
 import FileDetails from "../models/fileDetails.js";
@@ -406,15 +405,6 @@ export async function readEnvironmentVariablesFile(
     return envVars;
 }
 
-// Inform local processes to interrupt when a deployment has started
-export async function interruptLocalProcesses() {
-    const interruptLocalPath = path.join(os.homedir(), ".geneziointerrupt");
-    const interruptLocal = await fsPromise.open(interruptLocalPath, "w");
-    await interruptLocal.close();
-
-    await fsPromise.utimes(interruptLocalPath, new Date(), new Date());
-}
-
 export function getPathUntilProjectNodeModules(absolutePath: string, projectName: string): string {
     // Ensure that the path is absolute
     if (!path.isAbsolute(absolutePath)) {
@@ -430,7 +420,6 @@ export function getPathUntilProjectNodeModules(absolutePath: string, projectName
 
     // If the pattern is not found, return an empty string
     if (patternIndex === -1) {
-        console.log("intra aici");
         return "";
     }
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -404,28 +404,3 @@ export async function readEnvironmentVariablesFile(
     }
     return envVars;
 }
-
-export function getPathUntilProjectNodeModules(absolutePath: string, projectName: string): string {
-    // Ensure that the path is absolute
-    if (!path.isAbsolute(absolutePath)) {
-        throw new Error("The provided path is not absolute.");
-    }
-
-    // Split the path into components
-    const components = absolutePath.split(path.sep);
-
-    // Find the index of the "node_modules/<project_name>" pattern
-    const pattern = `node_modules${path.sep}@genezio-sdk${path.sep}${projectName}`;
-    const patternIndex = components.join(path.sep).indexOf(pattern);
-
-    // If the pattern is not found, return an empty string
-    if (patternIndex === -1) {
-        return "";
-    }
-
-    // Calculate the end index for the sub-path (add length of the pattern to start index of pattern)
-    const endIndex = patternIndex + pattern.length;
-
-    // Return the sub-path until "node_modules/<project_name>"
-    return absolutePath.substring(0, endIndex);
-}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -414,3 +414,29 @@ export async function interruptLocalProcesses() {
 
     await fsPromise.utimes(interruptLocalPath, new Date(), new Date());
 }
+
+export function getPathUntilProjectNodeModules(absolutePath: string, projectName: string): string {
+    // Ensure that the path is absolute
+    if (!path.isAbsolute(absolutePath)) {
+        throw new Error("The provided path is not absolute.");
+    }
+
+    // Split the path into components
+    const components = absolutePath.split(path.sep);
+
+    // Find the index of the "node_modules/<project_name>" pattern
+    const pattern = `node_modules${path.sep}@genezio-sdk${path.sep}${projectName}`;
+    const patternIndex = components.join(path.sep).indexOf(pattern);
+
+    // If the pattern is not found, return an empty string
+    if (patternIndex === -1) {
+        console.log("intra aici");
+        return "";
+    }
+
+    // Calculate the end index for the sub-path (add length of the pattern to start index of pattern)
+    const endIndex = patternIndex + pattern.length;
+
+    // Return the sub-path until "node_modules/<project_name>"
+    return absolutePath.substring(0, endIndex);
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -406,6 +406,7 @@ export async function readEnvironmentVariablesFile(
     return envVars;
 }
 
+// Inform local processes to interrupt when a deployment has started
 export async function interruptLocalProcesses() {
     const interruptLocalPath = path.join(os.homedir(), ".geneziointerrupt");
     const interruptLocal = await fsPromise.open(interruptLocalPath, "w");

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import fsPromise from "fs/promises";
 import os from "os";
 import path from "path";
 import FileDetails from "../models/fileDetails.js";
@@ -405,4 +406,12 @@ export async function readEnvironmentVariablesFile(
         envVars.push({ name: key, value: value });
     }
     return envVars;
+}
+
+export async function interruptLocalProcesses() {
+    const interruptLocalPath = path.join(os.homedir(), ".geneziointerrupt");
+    const interruptLocal = await fsPromise.open(interruptLocalPath, "w");
+    await interruptLocal.close();
+
+    await fsPromise.utimes(interruptLocalPath, new Date(), new Date());
 }

--- a/src/utils/linkDatabase.ts
+++ b/src/utils/linkDatabase.ts
@@ -3,14 +3,16 @@ import os from "os";
 import path from "path";
 
 async function getLinkContent(): Promise<Map<string, string[]>> {
-    const filePath = path.join(os.homedir(), ".geneziolinks");
+    const directoryPath = path.join(os.homedir(), ".genezio");
+    const filePath = path.join(directoryPath, "geneziolinks");
     try {
         // Try to read the file
         const data = await fs.readFile(filePath, "utf8");
         // Parse the content as JSON and return as a Map
         return new Map(Object.entries(JSON.parse(data)));
     } catch (error: any) {
-        if (error.code === "ENOENT") {
+        if (error.code === "ENOENT" || error.code === "ENOTDIR") {
+            await fs.mkdir(directoryPath, { recursive: true });
             // If the file doesn't exist, create it with an empty object
             await fs.writeFile(filePath, JSON.stringify({}), "utf8");
             return new Map<string, string[]>();
@@ -57,6 +59,7 @@ export async function deleteLinkPathForProject(projectName: string, region: stri
 }
 
 async function saveLinkContent(content: Map<string, string[]>): Promise<void> {
-    const filePath = path.join(os.homedir(), ".geneziolinks");
+    const directoryPath = path.join(os.homedir(), ".genezio");
+    const filePath = path.join(directoryPath, "geneziolinks");
     await fs.writeFile(filePath, JSON.stringify(Object.fromEntries(content)), "utf8");
 }

--- a/src/utils/linkDatabase.ts
+++ b/src/utils/linkDatabase.ts
@@ -1,0 +1,58 @@
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
+async function getLinkContent(): Promise<Map<string, string[]>> {
+    const filePath = path.join(os.homedir(), ".geneziolinks");
+    try {
+        // Try to read the file
+        const data = await fs.readFile(filePath, "utf8");
+        // Parse the content as JSON and return as a Map
+        return new Map(Object.entries(JSON.parse(data)));
+    } catch (error: any) {
+        if (error.code === "ENOENT") {
+            // If the file doesn't exist, create it with an empty object
+            await fs.writeFile(filePath, JSON.stringify({}), "utf8");
+            return new Map<string, string[]>();
+        }
+        // Rethrow the error if it's not because the file doesn't exist
+        throw error;
+    }
+}
+
+export async function getLinkPathsForProject(
+    projectName: string,
+    region: string,
+): Promise<string[]> {
+    const content = await getLinkContent();
+    const key = `${projectName}:${region}`;
+    return content.get(key) || [];
+}
+
+export async function setLinkPathForProject(
+    projectName: string,
+    region: string,
+    linkPath: string,
+): Promise<void> {
+    const content = await getLinkContent();
+    const key = `${projectName}:${region}`;
+    const paths = content.get(key) || [];
+    if (paths.includes(linkPath)) {
+        return;
+    }
+    paths.push(linkPath);
+    content.set(key, paths);
+    await saveLinkContent(content);
+}
+
+export async function deleteLinkPathForProject(projectName: string, region: string): Promise<void> {
+    const content = await getLinkContent();
+    const key = `${projectName}:${region}`;
+    content.delete(key);
+    await saveLinkContent(content);
+}
+
+async function saveLinkContent(content: Map<string, string[]>): Promise<void> {
+    const filePath = path.join(os.homedir(), ".geneziolinks");
+    await fs.writeFile(filePath, JSON.stringify(Object.fromEntries(content)), "utf8");
+}

--- a/src/utils/linkDatabase.ts
+++ b/src/utils/linkDatabase.ts
@@ -45,6 +45,10 @@ export async function setLinkPathForProject(
     await saveLinkContent(content);
 }
 
+export async function deleteAllLinkPaths(): Promise<void> {
+    await saveLinkContent(new Map<string, string[]>());
+}
+
 export async function deleteLinkPathForProject(projectName: string, region: string): Promise<void> {
     const content = await getLinkContent();
     const key = `${projectName}:${region}`;

--- a/src/utils/localInterrupt.ts
+++ b/src/utils/localInterrupt.ts
@@ -1,0 +1,13 @@
+import os from "os";
+import fsPromise from "fs/promises";
+import path from "path";
+
+export const interruptLocalPath = path.join(os.homedir(), ".genezio", "geneziointerrupt");
+
+// Inform local processes to interrupt when a deployment has started
+export async function interruptLocalProcesses() {
+    const interruptLocal = await fsPromise.open(interruptLocalPath, "w");
+    await interruptLocal.close();
+
+    await fsPromise.utimes(interruptLocalPath, new Date(), new Date());
+}

--- a/src/utils/localInterrupt.ts
+++ b/src/utils/localInterrupt.ts
@@ -1,13 +1,20 @@
 import os from "os";
 import fsPromise from "fs/promises";
 import path from "path";
+import { writeToFile } from "./file.js";
 
 export const interruptLocalPath = path.join(os.homedir(), ".genezio", "geneziointerrupt");
 
+export async function getInterruptLastModifiedTime() {
+    try {
+        const stats = await fsPromise.stat(interruptLocalPath);
+        return stats.mtimeMs;
+    } catch (err) {
+        return 0;
+    }
+}
+
 // Inform local processes to interrupt when a deployment has started
 export async function interruptLocalProcesses() {
-    const interruptLocal = await fsPromise.open(interruptLocalPath, "w");
-    await interruptLocal.close();
-
-    await fsPromise.utimes(interruptLocalPath, new Date(), new Date());
+    await writeToFile(path.join(os.homedir(), ".genezio"), "geneziointerrupt", "", true);
 }

--- a/src/utils/reporter.ts
+++ b/src/utils/reporter.ts
@@ -63,13 +63,7 @@ export function reportSuccess(
             if (newVersion) {
                 log.info(
                     boxen(
-                        `${colors.green(
-                            "To install the SDK in your client, run this command in your client's root:",
-                        )}\n${colors.magenta(
-                            `npm link @genezio-sdk/${projectConfiguration.name}_${projectConfiguration.region}`,
-                        )}\n\n${colors.green(
-                            "Then import your classes like this:",
-                        )}\n${colors.magenta(
+                        `${colors.green("Import your classes like this:")}\n${colors.magenta(
                             `import { ${classesInfo[0].className} } from "@genezio-sdk/${projectConfiguration.name}_${projectConfiguration.region}"`,
                         )}`,
                         {


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] 🧑‍💻 Improvement

## Description

When the user is testing locally, genezio was using `npm link` to install the latest SDK from the local disk. However, we've seen multiple issues with `npm link`:

- the package is removed if the user is running `npm install` or `npm install <package>`
- the user does not understand or forgets to run the `npm link` command
- if `npm` is installed with `nvm` multiple versions of `node` can cause problems

Instead of relying on `link`, we have decided to write directly to `node_modules/@genezio-sdk/...`. We are watching the folder, to see if the package is removed and we put it back if that happens. If `genezio deploy` is executed, we stop all the `genezio local` processes to make sure that the user doesn't push an SDK with localhost URL.

## Checklist

- [x] My code follows the contributor guidelines of this project;
