### PR TITLE
delete the destination folder before any copy or write

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -28,6 +28,7 @@ import cron from "node-cron";
 import {
     createLocalTempFolder,
     createTemporaryFolder,
+    deleteFolder,
     fileExists,
     readUTF8File,
 } from "../utils/file.js";
@@ -448,9 +449,10 @@ async function writeSdkToNodeModules(
             if (fs.lstatSync(toFinal).isSymbolicLink()) {
                 fs.unlinkSync(toFinal);
             }
-        } else {
-            fs.mkdirSync(toFinal, { recursive: true });
+            await deleteFolder(toFinal);
         }
+        fs.mkdirSync(toFinal, { recursive: true });
+
         await fsExtra.copy(from, toFinal, { overwrite: true });
     };
 

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -3,7 +3,8 @@ import { Language } from "../../models/yamlProjectConfiguration.js";
 import path from "path";
 import ts from "typescript";
 import { Worker } from "worker_threads";
-import { writeToFile } from "../../utils/file.js";
+import { deleteFolder, writeToFile } from "../../utils/file.js";
+import fs from "fs";
 import packageManager from "../../packageManagers/packageManager.js";
 
 const compilerWorkerScript = `const { parentPort, workerData } = require("worker_threads");
@@ -37,6 +38,12 @@ export async function compileSdk(
     publish: boolean,
     outDir = "../genezio-sdk",
 ) {
+    const genezioSdkPath = path.resolve(sdkPath, outDir);
+    // delete the old sdk
+    if (fs.existsSync(genezioSdkPath)) {
+        await deleteFolder(genezioSdkPath);
+    }
+    fs.mkdirSync(genezioSdkPath, { recursive: true });
     // compile the sdk to cjs and esm using worker threads
     const workers = [];
     const require = createRequire(import.meta.url);

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -1,5 +1,5 @@
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
-import { writeToFile } from "./file.js";
+import { deleteFolder, writeToFile } from "./file.js";
 import { debugLogger } from "./logging.js";
 import { File, SdkFileClass } from "../models/genezioModels.js";
 
@@ -34,6 +34,8 @@ export async function writeSdkToDisk(sdk: SdkGeneratorResponse, outputPath: stri
         debugLogger.debug("No SDK classes found...");
         return;
     }
+
+    await deleteFolder(outputPath);
 
     debugLogger.debug("Writing the SDK to files...");
     await Promise.all(


### PR DESCRIPTION
delete the destination folder before 1. write sdk to disk, 2. compile sdk or 3. write sdk to node modules

# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->


-   [x] 🐛 Bug Fix
-   [x] 🧑‍💻 Improvement


## Description
Because the sdk was written to a folder without deleting the contents of the folder first, we had issues with renaming classes because the old classes would remain in the sdk and occupy  space. Solution: delete the destination folder before 1. write sdk to disk, 2. compile sdk or 3. write sdk to node modules

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
