### PR TITLE
Dont show stdout on npm publish when pakcage is private

### DIFF
--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -75,10 +75,8 @@ export async function compileSdk(
     workers.push(writePackagePromise);
     await Promise.all(workers);
     if (environment === GenezioCommand.deploy) {
-        if (publicSdk?.public) {
-            await packageManager.publish(modulePath, publicSdk?.public, true);
-        } else {
-            await packageManager.publish(modulePath, false);
-        }
+        publicSdk?.public
+            ? await packageManager.publish(modulePath, publicSdk?.public, true)
+            : await packageManager.publish(modulePath, false);
     }
 }

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -75,6 +75,10 @@ export async function compileSdk(
     workers.push(writePackagePromise);
     await Promise.all(workers);
     if (environment === GenezioCommand.deploy) {
-        await packageManager.publish(modulePath, publicSdk?.public ?? false);
+        if (publicSdk?.public) {
+            await packageManager.publish(modulePath, publicSdk?.public, true);
+        } else {
+            await packageManager.publish(modulePath, false);
+        }
     }
 }

--- a/src/packageManagers/npm.ts
+++ b/src/packageManagers/npm.ts
@@ -22,7 +22,7 @@ export default class NpmPackageManager implements PackageManager {
         await asyncExec(`npm link ${cwd ? `--prefix ${cwd}` : ""} ${packages.join(" ")}`);
     }
 
-    async publish(cwd: string, publicPackage: boolean = true) {
+    async publish(cwd: string, publicPackage: boolean = true, customPackage: boolean = false) {
         return new Promise<void>((resolve, reject) => {
             const processElem = spawn(
                 "npm",
@@ -32,7 +32,7 @@ export default class NpmPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: publicPackage ? "inherit" : "ignore",
+                    stdio: publicPackage || customPackage ? "inherit" : "ignore",
                     shell: process.platform == "win32",
                 },
             );

--- a/src/packageManagers/npm.ts
+++ b/src/packageManagers/npm.ts
@@ -32,7 +32,8 @@ export default class NpmPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: "inherit",
+                    stdio: publicPackage ? "inherit" : "ignore",
+                    shell: process.platform == "win32",
                 },
             );
 

--- a/src/packageManagers/npm.ts
+++ b/src/packageManagers/npm.ts
@@ -32,7 +32,7 @@ export default class NpmPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: publicPackage || customPackage ? "inherit" : "ignore",
+                    stdio: customPackage ? "inherit" : "ignore",
                     shell: process.platform == "win32",
                 },
             );

--- a/src/packageManagers/packageManager.ts
+++ b/src/packageManagers/packageManager.ts
@@ -11,7 +11,7 @@ export interface PackageManager {
     install(packages: string[], cwd?: string): Promise<void>;
     installSync(packages: string[], cwd?: string): void;
     link(packages: string[], cwd?: string): Promise<void>;
-    publish(cwd: string, publicPackage?: boolean): Promise<void>;
+    publish(cwd: string, publicPackage?: boolean, customPackage?: boolean): Promise<void>;
     addScopedRegistry(scope: string, url: string, authToken?: string): Promise<void>;
     removeScopedRegistry(scope: string): Promise<void>;
     getVersion(): Promise<string>;

--- a/src/packageManagers/pnpm.ts
+++ b/src/packageManagers/pnpm.ts
@@ -48,7 +48,7 @@ export default class PnpmPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: publicPackage || customPackage ? "inherit" : "ignore",
+                    stdio: customPackage ? "inherit" : "ignore",
                     shell: process.platform == "win32",
                 },
             );

--- a/src/packageManagers/pnpm.ts
+++ b/src/packageManagers/pnpm.ts
@@ -37,7 +37,7 @@ export default class PnpmPackageManager implements PackageManager {
         await asyncExec(`pnpm link ${cwd ? `--dir ${cwd}` : ""} ${packages.join(" ")}`);
     }
 
-    async publish(cwd: string, publicPackage: boolean = true) {
+    async publish(cwd: string, publicPackage: boolean = true, customPackage: boolean = false) {
         return new Promise<void>((resolve, reject) => {
             const processElem = spawn(
                 "pnpm",
@@ -48,7 +48,7 @@ export default class PnpmPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: publicPackage ? "inherit" : "ignore",
+                    stdio: publicPackage || customPackage ? "inherit" : "ignore",
                     shell: process.platform == "win32",
                 },
             );

--- a/src/packageManagers/pnpm.ts
+++ b/src/packageManagers/pnpm.ts
@@ -48,7 +48,8 @@ export default class PnpmPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: "inherit",
+                    stdio: publicPackage ? "inherit" : "ignore",
+                    shell: process.platform == "win32",
                 },
             );
 

--- a/src/packageManagers/yarn.ts
+++ b/src/packageManagers/yarn.ts
@@ -49,7 +49,7 @@ export default class YarnPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: publicPackage || customPackage ? "inherit" : "ignore",
+                    stdio: customPackage ? "inherit" : "ignore",
                     shell: process.platform == "win32",
                 },
             );

--- a/src/packageManagers/yarn.ts
+++ b/src/packageManagers/yarn.ts
@@ -38,7 +38,7 @@ export default class YarnPackageManager implements PackageManager {
         await asyncExec(`yarn link ${cwd ? `--cwd ${cwd}` : ""} ${packages.join(" ")}`);
     }
 
-    async publish(cwd: string, publicPackage: boolean = true) {
+    async publish(cwd: string, publicPackage: boolean = true, customPackage: boolean = false) {
         return new Promise<void>((resolve, reject) => {
             const processElem = spawn(
                 "yarn",
@@ -49,7 +49,7 @@ export default class YarnPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: publicPackage ? "inherit" : "ignore",
+                    stdio: publicPackage || customPackage ? "inherit" : "ignore",
                     shell: process.platform == "win32",
                 },
             );

--- a/src/packageManagers/yarn.ts
+++ b/src/packageManagers/yarn.ts
@@ -49,7 +49,8 @@ export default class YarnPackageManager implements PackageManager {
                     ...(publicPackage ? ["--access", "public"] : ["--access", "restricted"]),
                 ],
                 {
-                    stdio: "inherit",
+                    stdio: publicPackage ? "inherit" : "ignore",
+                    shell: process.platform == "win32",
                 },
             );
 


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

Publishing a sdk to npm will show npm logs only if the package is public or if it is a custom package
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
