### PR TITLE
Treat `sdk.language` field as string to enable custom language plugins

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -413,12 +413,12 @@ export async function deployClasses(
     );
 
     if (configuration.sdk) {
-        await writeSdkToDisk(sdkResponse, configuration.sdk.language, configuration.sdk.path);
+        await writeSdkToDisk(sdkResponse, configuration.sdk.path);
     } else if (configuration.language === Language.ts || configuration.language === Language.js) {
         const localPath = await createLocalTempFolder(
             `${projectConfiguration.name}-${projectConfiguration.region}`,
         );
-        await writeSdkToDisk(sdkResponse, configuration.language, path.join(localPath, "sdk"));
+        await writeSdkToDisk(sdkResponse, path.join(localPath, "sdk"));
         const packageJson: string = getNodeModulePackageJson(
             configuration.name,
             configuration.region,

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -76,7 +76,7 @@ export async function generateLocalSdkCommand(options: GenezioSdkOptions) {
         })),
     );
 
-    await writeSdkToDisk(sdkResponse, configuration.sdk!.language, configuration.sdk!.path);
+    await writeSdkToDisk(sdkResponse, configuration.sdk!.path);
 }
 
 export async function generateRemoteSdkCommand(projectName: string, options: GenezioSdkOptions) {
@@ -242,5 +242,5 @@ async function generateRemoteSdkHandler(
     await replaceUrlsInSdk(sdkGeneratorResponse, classUrlMap);
 
     // write the sdk to disk in the specified path
-    await writeSdkToDisk(sdkGeneratorResponse, language as Language, sdkPath);
+    await writeSdkToDisk(sdkGeneratorResponse, sdkPath);
 }

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -312,7 +312,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
                     cloudUrl: `http://127.0.0.1:${options.port}/${c.className}`,
                 })),
             );
-            await writeSdkToDisk(sdk, sdkConfiguration.language, sdkConfiguration.path);
+            await writeSdkToDisk(sdk, sdkConfiguration.path);
             if (
                 !yamlProjectConfiguration.sdk &&
                 (sdkConfiguration.language === Language.ts ||

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -3,7 +3,7 @@ import { AstSummary } from "./astSummary.js";
 import { CloudProviderIdentifier } from "./cloudProviderIdentifier.js";
 import { NodeOptions } from "./nodeRuntime.js";
 import { SdkGeneratorResponse } from "./sdkGeneratorResponse.js";
-import { Language, TriggerType, YamlProjectConfiguration } from "./yamlProjectConfiguration.js";
+import { TriggerType, YamlProjectConfiguration } from "./yamlProjectConfiguration.js";
 
 export class ParameterType {
     name: string;
@@ -68,10 +68,10 @@ export class ClassConfiguration {
 }
 
 export class SdkConfiguration {
-    language: Language;
+    language: string;
     path: string;
 
-    constructor(language: Language, path: string) {
+    constructor(language: string, path: string) {
         this.language = language;
         this.path = path;
     }

--- a/src/models/yamlProjectConfiguration.ts
+++ b/src/models/yamlProjectConfiguration.ts
@@ -6,6 +6,7 @@ import { isValidCron } from "cron-validator";
 import { CloudProviderIdentifier } from "./cloudProviderIdentifier.js";
 import { DEFAULT_NODE_RUNTIME, NodeOptions } from "./nodeRuntime.js";
 import zod from "zod";
+import log from "loglevel";
 
 export enum TriggerType {
     jsonrpc = "jsonrpc",
@@ -86,10 +87,10 @@ export enum PackageManagerType {
 }
 
 export class YamlSdkConfiguration {
-    language: Language;
+    language: string;
     path: string;
 
-    constructor(language: Language, path: string) {
+    constructor(language: string, path: string) {
         this.language = language;
         this.path = path;
     }
@@ -360,7 +361,15 @@ export class YamlProjectConfiguration {
                 .optional(),
             sdk: zod
                 .object({
-                    language: zod.nativeEnum(Language),
+                    language: zod.string().refine((value) => {
+                        if (!Language[value as keyof typeof Language]) {
+                            log.warn(
+                                `The \`sdk.language\` ${value} value, specified in your configuration, is not supported by default. It will be treated as a custom language plugin.`,
+                            );
+                        }
+
+                        return true;
+                    }),
                     path: zod.string(),
                 })
                 .optional(),

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -1,5 +1,4 @@
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
-import { Language } from "../models/yamlProjectConfiguration.js";
 import { writeToFile } from "./file.js";
 import { debugLogger } from "./logging.js";
 import { File, SdkFileClass } from "../models/genezioModels.js";
@@ -30,11 +29,7 @@ export async function replaceUrlsInSdk(
 /**
  * Write the SDK files to disk.
  */
-export async function writeSdkToDisk(
-    sdk: SdkGeneratorResponse,
-    language: Language,
-    outputPath: string,
-) {
+export async function writeSdkToDisk(sdk: SdkGeneratorResponse, outputPath: string) {
     if (sdk.files.length == 0) {
         debugLogger.debug("No SDK classes found...");
         return;


### PR DESCRIPTION

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description
The SDK generation system supports AST/SDK gen plugins, so it does not make sense to restrict the `sdk.language` field to the Language type, because if a plugin is present, this field can also take `Language`s that are not supported by us yet.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
