### PR TITLE
Fix wrong comparison of dep versions.

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -2,13 +2,7 @@ import { AxiosError } from "axios";
 import log from "loglevel";
 import path from "path";
 import { exit } from "process";
-import { BundlerInterface } from "../bundlers/bundler.interface.js";
-import { BundlerComposer } from "../bundlers/bundlerComposer.js";
-import { DartBundler } from "../bundlers/dart/dartBundler.js";
-import { NodeJsBinaryDependenciesBundler } from "../bundlers/node/nodeJsBinaryDependenciesBundler.js";
-import { NodeJsBundler } from "../bundlers/node/nodeJsBundler.js";
-import { REACT_APP_BASE_URL } from "../constants.js";
-import { KotlinBundler } from "../bundlers/kotlin/kotlinBundler.js";
+import { REACT_APP_BASE_URL, RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE, REQUIRED_GENEZIO_TYPES_VERSION_RANGE } from "../constants.js";
 import { GENEZIO_NOT_AUTH_ERROR_MSG, GENEZIO_NO_CLASSES_FOUND } from "../errors.js";
 import { sdkGeneratorApiHandler } from "../generateSdk/generateSdkApi.js";
 import { ProjectConfiguration } from "../models/projectConfiguration.js";
@@ -39,10 +33,8 @@ import { GenezioCloudAdapter } from "../cloudAdapter/genezio/genezioAdapter.js";
 import { SelfHostedAwsAdapter } from "../cloudAdapter/aws/selfHostedAwsAdapter.js";
 import { CloudAdapter, GenezioCloudInput } from "../cloudAdapter/cloudAdapter.js";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
-import { TypeCheckerBundler } from "../bundlers/node/typeCheckerBundler.js";
 import { GenezioDeployOptions } from "../models/commandOptions.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js";
-import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
 import { setEnvironmentVariables } from "../requests/setEnvironmentVariables.js";
 import colors from "colors";
 import { getEnvironmentVariables } from "../requests/getEnvironmentVariables.js";
@@ -80,9 +72,9 @@ export async function deployCommand(options: GenezioDeployOptions) {
     // Otherwise, the user will get an error at runtime. This check can be removed in the future once no one is using version
     // 0.1.* of @genezio/types.
     const packageJsonPath = path.join(backendCwd, "package.json");
-    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", "1.0.0") === false) {
+    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", REQUIRED_GENEZIO_TYPES_VERSION_RANGE) === false) {
         log.error(
-            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@^1.0.0`
+            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`
         );
         exit(1);
     }

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -13,7 +13,7 @@ import url from "url";
 import * as http from "http";
 import colors from "colors";
 import { ProjectConfiguration, ClassConfiguration } from "../models/projectConfiguration.js";
-import { LOCAL_TEST_INTERFACE_URL } from "../constants.js";
+import { LOCAL_TEST_INTERFACE_URL, RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE, REQUIRED_GENEZIO_TYPES_VERSION_RANGE } from "../constants.js";
 import { GENEZIO_NO_CLASSES_FOUND, PORT_ALREADY_USED } from "../errors.js";
 import { sdkGeneratorApiHandler } from "../generateSdk/generateSdkApi.js";
 import { AstSummary } from "../models/astSummary.js";
@@ -166,9 +166,9 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
     const packageJsonPath = yamlProjectConfiguration.workspace ? 
         path.join(yamlProjectConfiguration.workspace.backend, "package.json") :
         path.join(process.cwd(), "package.json");
-    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", "1.0.0") === false) {
+    if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", REQUIRED_GENEZIO_TYPES_VERSION_RANGE) === false) {
         log.error(
-            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To resolve this, please update the @genezio/types package on your server using the following command: npm install @genezio/types@^1.0.0`
+            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To resolve this, please update the @genezio/types package on your server using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
         );
         exit(1);
     }

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -168,7 +168,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
         path.join(process.cwd(), "package.json");
     if (isDependencyVersionCompatible(packageJsonPath, "@genezio/types", REQUIRED_GENEZIO_TYPES_VERSION_RANGE) === false) {
         log.error(
-            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To resolve this, please update the @genezio/types package on your server using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
+            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
         );
         exit(1);
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,8 @@ let ENABLE_DEBUG_LOGS_BY_DEFAULT: boolean;
 let ENVIRONMENT: string;
 let SENTRY_DSN: string;
 let GENEZIO_REGISTRY: string;
+let REQUIRED_GENEZIO_TYPES_VERSION_RANGE: string;
+let RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE: string;
 
 const GENEZIO_TELEMETRY_ENDPOINT =
     "https://c4h2bia7gbokqdxxc6fe5sgj5e0imchy.lambda-url.us-east-1.on.aws/";
@@ -28,6 +30,8 @@ if (environment === "dev") {
     ENVIRONMENT = "dev";
     GENEZIO_REGISTRY =
         "yptt62gzkhog5xuxtuwxvb6ohi0dtfhg.lambda-url.us-east-1.on.aws/RegistryHTTPHandler";
+    REQUIRED_GENEZIO_TYPES_VERSION_RANGE = ">=1.0.0";
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.0.0";
 } else {
     REACT_APP_BASE_URL = "https://app.genez.io";
     FRONTEND_DOMAIN = "app.genez.io";
@@ -42,6 +46,8 @@ if (environment === "dev") {
     ENVIRONMENT = "prod";
     GENEZIO_REGISTRY =
         "rt3ersglfpyjlkzcjgql3s7xju0nuzym.lambda-url.us-east-1.on.aws/RegistryHTTPHandler";
+    REQUIRED_GENEZIO_TYPES_VERSION_RANGE = ">=1.0.0";
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.0.0";
 }
 
 export {
@@ -56,4 +62,6 @@ export {
     ENVIRONMENT,
     SENTRY_DSN,
     GENEZIO_REGISTRY,
+    REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE
 };

--- a/src/utils/dependencyChecker.ts
+++ b/src/utils/dependencyChecker.ts
@@ -26,7 +26,8 @@ export function isDependencyVersionCompatible(
             return undefined;
         }
 
-        return semver.satisfies(version, depVersion);
+        const minDependencyVersion = semver.minVersion(depVersion)
+        return semver.satisfies(minDependencyVersion!, version);
     } catch (error) {
         debugLogger.error(`Error while reading package.json file: ${error}`);
         return undefined;


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Use `semver.minVersion` to extract the minimum version from the interval described in `package.json` and use it to compare it with the required interval.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
