### PR TITLE
Properly serialize and deserialize errors over the wire

### DIFF
--- a/src/bundlers/node/lambdaHandlerGenerator.ts
+++ b/src/bundlers/node/lambdaHandlerGenerator.ts
@@ -171,7 +171,7 @@ if (!genezioClass) {
                 body = JSON.parse(event.body);
             } catch (error) {
                 return {
-                    statusCode: 500,
+                    statusCode: 400,
                     body: JSON.stringify({
                         jsonrpc: "2.0",
                         error: { code: -1, message: "Invalid JSON-RPC request" },
@@ -182,7 +182,7 @@ if (!genezioClass) {
             }
             if (!body || !body.method || !body.params || !Number.isInteger(body.id)) {
                 return {
-                    statusCode: 500,
+                    statusCode: 400,
                     body: JSON.stringify({
                         jsonrpc: "2.0",
                         error: { code: -1, message: "Invalid JSON-RPC request" },
@@ -198,7 +198,7 @@ if (!genezioClass) {
                 method = methodElems[1];
             } catch (error) {
                 return {
-                    statusCode: 500,
+                    statusCode: 400,
                     body: JSON.stringify({
                         jsonrpc: "2.0",
                         error: { code: -1, message: "Invalid Genezio JSON-RPC request" },
@@ -210,7 +210,7 @@ if (!genezioClass) {
 
             if (!object[method]) {
                 return {
-                    statusCode: 500,
+                    statusCode: 400,
                     body: JSON.stringify({
                         jsonrpc: "2.0",
                         error: { code: -1, message: "Method not found!" },
@@ -227,7 +227,7 @@ if (!genezioClass) {
                     console.error(err);
                     await sendSentryError(err);
                     resolve({
-                        statusCode: 500,
+                        statusCode: 200,
                         body: JSON.stringify({
                             jsonrpc: "2.0",
                             error: prepareForSerialization(err),

--- a/src/bundlers/node/lambdaHandlerGenerator.ts
+++ b/src/bundlers/node/lambdaHandlerGenerator.ts
@@ -256,7 +256,7 @@ if (!genezioClass) {
                         console.error(err);
                         await sendSentryError(err);
                         return {
-                            statusCode: 500,
+                            statusCode: 200,
                             body: JSON.stringify({
                                 jsonrpc: "2.0",
                                 error: prepareForSerialization(err),
@@ -272,7 +272,7 @@ if (!genezioClass) {
                 console.error(err);
                 await sendSentryError(err);
                 return {
-                    statusCode: 500,
+                    statusCode: 200,
                     body: JSON.stringify({
                         jsonrpc: "2.0",
                         error: prepareForSerialization(err),

--- a/src/bundlers/node/lambdaHandlerGenerator.ts
+++ b/src/bundlers/node/lambdaHandlerGenerator.ts
@@ -259,7 +259,7 @@ if (!genezioClass) {
                             statusCode: 500,
                             body: JSON.stringify({
                                 jsonrpc: "2.0",
-                                error: prepareForSerialization(error),
+                                error: prepareForSerialization(err),
                                 id: requestId,
                             }),
                             headers: { 'Content-Type': 'application/json', 'X-Powered-By': 'genezio' }

--- a/src/bundlers/node/lambdaHandlerGenerator.ts
+++ b/src/bundlers/node/lambdaHandlerGenerator.ts
@@ -10,6 +10,16 @@ import {  ${className.replace(/["]/g, "")} as genezioClass } from "./module.mjs"
 
 var handler = undefined;
 
+function prepareForSerialization(e) {
+    if (e instanceof Error) {
+        const object = { message: e.message, stack: e.stack, info: e.info, code: e.code } 
+        return object;
+    } else {
+        console.log(\`Unsupported error type \${typeof e}\`)
+        return { message: "Unknown error occurred. Check logs for more information!" }
+    }
+}
+
 if (!genezioClass) {
     console.error(
         'Error! No class found with name ${className}. Make sure you exported it from your file.'
@@ -220,7 +230,7 @@ if (!genezioClass) {
                         statusCode: 500,
                         body: JSON.stringify({
                             jsonrpc: "2.0",
-                            error: { code: -1, message: err.toString() },
+                            error: prepareForSerialization(err),
                             id: requestId,
                         }),
                         headers: { 'Content-Type': 'application/json', 'X-Powered-By': 'genezio' }
@@ -249,7 +259,7 @@ if (!genezioClass) {
                             statusCode: 500,
                             body: JSON.stringify({
                                 jsonrpc: "2.0",
-                                error: { code: -1, message: err.toString() },
+                                error: prepareForSerialization(error),
                                 id: requestId,
                             }),
                             headers: { 'Content-Type': 'application/json', 'X-Powered-By': 'genezio' }
@@ -265,7 +275,7 @@ if (!genezioClass) {
                     statusCode: 500,
                     body: JSON.stringify({
                         jsonrpc: "2.0",
-                        error: { code: -1, message: err.toString() },
+                        error: prepareForSerialization(err),
                         id: requestId,
                     }),
                     headers: { 'Content-Type': 'application/json', 'X-Powered-By': 'genezio' }

--- a/src/generateSdk/templates/nodeSdkJs.ts
+++ b/src/generateSdk/templates/nodeSdkJs.ts
@@ -86,6 +86,14 @@ export class Remote {
        }
    }
 
+   deserialize(s) {
+       const e = new Error(s.message);
+       e.stack = s.stack
+       e.info = s.info
+       e.code = s.code
+       return e
+   }
+
    async call(method, ...args) {
        const requestContent = {"jsonrpc": "2.0", "method": method, "params": args, "id": 3};
        let response = undefined;
@@ -99,7 +107,7 @@ export class Remote {
        }
 
        if (response.error) {
-           return response.error.message;
+           throw this.deserialize(response.error)
        }
 
        return response.result;

--- a/src/generateSdk/templates/nodeSdkTs.ts
+++ b/src/generateSdk/templates/nodeSdkTs.ts
@@ -88,6 +88,14 @@ async function makeRequestNode(request: any, url: any, agent: any) {
         }
     }
 
+     deserialize(s: any) {
+        const e: any = new Error(s.message);
+        e.stack = s.stack
+        e.info = s.info
+        e.code = s.code
+        return e
+    }
+
     async call(method: any, ...args: any[]) {
         const requestContent = {"jsonrpc": "2.0", "method": method, "params": args, "id": 3};
         let response: any = undefined;
@@ -102,7 +110,7 @@ async function makeRequestNode(request: any, url: any, agent: any) {
         }
 
         if (response.error) {
-            return response.error.message;
+            throw this.deserialize(response.error);
         }
 
         return response.result;


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 New feature

## Description

Up until now, we did not properly serialize the errors. We were just calling `error.toString()` but that does not include too much information. The proposal in this PR is to serialize Errors containing the following fields: message, code, info. This can be done in a multi language environment and satisfies most of the use cases.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
