### PR TITLE
we dont delete the folder when we have sdk generation legacy

### DIFF
--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -298,14 +298,20 @@ async function generateRemoteSdkHandler(
         );
         debugLogger.debug("Package json is: " + packageJson);
         debugLogger.debug("Start Compiling sdk");
-        await compileSdk(sdkPath, packageJson, language as Language, false, "", false);
+        await compileSdk(
+            sdkPath,
+            packageJson,
+            language as Language,
+            /* publish= */ false,
+            /* outDir= */ "",
+            /* overwriteIfExists= */ false,
+        );
         debugLogger.debug("Sdk compiled successfully");
 
         debugLogger.debug("Start sdk cleanup");
 
         await Promise.all(
             sdkGeneratorResponse.files.map(async (file) => {
-                // console.log("Deleting file: " + file.path);
                 // delete the files and its parent directories
 
                 await deleteFile(path.join(sdkPath, file.path));

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -14,10 +14,7 @@ import { getProjectConfiguration, scanClassesForDecorators } from "../utils/conf
 import { ClassUrlMap, replaceUrlsInSdk, writeSdkToDisk } from "../utils/sdk.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js";
 import path from "path";
-import {
-    SdkGeneratorClassesInfoInput,
-    SdkGeneratorInput,
-} from "../models/genezioModels.js";
+import { SdkGeneratorClassesInfoInput, SdkGeneratorInput } from "../models/genezioModels.js";
 import { mapDbAstToSdkGeneratorAst } from "../generateSdk/utils/mapDbAstToFullAst.js";
 import { generateSdk } from "../generateSdk/sdkGeneratorHandler.js";
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
@@ -301,19 +298,20 @@ async function generateRemoteSdkHandler(
         );
         debugLogger.debug("Package json is: " + packageJson);
         debugLogger.debug("Start Compiling sdk");
-        await compileSdk(sdkPath, packageJson, language as Language, false, "");
+        await compileSdk(sdkPath, packageJson, language as Language, false, "", false);
         debugLogger.debug("Sdk compiled successfully");
 
         debugLogger.debug("Start sdk cleanup");
 
         await Promise.all(
-            sdkGeneratorResponse.files.map((file) => {
+            sdkGeneratorResponse.files.map(async (file) => {
                 // console.log("Deleting file: " + file.path);
                 // delete the files and its parent directories
-                deleteFile(path.join(sdkPath, file.path));
+
+                await deleteFile(path.join(sdkPath, file.path));
                 const firstParentDir = path.dirname(file.path).split(path.sep)[0];
                 if (firstParentDir && firstParentDir !== ".") {
-                    deleteFolder(path.join(sdkPath, firstParentDir));
+                    await deleteFolder(path.join(sdkPath, firstParentDir));
                 }
             }),
         );

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -37,11 +37,14 @@ export async function compileSdk(
     language: Language,
     publish: boolean,
     outDir = "../genezio-sdk",
+    ShouldDeleteFolder = true,
 ) {
     const genezioSdkPath = path.resolve(sdkPath, outDir);
     // delete the old sdk
-    if (fs.existsSync(genezioSdkPath)) {
-        await deleteFolder(genezioSdkPath);
+    if (ShouldDeleteFolder) {
+        if (fs.existsSync(genezioSdkPath)) {
+            await deleteFolder(genezioSdkPath);
+        }
     }
     fs.mkdirSync(genezioSdkPath, { recursive: true });
     // compile the sdk to cjs and esm using worker threads

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -37,11 +37,11 @@ export async function compileSdk(
     language: Language,
     publish: boolean,
     outDir = "../genezio-sdk",
-    ShouldDeleteFolder = true,
+    overwriteIfExists = true,
 ) {
     const genezioSdkPath = path.resolve(sdkPath, outDir);
     // delete the old sdk
-    if (ShouldDeleteFolder) {
+    if (overwriteIfExists) {
         if (fs.existsSync(genezioSdkPath)) {
             await deleteFolder(genezioSdkPath);
         }


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->


-   [x] 🐛 Bug Fix


## Description

When we generate sdk as a node modules package, we have the following flow for sdk generation: temp/sdk is deleted, newSdk is written in temp/sdk, temp/genezio-sdk is deleted, newCompiledSdk is written to temp/genezio-sdk, node_module/genezio-sdk is deleted, newCompiledSdk is written to node_module/genezio-sdk. However, on legacy mode, the sdk was written in the sdkPath provided by user and also compiled in that path which led to the folder being deleted before it could compile its own contents. For this fix i added a default true paremeter at the compileSdk function that, if set to false, will not delete the target directory before compiling. 
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
