### PR TITLE
Change randomly the version of the SDK package when testing locally

### DIFF
--- a/src/generateSdk/templates/packageJson.ts
+++ b/src/generateSdk/templates/packageJson.ts
@@ -1,6 +1,14 @@
+function getRandomSemVer() {
+    const major = Math.floor(Math.random() * 10); // Random major version between 0 and 9
+    const minor = Math.floor(Math.random() * 10); // Random minor version between 0 and 9
+    const patch = Math.floor(Math.random() * 10); // Random patch version between 0 and 9
+
+    return `${major}.${minor}.${patch}-local`;
+}
+
 export const getNodeModulePackageJsonLocal = (projectName: string, region: string): string => `{
   "name": "@genezio-sdk/${projectName}_${region}",
-  "version": "1.0.0-local",
+  "version": "${getRandomSemVer()}",
   "description": "",
   "main": "./cjs/index.js",
   "module": "./esm/index.js"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] 🍕 New feature
- [x] 🐛 Bug Fix
- [ ] 🔥 Breaking change
- [ ] 🧑‍💻 Improvement
- [ ] 📝 Documentation Update

## Description

Change randomly the version of the SDK package when testing locally. This is done to invalidate the webpack caching.
