### PR TITLE
Update axios to 1.6.0 to solve security alert from dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "async-mutex": "^0.4.0",
                 "await-exec": "^0.1.2",
                 "aws-cron-parser": "^1.1.12",
-                "axios": "^1.5.1",
+                "axios": "^1.6.0",
                 "babel-jest": "^29.7.0",
                 "body": "^5.1.0",
                 "body-parser": "^1.20.1",
@@ -6349,9 +6349,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-            "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "dependencies": {
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "async-mutex": "^0.4.0",
         "await-exec": "^0.1.2",
         "aws-cron-parser": "^1.1.12",
-        "axios": "^1.5.1",
+        "axios": "^1.6.0",
         "babel-jest": "^29.7.0",
         "body": "^5.1.0",
         "body-parser": "^1.20.1",


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🧑‍💻 Improvement


## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

A moderate severity alert was detected by dependabot [1].

I am manually updating axios to 1.6.0 because the dependabot PR is updating the version only in `package-lock.json`.

[1] https://github.com/Genez-io/genezio/pull/536/files

## Checklist

- [x] My code follows the contributor guidelines of this project;
- [x] New and existing unit tests pass locally with my changes;
