### PR TITLE
Bugfix sourcemaps not generating properly due to babel transform

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,8 +16,6 @@ module.exports = {
     ],
     env: {
         node: true,
-        commonjs: true,
-        browser: true,
         es6: true,
     },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,4 +14,10 @@ module.exports = {
         "solveEnvVariables.js",
         ".eslintrc.cjs",
     ],
+    env: {
+        node: true,
+        commonjs: true,
+        browser: true,
+        es6: true,
+    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
                 "@babel/preset-env": "^7.23.7",
                 "@babel/preset-typescript": "^7.23.3",
                 "@babel/traverse": "^7.23.5",
-                "@rollup/rollup-android-arm-eabi": "4.9.4",
                 "@sentry/node": "^7.74.1",
                 "@sentry/profiling-node": "~1.2.6",
                 "archiver": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "build": "npx tsc && node solveEnvVariables.js build/src/constants.js",
         "install-locally-dev": "npm run install-locally -- dev",
         "build-dev": "npx tsc && node solveEnvVariables.js build/src/constants.js -- dev",
-        "checkChangesInVariables": "./scripts/checkConstants",
-        "checkUnwantedLogs": "./scripts/checkUnwantedLogs",
+        "checkChangesInVariables": "node scripts/checkConstants.js",
+        "checkUnwantedLogs": "node scripts/checkUnwantedLogs.js",
         "release": "npm run build && npm publish",
         "test": "vitest run",
         "prepare": "husky install"

--- a/scripts/checkConstants.js
+++ b/scripts/checkConstants.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { execSync } from "child_process";
+import { log } from "console";
+
+try {
+    const output = execSync("git status --porcelain").toString();
+
+    // Check if src/constants.ts is modified
+    if (!output.includes("src/constants.ts")) {
+        log("src/constants.ts is not modified.");
+        process.exit(0);
+    } else {
+        log("ERROR: src/constants.ts is modified.");
+        process.exit(1);
+    }
+} catch (error) {
+    log("An error occurred while running the script:", error);
+    process.exit(1);
+}

--- a/scripts/checkUnwantedLogs.js
+++ b/scripts/checkUnwantedLogs.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { execSync } from "child_process";
+import { log } from "console";
+
+function checkForStatements(regex, message, exitCode) {
+    const diff = execSync("git diff --cached").toString();
+    if (new RegExp(regex).test(diff)) {
+        log(message);
+        process.exit(exitCode);
+    }
+}
+
+try {
+    // Check for console statements
+    checkForStatements(
+        "\\bconsole\\.",
+        "ERROR: Found console statements in the git diff. Please remove them before committing.",
+        1,
+    );
+
+    // Check for log statements
+    checkForStatements(
+        "\\blog\\.",
+        "WARNING: Found log statements in the git diff. Please make sure they are wanted before committing. If they are, run commit with --no-verify / -n to skip this check.",
+        1,
+    );
+
+    // Check for debugLogger statements
+    checkForStatements(
+        "\\bdebugLogger\\.",
+        "WARNING: Found debugLogger statements in the git diff. Please make sure they are wanted before committing. If they are, run commit with --no-verify / -n to skip this check.",
+        1,
+    );
+} catch (error) {
+    process.exit(1);
+}
+
+// If no errors are found, allow the commit to proceed
+process.exit(0);

--- a/src/utils/transformDecorators.ts
+++ b/src/utils/transformDecorators.ts
@@ -17,6 +17,7 @@ export default async function (filePath: string): Promise<string> {
             stripDecorator,
         ],
         filename: filePath,
+        sourceMaps: "inline",
     });
 
     if (!babelOutput?.code) {


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix
-   [x] 🧑‍💻 Improvement

## Description

There was a bug that in the logs from the dashboard, the error stack trace didn't show the original error location. This was due to the fact that the sourcemap, which should have been in the bundled file, was overwritten by the babel transformation. This PR fixes this by setting the sourcemap style to be inline in the babel transformation. Also, due to the fact that the eslint was configured to have scripts in bash, the eslint often stopped Windows users from commiting anything to the Repo. I changed that by making the script in native JS so that they would be OS agnostic.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
