### PR TITLE
Improve ignore paths for glob from .genezioignore relative paths

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -30,10 +30,20 @@ export async function getAllFilesRecursively(folderPath: string): Promise<string
     return files;
 }
 
-export function ensureRelativePaths(file: string) {
+export function ensureRelativePaths(file: string): string {
+    if (file.startsWith("!")) {
+        // negated patterns are passed through
+        return "!" + ensureRelativePaths(file.substring(1));
+    }
+
+    if (file.endsWith(path.sep)) {
+        // user probably wants to include all files in the directory
+        return ensureRelativePaths(path.join(file, "./**"));
+    }
+
     const absolutePath = path.resolve(file);
     const relativePath = path.relative(".", absolutePath);
-    return "./" + relativePath;
+    return relativePath;
 }
 
 export async function getAllFilesFromPath(inputPath: string): Promise<FileDetails[]> {

--- a/tests/genezioignore.test.ts
+++ b/tests/genezioignore.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "@jest/globals";
+import path from "path";
 
 import { ensureRelativePaths } from "../src/utils/file";
 
@@ -11,23 +12,23 @@ describe("genezioignore paths", () => {
         expect(ensureRelativePaths("test")).toEqual("test");
     });
 
-    test("relative dir ending with /", () => {
-        expect(ensureRelativePaths("test/")).toEqual("test/**");
+    test("relative dir ending with " + path.sep, () => {
+        expect(ensureRelativePaths("test" + path.sep)).toEqual(`test${path.sep}**`);
     });
 
     test("relative file starting with dot", () => {
-        expect(ensureRelativePaths("./test/1.txt")).toEqual("test/1.txt");
+        expect(ensureRelativePaths("./test/1.txt")).toEqual(`test${path.sep}1.txt`);
     });
 
     test("relative file starting without dot", () => {
-        expect(ensureRelativePaths("test/1.txt")).toEqual("test/1.txt");
+        expect(ensureRelativePaths("test/1.txt")).toEqual(`test${path.sep}1.txt`);
     });
 
     test("negated file starting with dot", () => {
-        expect(ensureRelativePaths("!./test/1.txt")).toEqual("!test/1.txt");
+        expect(ensureRelativePaths("!./test/1.txt")).toEqual(`!test${path.sep}1.txt`);
     });
 
     test("negated file starting without dot", () => {
-        expect(ensureRelativePaths("!test/1.txt")).toEqual("!test/1.txt");
+        expect(ensureRelativePaths("!test/1.txt")).toEqual(`!test${path.sep}1.txt`);
     });
 });

--- a/tests/genezioignore.test.ts
+++ b/tests/genezioignore.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "@jest/globals";
+
+import { ensureRelativePaths } from "../src/utils/file";
+
+describe("genezioignore paths", () => {
+    test("relative dir starting with dot", () => {
+        expect(ensureRelativePaths("./test")).toEqual("test");
+    });
+
+    test("relative dir starting without dot", () => {
+        expect(ensureRelativePaths("test")).toEqual("test");
+    });
+
+    test("relative dir ending with /", () => {
+        expect(ensureRelativePaths("test/")).toEqual("test/**");
+    });
+
+    test("relative file starting with dot", () => {
+        expect(ensureRelativePaths("./test/1.txt")).toEqual("test/1.txt");
+    });
+
+    test("relative file starting without dot", () => {
+        expect(ensureRelativePaths("test/1.txt")).toEqual("test/1.txt");
+    });
+
+    test("negated file starting with dot", () => {
+        expect(ensureRelativePaths("!./test/1.txt")).toEqual("!test/1.txt");
+    });
+
+    test("negated file starting without dot", () => {
+        expect(ensureRelativePaths("!test/1.txt")).toEqual("!test/1.txt");
+    });
+});


### PR DESCRIPTION

## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [x] 📝 Documentation Update

## Description

Fixes genez-io/genezio#616

[Docs PR](https://github.com/Genez-io/genezio-documentation/pull/3)

- `glob` doesn't expect to receive ignore patterns that start with `./`.
- If the pattern ends with `/`, `glob` will ignore the directory entry, but not the files inside; this is most likely what the user expects to happen (and this is also how it is explained in the docs). This is fixed by appending `**` to the pattern if it ends with `/` to match user expectations
- **Improvement**: if the pattern is negated, it gets passed through; `glob` already knows to handle negated patterns.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] I have updated the documentation;
-   [x] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
