### PR TITLE
Deploy with custom config

### DIFF
--- a/src/commands/addClass.ts
+++ b/src/commands/addClass.ts
@@ -23,7 +23,7 @@ export async function addClassCommand(classPath: string, classType: string) {
         throw new Error("Please provide a path to the class you want to add.");
     }
 
-    const projectConfiguration = await getProjectConfiguration();
+    const projectConfiguration = await getProjectConfiguration("./genezio.yaml");
 
     const className = classPath.split(path.sep).pop();
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -57,7 +57,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
     let configuration;
 
     try {
-        configuration = await getProjectConfiguration();
+        configuration = await getProjectConfiguration(options.config);
     } catch (error) {
         if (error instanceof Error) {
             log.error(error.message);

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -162,7 +162,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
         eventType: TelemetryEventTypes.GENEZIO_LOCAL,
         commandOptions: JSON.stringify(options),
     });
-    const yamlProjectConfiguration = await getProjectConfiguration();
+    const yamlProjectConfiguration = await getProjectConfiguration(options.config);
 
     // We need to check if the user is using an older version of @genezio/types
     // because we migrated the decorators implemented in the @genezio/types package to the stage 3 implementation.
@@ -212,7 +212,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
         // Read the project configuration every time because it might change
         let yamlProjectConfiguration;
         try {
-            yamlProjectConfiguration = await getProjectConfiguration();
+            yamlProjectConfiguration = await getProjectConfiguration(options.config);
         } catch (error) {
             if (error instanceof Error) {
                 log.error(error.message);

--- a/src/commands/superGenezio.ts
+++ b/src/commands/superGenezio.ts
@@ -47,6 +47,7 @@ export async function genezioCommand() {
                 process.env["CURRENT_COMMAND"] = "deploy";
                 const options: GenezioDeployOptions = {
                     installDeps: true,
+                    config: "./genezio.yaml",
                 };
 
                 return await deployCommand(options).catch(async (error) => {
@@ -63,6 +64,7 @@ export async function genezioCommand() {
                 const options: GenezioLocalOptions = {
                     port: PORT_LOCAL_ENVIRONMENT,
                     installDeps: true,
+                    config: "./genezio.yaml",
                 };
 
                 return await startLocalEnvironment(options).catch(async (error) => {

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -155,6 +155,11 @@ program
         "Set a subdomain for your frontend. If not set, the subdomain will be randomly generated.",
         undefined,
     )
+    .option(
+        "--config <config>",
+        "Use a specific `genezio.yaml` file as deployment configuration",
+        "./genezio.yaml",
+    )
     .summary("Deploy your project to the cloud.")
     .description(
         `Use --frontend to deploy only the frontend application.
@@ -191,6 +196,11 @@ program
     .option("--path <path>", "Set the path where to generate your local sdk.")
     .option("-l | --language <language>", "Language of the generated sdk.")
     .option("--install-deps", "Automatically install missing dependencies.", false)
+    .option(
+        "--config <config>",
+        "Use a specific `genezio.yaml` file as deployment configuration",
+        "./genezio.yaml",
+    )
     .summary("Test a project in a local environment.")
     .action(async (options: GenezioLocalOptions) => {
         setDebuggingLoggerLogLevel(options.logLevel);

--- a/src/models/commandOptions.ts
+++ b/src/models/commandOptions.ts
@@ -15,6 +15,7 @@ export interface GenezioLocalOptions extends BaseOptions {
     env?: string;
     path?: string;
     language?: string;
+    config: string;
 }
 
 export interface GenezioDeployOptions extends BaseOptions {
@@ -24,6 +25,7 @@ export interface GenezioDeployOptions extends BaseOptions {
     env?: string;
     stage?: string;
     subdomain?: string;
+    config: string;
 }
 
 export interface GenezioListOptions extends BaseOptions {

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -217,7 +217,7 @@ async function tryToReadClassInformationFromDecorators(
 }
 
 export async function getProjectConfiguration(
-    configurationFilePath = "./genezio.yaml",
+    configurationFilePath: string,
     skipClassScan = false,
 ): Promise<YamlProjectConfiguration> {
     if (!(await checkYamlFileExists(configurationFilePath))) {


### PR DESCRIPTION
-   [X] 🧑‍💻 Improvement

Add `configFile` option to `genezio local` and `genezio deploy`. The option defaults to `./genezio.yaml` explicitly. Changed the interface of `getProjectConfiguration` to explicitly require the configuration file path to improve readability.