### PR TITLE
Ignore esbuild updates greater than 0.18.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,6 +15,9 @@ updates:
       time: "10:00"
       timezone: Europe/Bucharest
     versioning-strategy: increase
+    ignore:
+      - dependency-name: "esbuild"
+        versions: [">= 0.18.0"]
   - package-ecosystem: "gitsubmodule"
     target-branch: "master"
     directory: "/"


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

The updates for esbuild to versions greater than 0.18.0 are breaking for genezio.
This PR disables future updates on this dependency.

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
