### PR TITLE
Check if the @genezio/types version used is older and throw an error.

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -82,7 +82,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
     const packageJsonPath = path.join(backendCwd, "package.json");
     if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", "1.0.0") === false) {
         log.error(
-            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To resolve this, please update the @genezio/types package on your server using the following command: npm install @genezio/types@^1.0.0`
+            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@^1.0.0`
         );
         exit(1);
     }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -80,7 +80,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
     // Otherwise, the user will get an error at runtime. This check can be removed in the future once no one is using version
     // 0.1.* of @genezio/types.
     const packageJsonPath = path.join(backendCwd, "package.json");
-    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", "1.0.0") == false) {
+    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", "1.0.0") === false) {
         log.error(
             `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To resolve this, please update the @genezio/types package on your server using the following command: npm install @genezio/types@^1.0.0`
         );

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -166,7 +166,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
     const packageJsonPath = yamlProjectConfiguration.workspace ? 
         path.join(yamlProjectConfiguration.workspace.backend, "package.json") :
         path.join(process.cwd(), "package.json");
-    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", "1.0.0") == false) {
+    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", "1.0.0") === false) {
         log.error(
             `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To resolve this, please update the @genezio/types package on your server using the following command: npm install @genezio/types@^1.0.0`
         );

--- a/src/utils/dependencyChecker.ts
+++ b/src/utils/dependencyChecker.ts
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import semver from 'semver';
+import { debugLogger } from './logging.js';
+
+
+/**
+ * Reads the package.json file from a given path and checks if the version
+ * of a specified dependency is above a given version.
+ * 
+ * @param path - The path to the package.json file.
+ * @param dependency - The name of the dependency to check.
+ * @param version - The version to compare against.
+ * @returns True if the dependency version is above or equal to the given version, false otherwise. Undefined if the dependency is not found.
+ */
+export function isDependencyVersionCompatible(path: string, dependency: string, version: string): boolean|undefined {
+    try {
+    const packageJson = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+    const depVersion = packageJson.dependencies[dependency] || packageJson.devDependencies[dependency];
+    if (!depVersion) {
+        debugLogger.error(`Dependency ${dependency} not found.`);
+        return undefined;
+    }
+
+    return semver.satisfies(version, depVersion)
+    } catch(error) {
+        debugLogger.error(`Error while reading package.json file: ${error}`);
+        return undefined;
+    }
+}

--- a/src/utils/dependencyChecker.ts
+++ b/src/utils/dependencyChecker.ts
@@ -1,29 +1,33 @@
-import fs from 'fs';
-import semver from 'semver';
-import { debugLogger } from './logging.js';
-
+import fs from "fs";
+import semver from "semver";
+import { debugLogger } from "./logging.js";
 
 /**
  * Reads the package.json file from a given path and checks if the version
- * of a specified dependency is above a given version.
- * 
+ * of a specified dependency is comptabile with a given version.
+ *
  * @param path - The path to the package.json file.
  * @param dependency - The name of the dependency to check.
  * @param version - The version to compare against.
  * @returns True if the dependency version is above or equal to the given version, false otherwise. Undefined if the dependency is not found.
  */
-export function isDependencyVersionCompatible(path: string, dependency: string, version: string): boolean|undefined {
+export function isDependencyVersionCompatible(
+    path: string,
+    dependency: string,
+    version: string,
+): boolean | undefined {
     try {
-    const packageJson = JSON.parse(fs.readFileSync(path, 'utf8'));
+        const packageJson = JSON.parse(fs.readFileSync(path, "utf8"));
 
-    const depVersion = packageJson.dependencies[dependency] || packageJson.devDependencies[dependency];
-    if (!depVersion) {
-        debugLogger.error(`Dependency ${dependency} not found.`);
-        return undefined;
-    }
+        const depVersion =
+            packageJson.dependencies[dependency] || packageJson.devDependencies[dependency];
+        if (!depVersion) {
+            debugLogger.error(`Dependency ${dependency} not found.`);
+            return undefined;
+        }
 
-    return semver.satisfies(version, depVersion)
-    } catch(error) {
+        return semver.satisfies(version, depVersion);
+    } catch (error) {
         debugLogger.error(`Error while reading package.json file: ${error}`);
         return undefined;
     }


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

We need to check if the user is using an older version of @genezio/types because we migrated the decorators implemented in the @genezio/types package to the stage 3 implementation. Otherwise, the user will get an error at runtime. This check can be removed in the future once no one is using version 0.1.* of @genezio/types.


## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
