### PR TITLE
move go, kotlin and dart parsers to .genezio folder

### DIFF
--- a/src/generateSdk/astGenerator/GoAstGenerator.ts
+++ b/src/generateSdk/astGenerator/GoAstGenerator.ts
@@ -43,13 +43,14 @@ export class AstGenerator implements AstGeneratorInterface {
             );
         }
 
-        if (!fs.existsSync(path.join(os.homedir(), ".golang_ast_generator"))) {
-            fs.mkdirSync(path.join(os.homedir(), ".golang_ast_generator"));
+        if (!fs.existsSync(path.join(os.homedir(), ".genezio", ".golang_ast_generator"))) {
+            fs.mkdirSync(path.join(os.homedir(), ".genezio", ".golang_ast_generator"));
         }
 
         const goAstGeneratorPath = path.join(folder, binaryName);
         const goAstGeneratorPathInHome = path.join(
             os.homedir(),
+            ".genezio",
             ".golang_ast_generator",
             binaryName,
         );
@@ -61,7 +62,12 @@ export class AstGenerator implements AstGeneratorInterface {
         checkIfGoIsInstalled();
 
         // Check if the go ast generator is compiled
-        const goAstGeneratorPath = path.join(os.homedir(), ".golang_ast_generator", binaryName);
+        const goAstGeneratorPath = path.join(
+            os.homedir(),
+            ".genezio",
+            ".golang_ast_generator",
+            binaryName,
+        );
         if (!fs.existsSync(goAstGeneratorPath)) {
             await this.#compileGenezioGoAstExtractor();
         }

--- a/src/generateSdk/astGenerator/KotlinAstGenerator.ts
+++ b/src/generateSdk/astGenerator/KotlinAstGenerator.ts
@@ -72,12 +72,17 @@ export class AstGenerator implements AstGeneratorInterface {
             );
         }
 
-        if (!fs.existsSync(path.join(os.homedir(), ".kotlin_ast_generator"))) {
-            fs.mkdirSync(path.join(os.homedir(), ".kotlin_ast_generator"));
+        if (!fs.existsSync(path.join(os.homedir(), ".genezio", ".kotlin_ast_generator"))) {
+            fs.mkdirSync(path.join(os.homedir(), ".genezio", ".kotlin_ast_generator"));
         }
 
         const ast_gen_path = path.join(folder, "app", "build", "libs", "app-standalone.jar");
-        const ast_gen_dest = path.join(os.homedir(), ".kotlin_ast_generator", "ast-generator.jar");
+        const ast_gen_dest = path.join(
+            os.homedir(),
+            ".genezio",
+            ".kotlin_ast_generator",
+            "ast-generator.jar",
+        );
         fsExtra.copyFileSync(ast_gen_path, ast_gen_dest);
     }
 
@@ -188,6 +193,7 @@ export class AstGenerator implements AstGeneratorInterface {
         // Check if the kotlin ast extractor is compiled and installed in home.
         const genezioAstGeneratorPath = path.join(
             os.homedir(),
+            ".genezio",
             ".kotlin_ast_generator",
             "ast-generator.jar",
         );

--- a/src/utils/dart.ts
+++ b/src/utils/dart.ts
@@ -39,9 +39,10 @@ export function getDartAstGeneratorPath(dartSdkVersion: string): {
     path: string;
 } {
     return {
-        directory: path.join(os.homedir(), ".dart_ast_generator"),
+        directory: path.join(os.homedir(), ".genezio", ".dart_ast_generator"),
         path: path.join(
             os.homedir(),
+            ".genezio",
             ".dart_ast_generator",
             `genezioDartAstGenerator_${dartSdkVersion}_v0.1.aot`,
         ),


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

Moved the resulting executables for parsing compiled languages in the .genezio folder instead of the users home directory.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
