### PR TITLE
Disable ESLint check until more errors get fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
         "node": ">= 16"
     },
     "lint-staged": {
-        "*.{js,jsx,ts,tsx}": "eslint --cache --fix",
         "*.{js,jsx,ts,tsx,css,md,json,yaml,yml}": "prettier --write"
     }
 }


### PR DESCRIPTION


<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/master/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/master/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

Temporarily disable ESLint check for pre commit because in this new ESLint TypeScript plugin version, all the warnings have become errors. This makes it very annoying for the programmer because he either has to fix a lot of things not related to his code, or just skip the entire check (including formatting).

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
