### PR TITLE
Handle Axios error when fetching the user based on access token

### DIFF
--- a/src/requests/axios.ts
+++ b/src/requests/axios.ts
@@ -1,5 +1,6 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { debugLogger } from "../utils/logging.js";
+import { StatusError } from "./models.js";
 
 enum GenezioErrorCode {
     UnknownError = 0,
@@ -18,20 +19,28 @@ axios.interceptors.response.use(
         // Do something with response data
         return response;
     },
-    function (error) {
-        if (error.response?.status === 402) {
+    function (error: AxiosError<StatusError>) {
+        const response = error.response;
+        if (!response) {
+            throw new Error("There was an error connecting to the server.");
+        }
+
+        if (response.status === 402) {
             throw new Error(
                 "You've hit the maximum number of projects. To continue, please upgrade your subscription.",
             );
-        } else {
-            if (error.response?.data?.error?.code === GenezioErrorCode.UpdateRequired) {
-                throw new Error("Please update your genezio CLI. Run 'npm update -g genezio'.");
-            } else if (error.response?.data?.error) {
-                debugLogger.debug(JSON.stringify(error.response.data.error));
-            }
         }
-        // Do something with response error
-        return Promise.reject(error);
+        if (response.data.error.code === GenezioErrorCode.UpdateRequired) {
+            throw new Error("Please update your genezio CLI. Run 'npm update -g genezio'.");
+        }
+
+        debugLogger.debug("Axios error received:", JSON.stringify(response.data.error));
+
+        if (response.data.status === "error") {
+            throw new Error(response.data.error.message);
+        }
+
+        throw new Error("An unknown error occurred. Please file a bug report.");
     },
 );
 

--- a/src/requests/getUser.ts
+++ b/src/requests/getUser.ts
@@ -1,10 +1,10 @@
 import axios, { AxiosResponse } from "axios";
-import { Status, UserPayload } from "./models.js";
+import { StatusOk, UserPayload } from "./models.js";
 import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 
 export default async function getUser(token: string): Promise<UserPayload> {
-    const response: AxiosResponse<Status<{ user: UserPayload }>> = await axios({
+    const response: AxiosResponse<StatusOk<{ user: UserPayload }>> = await axios({
         method: "GET",
         url: `${BACKEND_ENDPOINT}/users/user`,
         headers: {
@@ -12,10 +12,6 @@ export default async function getUser(token: string): Promise<UserPayload> {
             "Accept-Version": `genezio-cli/${version}`,
         },
     });
-
-    if (response.data.status === "error") {
-        throw new Error(response.data.error.message);
-    }
 
     return response.data.user;
 }

--- a/src/requests/models.ts
+++ b/src/requests/models.ts
@@ -1,16 +1,15 @@
 import { AstSummaryClassResponse } from "../models/astSummary.js";
 
-export type Status<T = object> =
-    | {
-          status: "error";
-          error: {
-              code: number;
-              message: string;
-          };
-      }
-    | ({
-          status: "ok";
-      } & T);
+export type Status<T = object> = StatusError | StatusOk<T>;
+
+export type StatusOk<T = object> = { status: "ok" } & T;
+export type StatusError = {
+    status: "error";
+    error: {
+        code: number;
+        message: string;
+    };
+};
 
 export interface ProjectListElement {
     id: string;


### PR DESCRIPTION
<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

Apparenlty, Axios throws when the status code of the request is != 200. I have moved the error check that throws the error message in the Axios intercepter.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
