### PR TITLE
Modify import paths from types in @genezio/types

### DIFF
--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -134,6 +134,8 @@ export class AstGenerator implements AstGeneratorInterface {
                     if (typeAtLocationPath.endsWith(".d")) {
                         typeAtLocationPath = typeAtLocationPath.slice(0, -2);
                     }
+                    // We do this because typescript ignores the node_modules folder
+                    // And the types that are present in the node_modules will dissapear
                     if (typeAtLocationPath.includes("node_modules")) {
                         typeAtLocationPath = typeAtLocationPath.replace("node_modules", "src");
                     }

--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -131,6 +131,12 @@ export class AstGenerator implements AstGeneratorInterface {
                     typeAtLocation.aliasSymbol?.declarations?.[0].getSourceFile().fileName;
                 if (typeAtLocationPath?.endsWith(".ts")) {
                     typeAtLocationPath = typeAtLocationPath.slice(0, -3);
+                    if (typeAtLocationPath.endsWith(".d")) {
+                        typeAtLocationPath = typeAtLocationPath.slice(0, -2);
+                    }
+                    if (typeAtLocationPath.includes("node_modules")) {
+                        typeAtLocationPath = typeAtLocationPath.replace("node_modules", "src");
+                    }
                 }
                 if (!typeAtLocationPath) {
                     throw new Error(


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

Imports from our own library `genezio_types` in deployed classes were generating SDK errors because the file is ignored by `tsc`. Changing the path by replacing `node_modules` with something else seems to have solved the problem. Need extended testing.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
