### PR TITLE
remade the regex to split ignore file properly

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -55,7 +55,6 @@ import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js
 import dotenv from "dotenv";
 import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
 import inquirer, { Answers } from "inquirer";
-import { EOL } from "os";
 import { DEFAULT_NODE_RUNTIME } from "../models/nodeRuntime.js";
 import { getNodeModulePackageJsonLocal } from "../generateSdk/templates/packageJson.js";
 import { compileSdk } from "../generateSdk/utils/compileSdk.js";
@@ -878,7 +877,7 @@ async function listenForChanges(sdkPathRelative: string | undefined) {
         // read the file as a string
         const ignoreFile = await readUTF8File(ignoreFilePath);
         // split the string by newline - CRLF or LF
-        const ignoreFileLines = ignoreFile.split(EOL);
+        const ignoreFileLines = ignoreFile.split(/\r?\n/);
         // remove empty lines
         const ignoreFileLinesWithoutEmptyLines = ignoreFileLines.filter(
             (line) => line !== "" && !line.startsWith("#"),


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix
-   [x] 🧑‍💻 Improvement

## Description

The genezio local procces would restart without any changes being made by the user to the watched directories. There were two reasons for this, one of them is that the EOL variable from the OS package was used to split the .genezioignore file lines but this didn't work. To fix this i made a regex that should work on unix and windows systems. The second reason is that VS code would periodically perform git fetch which would change the .git folder. To fix this i just added the .git folder to the .genezioignore path. This means that we should also update any existing templates and examples with the .git folder in the .genezioignore file. We also need to specify in the documentation that the .git folder should be added to the .genezioignore file.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
--> 

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [x] New and existing unit tests pass locally with my changes;
