### PR TITLE
add version tag to go-ast-parser

### DIFF
--- a/src/generateSdk/astGenerator/GoAstGenerator.ts
+++ b/src/generateSdk/astGenerator/GoAstGenerator.ts
@@ -18,7 +18,8 @@ import { runNewProcess, runNewProcessWithResultAndReturnCode } from "../../utils
 import { checkIfGoIsInstalled } from "../../utils/go.js";
 import { createTemporaryFolder } from "../../utils/file.js";
 
-const binaryName = "gnzparser";
+const releaseTag = "v0.1";
+const binaryName = `golang_ast_generator_${releaseTag}`;
 
 export class AstGenerator implements AstGeneratorInterface {
     async #compileGenezioGoAstExtractor() {
@@ -34,6 +35,7 @@ export class AstGenerator implements AstGeneratorInterface {
                     " temporary folder!",
             );
         }
+        await runNewProcess(`git checkout --quiet tags/${releaseTag}`, folder);
         const goBuildSuccess = await runNewProcess(`go build -o ${binaryName} cmd/main.go`, folder);
         if (!goBuildSuccess) {
             throw new Error(


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

This solves a bug where a change in the GO parser repository would be inaccessible for users that already compiled a previous version of the repository.
To update the repository, a new release tag should be created on the [GO parser repository](https://github.com/Genez-io/go-ast), and the constant `releaseTag` from the `GoAstGenerator` class should be updated with the new tag.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
