### PR TITLE
add index file to old ts and js sdk generation

### DIFF
--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -17,7 +17,6 @@ import path from "path";
 import {
     SdkGeneratorClassesInfoInput,
     SdkGeneratorInput,
-    SdkVersion,
 } from "../models/genezioModels.js";
 import { mapDbAstToSdkGeneratorAst } from "../generateSdk/utils/mapDbAstToFullAst.js";
 import { generateSdk } from "../generateSdk/sdkGeneratorHandler.js";
@@ -268,11 +267,7 @@ async function generateRemoteSdkHandler(
         },
     };
 
-    const sdkGeneratorOutput = await generateSdk(
-        sdkGeneratorInput,
-        undefined,
-        sdkType === SdkType.PACKAGE ? SdkVersion.NEW_SDK : SdkVersion.OLD_SDK,
-    );
+    const sdkGeneratorOutput = await generateSdk(sdkGeneratorInput, undefined);
 
     const sdkGeneratorResponse: SdkGeneratorResponse = {
         files: sdkGeneratorOutput.files,

--- a/src/generateSdk/generateSdkApi.ts
+++ b/src/generateSdk/generateSdkApi.ts
@@ -2,7 +2,7 @@ import { generateAst } from "./astGeneratorHandler.js";
 import { generateSdk } from "./sdkGeneratorHandler.js";
 import { YamlProjectConfiguration } from "../models/yamlProjectConfiguration.js";
 import { getGenerateAstInputs } from "./utils/getFiles.js";
-import { SdkGeneratorInput, SdkGeneratorOutput, SdkVersion } from "../models/genezioModels.js";
+import { SdkGeneratorInput, SdkGeneratorOutput } from "../models/genezioModels.js";
 import path from "path";
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
 import { AstGeneratorInput } from "../models/genezioModels.js";
@@ -56,7 +56,6 @@ export async function sdkGeneratorApiHandler(
     const sdkOutput: SdkGeneratorOutput = await generateSdk(
         sdkGeneratorInput,
         projectConfiguration.plugins?.sdkGenerator,
-        projectConfiguration.sdk ? SdkVersion.OLD_SDK : SdkVersion.NEW_SDK,
     );
 
     return {

--- a/src/generateSdk/sdkGenerator/DartSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/DartSdkGenerator.ts
@@ -11,7 +11,6 @@ import {
     Node,
     MapType,
     SdkFileClass,
-    SdkVersion,
 } from "../../models/genezioModels.js";
 import { TriggerType, YamlClassConfiguration } from "../../models/yamlProjectConfiguration.js";
 import { dartSdk } from "../templates/dartSdk.js";

--- a/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
@@ -6,7 +6,6 @@ import {
     SdkGeneratorInput,
     SdkGeneratorOutput,
     IndexModel,
-    SdkVersion,
 } from "../../models/genezioModels.js";
 import { nodeSdkJs } from "../templates/nodeSdkJs.js";
 import Mustache from "mustache";
@@ -43,10 +42,7 @@ export class {{{className}}} {
 `;
 
 class SdkGenerator implements SdkGeneratorInterface {
-    async generateSdk(
-        sdkGeneratorInput: SdkGeneratorInput,
-        sdkVersion: SdkVersion,
-    ): Promise<SdkGeneratorOutput> {
+    async generateSdk(sdkGeneratorInput: SdkGeneratorInput): Promise<SdkGeneratorOutput> {
         const generateSdkOutput: SdkGeneratorOutput = {
             files: [],
         };
@@ -144,16 +140,14 @@ class SdkGenerator implements SdkGeneratorInterface {
         });
 
         // generate index.js
-        if (sdkVersion === SdkVersion.NEW_SDK) {
-            if (indexModel.exports.length > 0) {
-                indexModel.exports[indexModel.exports.length - 1].last = true;
-            }
-            generateSdkOutput.files.push({
-                className: "index",
-                path: "index.js",
-                data: Mustache.render(indexTemplate, indexModel),
-            });
+        if (indexModel.exports.length > 0) {
+            indexModel.exports[indexModel.exports.length - 1].last = true;
         }
+        generateSdkOutput.files.push({
+            className: "index",
+            path: "index.js",
+            data: Mustache.render(indexTemplate, indexModel),
+        });
 
         return generateSdkOutput;
     }

--- a/src/generateSdk/sdkGenerator/PythonSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/PythonSdkGenerator.ts
@@ -20,7 +20,6 @@ import {
     ParameterDefinition,
     MethodDefinition,
     ModelView,
-    SdkVersion,
 } from "../../models/genezioModels.js";
 import { TriggerType } from "../../models/yamlProjectConfiguration.js";
 import { pythonSdk } from "../templates/pythonSdk.js";
@@ -180,11 +179,11 @@ class SdkGenerator implements SdkGeneratorInterface {
                             (e.optional
                                 ? " = None"
                                 : e.defaultValue
-                                ? " = " +
-                                  (e.defaultValue.type === AstNodeType.StringLiteral
-                                      ? "'" + e.defaultValue.value + "'"
-                                      : e.defaultValue.value)
-                                : ""),
+                                  ? " = " +
+                                    (e.defaultValue.type === AstNodeType.StringLiteral
+                                        ? "'" + e.defaultValue.value + "'"
+                                        : e.defaultValue.value)
+                                  : ""),
                         last: false,
                     };
                 });

--- a/src/generateSdk/sdkGenerator/SwiftSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/SwiftSdkGenerator.ts
@@ -8,7 +8,6 @@ import {
     Node,
     ArrayType,
     PromiseType,
-    SdkVersion,
 } from "../../models/genezioModels.js";
 import { TriggerType } from "../../models/yamlProjectConfiguration.js";
 import { swiftSdk } from "../templates/swiftSdk.js";

--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -20,7 +20,6 @@ import {
     ModelView,
     IndexModel,
     MapType,
-    SdkVersion,
 } from "../../models/genezioModels.js";
 import { TriggerType } from "../../models/yamlProjectConfiguration.js";
 import { nodeSdkTs } from "../templates/nodeSdkTs.js";
@@ -158,10 +157,7 @@ export { Remote };
 `;
 
 class SdkGenerator implements SdkGeneratorInterface {
-    async generateSdk(
-        sdkGeneratorInput: SdkGeneratorInput,
-        sdkVersion: SdkVersion,
-    ): Promise<SdkGeneratorOutput> {
+    async generateSdk(sdkGeneratorInput: SdkGeneratorInput): Promise<SdkGeneratorOutput> {
         const generateSdkOutput: SdkGeneratorOutput = {
             files: [],
         };
@@ -355,22 +351,19 @@ class SdkGenerator implements SdkGeneratorInterface {
             data: nodeSdkTs.replace("%%%url%%%", "undefined"),
         });
 
-        // generate index.ts
-        if (sdkVersion === SdkVersion.NEW_SDK) {
-            if (indexModel.exports.length > 0) {
-                indexModel.exports[indexModel.exports.length - 1].last = true;
-            }
-            for (const importStatement of indexModel.imports) {
-                if (importStatement.models.length > 0) {
-                    importStatement.models[importStatement.models.length - 1].last = true;
-                }
-            }
-            generateSdkOutput.files.push({
-                className: "index.ts",
-                path: "index.ts",
-                data: Mustache.render(indexTemplate, indexModel),
-            });
+        if (indexModel.exports.length > 0) {
+            indexModel.exports[indexModel.exports.length - 1].last = true;
         }
+        for (const importStatement of indexModel.imports) {
+            if (importStatement.models.length > 0) {
+                importStatement.models[importStatement.models.length - 1].last = true;
+            }
+        }
+        generateSdkOutput.files.push({
+            className: "index.ts",
+            path: "index.ts",
+            data: Mustache.render(indexTemplate, indexModel),
+        });
 
         return generateSdkOutput;
     }

--- a/src/generateSdk/sdkGeneratorHandler.ts
+++ b/src/generateSdk/sdkGeneratorHandler.ts
@@ -8,7 +8,6 @@ import {
     SdkGeneratorInput,
     SdkGeneratorInterface,
     SdkGeneratorOutput,
-    SdkVersion,
 } from "../models/genezioModels.js";
 import log from "loglevel";
 import { exit } from "process";
@@ -30,7 +29,6 @@ interface SdkGeneratorPlugin {
 export async function generateSdk(
     sdkGeneratorInput: SdkGeneratorInput,
     plugins: string[] | undefined,
-    sdkVersion: SdkVersion,
 ): Promise<SdkGeneratorOutput> {
     let pluginsImported: SdkGeneratorPlugin[] = [];
 
@@ -90,5 +88,5 @@ export async function generateSdk(
 
     const sdkGeneratorClass = new sdkGeneratorElem.SdkGenerator();
 
-    return await sdkGeneratorClass.generateSdk(sdkGeneratorInput, sdkVersion);
+    return await sdkGeneratorClass.generateSdk(sdkGeneratorInput);
 }

--- a/src/models/genezioModels.ts
+++ b/src/models/genezioModels.ts
@@ -356,8 +356,5 @@ export enum SdkVersion {
  * A class implementing this interface will create the sdk for a given language.
  */
 export interface SdkGeneratorInterface {
-    generateSdk: (
-        sdkGeneratorInput: SdkGeneratorInput,
-        sdkVersion: SdkVersion,
-    ) => Promise<SdkGeneratorOutput>;
+    generateSdk: (sdkGeneratorInput: SdkGeneratorInput) => Promise<SdkGeneratorOutput>;
 }

--- a/src/models/genezioModels.ts
+++ b/src/models/genezioModels.ts
@@ -347,11 +347,6 @@ export type SdkGeneratorOutput = {
     files: SdkFileClass[];
 };
 
-export enum SdkVersion {
-    OLD_SDK,
-    NEW_SDK,
-}
-
 /**
  * A class implementing this interface will create the sdk for a given language.
  */


### PR DESCRIPTION
# Pull Request Template

## Type of change

-   [x] 🧑‍💻 Improvement


## Description

We added the index file (a file that exports all the types and classes of an sdk) in order to have an entry point for our genezio sdk node module, so initially we only added it for the new way of generating the sdk.
Now it is clear that is much cleaner to import everything from one place, so from now on we add this file in the old way of generating the sdk as well. This should not break any existing genezio projects as the old way of importing types and classes still works.

## Checklist

-   [x] New and existing unit tests pass locally with my changes;
