### PR TITLE
we don't delete the sdk if we are on legacy mode

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -343,12 +343,14 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
                     cloudUrl: `http://127.0.0.1:${options.port}/${c.className}`,
                 })),
             );
-            await writeSdkToDisk(sdk, sdkConfiguration.path);
+
             if (
                 !yamlProjectConfiguration.sdk &&
                 (sdkConfiguration.language === Language.ts ||
                     sdkConfiguration.language === Language.js)
             ) {
+                await deleteFolder(sdkConfiguration.path);
+                await writeSdkToDisk(sdk, sdkConfiguration.path);
                 // compile the sdk
                 const packageJson: string = getNodeModulePackageJsonLocal(
                     projectConfiguration.name,
@@ -366,6 +368,8 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
                     yamlProjectConfiguration,
                     sdkConfiguration.path,
                 );
+            } else {
+                await writeSdkToDisk(sdk, sdkConfiguration.path);
             }
         }
 

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -1,8 +1,7 @@
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
-import { deleteFolder, writeToFile } from "./file.js";
+import { writeToFile } from "./file.js";
 import { debugLogger } from "./logging.js";
 import { File, SdkFileClass } from "../models/genezioModels.js";
-import { Language } from "../models/yamlProjectConfiguration.js";
 
 export type ClassUrlMap = {
     name: string;
@@ -34,14 +33,6 @@ export async function writeSdkToDisk(sdk: SdkGeneratorResponse, outputPath: stri
     if (sdk.files.length == 0) {
         debugLogger.debug("No SDK classes found...");
         return;
-    }
-
-    if (
-        sdk.sdkGeneratorInput.sdk?.language &&
-        (sdk.sdkGeneratorInput.sdk.language === Language.js ||
-            sdk.sdkGeneratorInput.sdk.language === Language.ts)
-    ) {
-        await deleteFolder(outputPath);
     }
 
     debugLogger.debug("Writing the SDK to files...");


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

Legacy sdk would delete all the contents of a folder, if you were to put the sdk path in root, it would delete all your project files then write the sdk. Now, if we are on legacy sdk we don't delete anything.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
