### PR TITLE
Go map type

### DIFF
--- a/src/bundlers/go/goBundler.ts
+++ b/src/bundlers/go/goBundler.ts
@@ -20,6 +20,7 @@ import {
     AstNodeType,
     ClassDefinition,
     CustomAstNodeType,
+    MapType,
     Node,
     Program,
     StructLiteral,
@@ -89,6 +90,10 @@ export class GoBundler implements BundlerInterface {
                 return (type as CustomAstNodeType).rawValue;
             case AstNodeType.ArrayType:
                 return "[]" + this.#mapTypeToGoType((type as ArrayType).generic, ast, imports);
+            case AstNodeType.MapType:
+                return `map[${this.#mapTypeToGoType((type as MapType).genericKey, ast, imports)}]${this.#mapTypeToGoType((type as MapType).genericValue, ast, imports)}`;
+            case AstNodeType.AnyLiteral:
+                return "interface{}";
         }
         return "interface{}";
     }
@@ -142,6 +147,7 @@ export class GoBundler implements BundlerInterface {
                 }
                 return `paramFloat${index} := body.Params[${index}].(float64)
         param${index} := int(paramFloat${index})`;
+            case AstNodeType.MapType:
             case AstNodeType.CustomNodeLiteral:
             case AstNodeType.ArrayType:
                 return `var param${index} ${parameter.optional ? "*" : ""}${this.#mapTypeToGoType(
@@ -159,6 +165,8 @@ export class GoBundler implements BundlerInterface {
             errorResponse := sendError(err)
             return errorResponse, nil
         }`;
+            case AstNodeType.AnyLiteral:
+                return `param${index} := body.Params[${index}]`;
         }
         return "";
     }
@@ -207,8 +215,11 @@ export class GoBundler implements BundlerInterface {
                 })),
         };
 
-        moustacheViewForMain.imports.push(this.#getImportViewFromPath(mainClass.path ?? ""));
         moustacheViewForMain.imports.push(...imports);
+        const classImport = this.#getImportViewFromPath(mainClass.path ?? "");
+        if (!moustacheViewForMain.imports.find((i) => i.path === classImport.path)) {
+            moustacheViewForMain.imports.push(classImport);
+        }
 
         const routerFileContent = Mustache.render(template, moustacheViewForMain);
         await writeToFile(folderPath, "main.go", routerFileContent);

--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -188,7 +188,7 @@ export class AstGenerator implements AstGeneratorInterface {
                 const properties: PropertyDefinition[] = [];
 
                 for (const member of (type as typescript.TypeLiteralNode).members) {
-                    if (typescript.isPropertyDeclaration(member) && member.type) {
+                    if (typescript.isPropertySignature(member) && member.type) {
                         properties.push({
                             name: typescript.isIdentifier(member.name)
                                 ? member.name.text

--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -448,7 +448,7 @@ export class AstGenerator implements AstGeneratorInterface {
             params: parameters,
             returnType: methodDeclarationCopy.type
                 ? this.mapTypesToParamType(methodDeclarationCopy.type, typeChecker, declarations)
-                : { type: AstNodeType.VoidLiteral },
+                : { type: AstNodeType.AnyLiteral },
             static: false,
             kind: MethodKindEnum.method,
         };

--- a/src/generateSdk/sdkGenerator/GoSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/GoSdkGenerator.ts
@@ -450,17 +450,19 @@ class SdkGenerator implements SdkGeneratorInterface {
         } else if (elem.type === AstNodeType.UnionType) {
             return (elem as UnionType).params.map((e: Node) => this.getParamType(e)).join(" | ");
         } else if (elem.type === AstNodeType.TypeLiteral) {
-            return `{${(elem as TypeLiteral).properties
-                .map((e: PropertyDefinition) => {
-                    if (e.type.type === AstNodeType.MapType) {
-                        return `[key: ${this.getParamType(
-                            (e.type as MapType).genericKey,
-                        )}]: ${this.getParamType((e.type as MapType).genericValue)}`;
-                    } else {
-                        return `${e.name}${e.optional ? "?" : ""}: ${this.getParamType(e.type)}`;
-                    }
-                })
-                .join(", ")}}`;
+            const elemTypeLiteral = elem as TypeLiteral;
+            if (
+                elemTypeLiteral.properties.length === 1 &&
+                elemTypeLiteral.properties[0].type.type === AstNodeType.MapType
+            ) {
+                return this.getParamType(elemTypeLiteral.properties[0].type);
+            }
+            return `struct {${elemTypeLiteral.properties
+                .map(
+                    (e: PropertyDefinition) =>
+                        `${e.name} ${e.optional ? "*" : ""}${this.getParamType(e.type)}`,
+                )
+                .join("; ")}}`;
         } else if (elem.type === AstNodeType.MapType) {
             return `map[${this.getParamType((elem as MapType).genericKey)}]${this.getParamType(
                 (elem as MapType).genericValue,

--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -492,7 +492,7 @@ class SdkGenerator implements SdkGeneratorInterface {
     }
 
     getReturnType(returnType: Node): string {
-        if (!returnType || returnType.type === AstNodeType.VoidLiteral) {
+        if (!returnType) {
             return "";
         }
 
@@ -505,51 +505,54 @@ class SdkGenerator implements SdkGeneratorInterface {
     }
 
     getParamType(elem: Node): string {
-        if (elem.type === AstNodeType.CustomNodeLiteral) {
-            return (elem as CustomAstNodeType).rawValue;
-        } else if (elem.type === AstNodeType.StringLiteral) {
-            return "string";
-        } else if (
-            elem.type === AstNodeType.IntegerLiteral ||
-            elem.type === AstNodeType.FloatLiteral ||
-            elem.type === AstNodeType.DoubleLiteral
-        ) {
-            return "number";
-        } else if (elem.type === AstNodeType.BooleanLiteral) {
-            return "boolean";
-        } else if (elem.type === AstNodeType.AnyLiteral) {
-            return "any";
-        } else if (elem.type === AstNodeType.ArrayType) {
-            return `Array<${this.getParamType((elem as ArrayType).generic)}>`;
-        } else if (elem.type === AstNodeType.PromiseType) {
-            return `Promise<${this.getParamType((elem as PromiseType).generic)}>`;
-        } else if (elem.type === AstNodeType.Enum) {
-            return (elem as Enum).name;
-        } else if (elem.type === AstNodeType.TypeAlias) {
-            return (elem as TypeAlias).name;
-        } else if (elem.type === AstNodeType.UnionType) {
-            return (elem as UnionType).params.map((e: Node) => this.getParamType(e)).join(" | ");
-        } else if (elem.type === AstNodeType.TypeLiteral) {
-            return `{${(elem as TypeLiteral).properties
-                .map((e: PropertyDefinition) => {
-                    if (
-                        e.type.type === AstNodeType.MapType &&
-                        (elem as TypeLiteral).properties.length === 1
-                    ) {
-                        return `[key: ${this.getParamType(
-                            (e.type as MapType).genericKey,
-                        )}]: ${this.getParamType((e.type as MapType).genericValue)}`;
-                    } else {
-                        return `${e.name}${e.optional ? "?" : ""}: ${this.getParamType(e.type)}`;
-                    }
-                })
-                .join(", ")}}`;
-        } else if (elem.type === AstNodeType.DateType) {
-            return "Date";
-        } else if (elem.type == AstNodeType.MapType) {
-            return `{[key: ${this.getParamType((elem as MapType).genericKey)}]: ${this.getParamType(
-                (elem as MapType).genericValue,
-            )}}`;
+        switch (elem.type) {
+            case AstNodeType.CustomNodeLiteral:
+                return (elem as CustomAstNodeType).rawValue;
+            case AstNodeType.StringLiteral:
+                return "string";
+            case AstNodeType.IntegerLiteral:
+            case AstNodeType.FloatLiteral:
+            case AstNodeType.DoubleLiteral:
+                return "number";
+            case AstNodeType.BooleanLiteral:
+                return "boolean";
+            case AstNodeType.AnyLiteral:
+                return "any";
+            case AstNodeType.ArrayType:
+                return `Array<${this.getParamType((elem as ArrayType).generic)}>`;
+            case AstNodeType.PromiseType:
+                return `Promise<${this.getParamType((elem as PromiseType).generic)}>`;
+            case AstNodeType.Enum:
+                return (elem as Enum).name;
+            case AstNodeType.TypeAlias:
+                return (elem as TypeAlias).name;
+            case AstNodeType.UnionType:
+                return (elem as UnionType).params
+                    .map((e: Node) => this.getParamType(e))
+                    .join(" | ");
+            case AstNodeType.TypeLiteral:
+                return `{${(elem as TypeLiteral).properties
+                    .map((e: PropertyDefinition) => {
+                        if (
+                            e.type.type === AstNodeType.MapType &&
+                            (elem as TypeLiteral).properties.length === 1
+                        ) {
+                            return `[key: ${this.getParamType(
+                                (e.type as MapType).genericKey,
+                            )}]: ${this.getParamType((e.type as MapType).genericValue)}`;
+                        } else {
+                            return `${e.name}${e.optional ? "?" : ""}: ${this.getParamType(e.type)}`;
+                        }
+                    })
+                    .join(", ")}}`;
+            case AstNodeType.DateType:
+                return "Date";
+            case AstNodeType.MapType:
+                return `{[key: ${this.getParamType((elem as MapType).genericKey)}]: ${this.getParamType(
+                    (elem as MapType).genericValue,
+                )}}`;
+            case AstNodeType.VoidLiteral:
+                return "void";
         }
         return "any";
     }


### PR DESCRIPTION
## Type of change

-   [x] 🧑‍💻 Improvement

## Description

GO on genezio now supports map types for parameters and struct properties.
Syntax like `map[string]interface{}` (where the value type is any serializable genezio type) is allowed and can be used in the SDK for GO and TS.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
