### PR TITLE
Add private repository authentication (scoped registries) for yarn v2 and above

### DIFF
--- a/src/packageManagers/npm.ts
+++ b/src/packageManagers/npm.ts
@@ -1,7 +1,9 @@
 import { PackageManager } from "./packageManager.js";
-import { exec, execSync } from "child_process";
+import { ExecOptions, exec, execSync } from "child_process";
+import { homedir } from "os";
 import { promisify } from "util";
-const asyncExec = promisify(exec);
+const asyncExec = (cmd: string, options?: ExecOptions) =>
+    promisify(exec)(cmd, options ?? { cwd: homedir() });
 
 export default class NpmPackageManager implements PackageManager {
     readonly command = "npm";

--- a/src/packageManagers/pnpm.ts
+++ b/src/packageManagers/pnpm.ts
@@ -1,7 +1,9 @@
 import { PackageManager } from "./packageManager.js";
-import { exec, execSync } from "child_process";
+import { ExecOptions, exec, execSync } from "child_process";
+import { homedir } from "os";
 import { promisify } from "util";
-const asyncExec = promisify(exec);
+const asyncExec = (cmd: string, options?: ExecOptions) =>
+    promisify(exec)(cmd, options ?? { cwd: homedir() });
 
 export default class PnpmPackageManager implements PackageManager {
     readonly command = "pnpm";


### PR DESCRIPTION


<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

This change enables users who use `yarn` to install the production `sdk` which is stored in a private npm repository (needs auth).

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
