### PR TITLE
GNZ-1441 Disable fsEvent on MacOS to avoid infinite reloading

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -916,6 +916,8 @@ async function listenForChanges(sdkPathRelative: string | undefined) {
         const startWatching = () => {
             const watch = chokidar
                 .watch(watchPaths, {
+                    // Disable fsevents for macos
+                    useFsEvents: false,
                     ignored: ignoredPaths,
                     ignoreInitial: true,
                 })


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Problem: When testing locally on macos, if `client` is not set in `genezioignore`, an infinite loop is triggered due to regex-related issues in `chokidar`.
I couldn't exactly pin-point the regex problems and I couldn't find a decent, os-agnostic solution [1].

To have a robust, os-agnostic solution, this PR disables `fsevents` - a mechanism to trigger filesystem events faster/more efficient than polling - on macos.

This solution should not affect Linux or Windows because these systems have `fsevents` disabled by default.

There might be an alternate solution to remove the regex pattern and create a method that verifies if the string `/node_modules/` is in `<absolute_path>` for every filesystem event triggered. I disregarded this solution because it's error prone and adds a maintenance burden.

[1] https://github.com/paulmillr/chokidar

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
