### PR TITLE
Enable `noPropertyAccessFromIndexSignature` TypeScript compiler option

### DIFF
--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -254,7 +254,8 @@ export class NodeJsBundler implements BundlerInterface {
         const resolveRegex = /Could not resolve "(?<dependencyName>.+)"/;
         let npmInstallRequired = false;
         const errToDeps = error.errors.map((error: Message) => {
-            const packageName = resolveRegex.exec(error.text)?.groups?.dependencyName;
+            const regexGroups = resolveRegex.exec(error.text)?.groups;
+            const packageName = regexGroups ? regexGroups["dependencyName"] : undefined;
             if (packageName && !error.location?.file.startsWith("node_modules/")) {
                 npmInstallRequired = true;
                 return null;

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -72,8 +72,8 @@ export async function generateSdkCommand(projectName: string, options: GenezioSd
                             "Oops! The configuration file does not exist at the specified path. Do you want us to create one for you?",
                     },
                 ]);
-                if (answers.createConfig) {
-                    const projects = await listProjects(0).catch((error: any) => {
+                if (answers["createConfig"]) {
+                    const projects = await listProjects(0).catch((error) => {
                         throw error;
                     });
                     const options = [
@@ -96,8 +96,8 @@ export async function generateSdkCommand(projectName: string, options: GenezioSd
                         },
                     ]);
                     configuration = await YamlProjectConfiguration.create({
-                        name: answers.project.name,
-                        region: answers.project.region,
+                        name: answers["project"].name,
+                        region: answers["project"].region,
                     });
                     await configuration.writeToFile(source);
                 } else {

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -223,7 +223,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
                     choices: Object.keys(PackageManagerType).filter((key) => isNaN(Number(key))),
                 },
             ]);
-            yamlProjectConfiguration.packageManager = optionalPackageManager.packageManager;
+            yamlProjectConfiguration.packageManager = optionalPackageManager["packageManager"];
             await yamlProjectConfiguration.writeToFile();
         }
 

--- a/src/commands/superGenezio.ts
+++ b/src/commands/superGenezio.ts
@@ -79,7 +79,7 @@ export async function genezioCommand() {
 
     log.info(
         colors.cyan(
-            `Your project will start from the ${colors.green(templateAnswer.template)} template.\n`,
+            `Your project will start from the ${colors.green(templateAnswer["template"])} template.\n`,
         ),
     );
 
@@ -102,7 +102,7 @@ export async function genezioCommand() {
     ]);
 
     log.info(
-        colors.cyan(`Your project will be named ${colors.green(projectNameAnswer.projectName)}.\n`),
+        colors.cyan(`Your project will be named ${colors.green(projectNameAnswer["projectName"])}.\n`),
     );
 
     const regionAnswer: Answers = await inquirer.prompt([
@@ -117,7 +117,7 @@ export async function genezioCommand() {
     ]);
 
     log.info(
-        colors.cyan(`Your project will be deployed in ${colors.green(regionAnswer.region)}.\n`),
+        colors.cyan(`Your project will be deployed in ${colors.green(regionAnswer["region"])}.\n`),
     );
 
     // TODO: To be added in the future
@@ -134,9 +134,9 @@ export async function genezioCommand() {
     // log.info(colors.cyan(`Your project will use ${colors.green(packageManagerAnswer.packageManager)} as package manager.\n`));
 
     let directoryName = ".";
-    const template: string = templateAnswer.template;
-    const projectName = projectNameAnswer.projectName;
-    const region = regions[regionNames.indexOf(regionAnswer.region)];
+    const template: string = templateAnswer["template"];
+    const projectName = projectNameAnswer["projectName"];
+    const region = regions[regionNames.indexOf(regionAnswer["region"])];
 
     if (!emptyDirectory) {
         const confirmAnswer: Answers = await inquirer.prompt([
@@ -151,11 +151,11 @@ export async function genezioCommand() {
         log.info(
             colors.cyan(
                 `We are creating the project in ${colors.green(
-                    `./${confirmAnswer.directoryName}`,
+                    `./${confirmAnswer["directoryName"]}`,
                 )}.\n`,
             ),
         );
-        directoryName = confirmAnswer.directoryName;
+        directoryName = confirmAnswer["directoryName"];
     } else {
         log.info(colors.cyan(`We are creating the project in the current directory.\n\n`));
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-const environment = process.env.NODE_ENV;
+const environment = process.env["NODE_ENV"];
 
 let REACT_APP_BASE_URL: string;
 let BACKEND_ENDPOINT: string;

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -63,7 +63,7 @@ export class GenezioTelemetry {
     }
 
     public static async sendEvent(eventRequest: EventRequest): Promise<void> {
-        if (process.env.GENEZIO_NO_TELEMETRY == "1") {
+        if (process.env["GENEZIO_NO_TELEMETRY"] == "1") {
             debugLogger.debug(`[GenezioTelemetry]`, `Telemetry disabled by user`);
             return;
         }
@@ -102,7 +102,7 @@ export class GenezioTelemetry {
             timeZone: timeZone,
             genezioVersion: version,
             commandOptions: eventRequest.commandOptions || "",
-            isCI: process.env.CI ? true : false,
+            isCI: process.env["CI"] ? true : false,
             nodeVersion: process.version,
         };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "noImplicitAny": true,
         "esModuleInterop": true,
         "resolveJsonModule": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "noPropertyAccessFromIndexSignature": true
     },
     "include": ["src/**/*", "package.json"],
     "exclude": ["test.js"]


### PR DESCRIPTION
<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

This change disallows developers to use `dot access` on properties that are declared as IndexSignature;

Example:

```ts
interface Foo {
  a: number;
  b: string;
  [key: string]: string;
}

function func(foo: Foo) {
  foo.a;             // allowed
  foo.b;             // allowed
  foo.anything;      // not allowed
  foo["anything"];   // allowed
}
```

This TS Compiler rule helps other ESLint rules not trigger in the future, when we enable a stricter typed ESLint rule set.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
