### PR TITLE
Fix/npm doesn't install latest genezio types version

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,7 @@ if (environment === "dev") {
     GENEZIO_REGISTRY =
         "yptt62gzkhog5xuxtuwxvb6ohi0dtfhg.lambda-url.us-east-1.on.aws/RegistryHTTPHandler";
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE = ">=1.0.0";
-    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.0.0";
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.x";
 } else {
     REACT_APP_BASE_URL = "https://app.genez.io";
     FRONTEND_DOMAIN = "app.genez.io";
@@ -47,7 +47,7 @@ if (environment === "dev") {
     GENEZIO_REGISTRY =
         "rt3ersglfpyjlkzcjgql3s7xju0nuzym.lambda-url.us-east-1.on.aws/RegistryHTTPHandler";
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE = ">=1.0.0";
-    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.0.0";
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.x";
 }
 
 export {
@@ -63,5 +63,5 @@ export {
     SENTRY_DSN,
     GENEZIO_REGISTRY,
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
-    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,7 @@ if (environment === "dev") {
     GENEZIO_REGISTRY =
         "yptt62gzkhog5xuxtuwxvb6ohi0dtfhg.lambda-url.us-east-1.on.aws/RegistryHTTPHandler";
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE = ">=1.0.0";
-    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.x";
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "1.x";
 } else {
     REACT_APP_BASE_URL = "https://app.genez.io";
     FRONTEND_DOMAIN = "app.genez.io";
@@ -47,7 +47,7 @@ if (environment === "dev") {
     GENEZIO_REGISTRY =
         "rt3ersglfpyjlkzcjgql3s7xju0nuzym.lambda-url.us-east-1.on.aws/RegistryHTTPHandler";
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE = ">=1.0.0";
-    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "^1.x";
+    RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE = "1.x";
 }
 
 export {


### PR DESCRIPTION
# Pull Request Template

`npm install @genezio/types@^1.0.0` would not install the proper version on windows. This is fixed by chaning the command to `npm install @genezio/types@^1.x`
<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->


-   [x] 🐛 Bug Fix
-   [x] 🧑‍💻 Improvement


## Description
`npm install @genezio/types@^1.0.0` would not install the proper version on windows. This is fixed by chaning the command to `npm install @genezio/types@^1.x`
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
