### PR TITLE
Add a workflow to automatically push to npm on a new tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,24 +1,25 @@
+# This workflow is triggered when a tag v* is pushed to the repository
+
+# To release to npm, make sure you incremented the version in package.json
+# and then run `git tag vx.x.x` and `git push origin vx.x.x`
 name: npm-publish
 on:
     push:
-        branches:
-            - main
+        tags:
+            - "v*"
+    workflow_dispatch:
+
 jobs:
-    npm-publish:
-        name: npm-publish
+    publish:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v2
-            - name: Publish if version has been updated
-              uses: pascalgn/npm-publish-action@1.3.9
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v3
               with:
-                  tag_name: "v%s"
-                  create_tag: "true"
-                  commit_pattern: "^Release (\\S+)"
-                  workspace: "."
-                  publish_command: "npm"
-                  publish_args: "--non-interactive"
+                  node-version: "18.x"
+                  registry-url: "https://registry.npmjs.org"
+            - run: npm ci
+            - run: npm run build
+            - run: npm publish
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR automatically pushes to  the npm registry.

There are 2 ways of triggering this workflow:
- when a version tag is pushed to the repo
- manually

The developer still needs to manually increment the package version in an explicit PR/commit push to `main`.

This will ease the process of releasing the cli tool and make it less error prone.

## Checklist
-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
