### PR TITLE
Set up AB testing for cloud providers

### DIFF
--- a/src/utils/abTesting.ts
+++ b/src/utils/abTesting.ts
@@ -1,0 +1,22 @@
+import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
+import getProjectInfoByName from "../requests/getProjectInfoByName.js";
+
+// This function is used to check if the project is already deployed.
+export async function isProjectDeployed(name: string, region: string): Promise<boolean> {
+    try {
+        const projectInfo = await getProjectInfoByName(name, region);
+        if (projectInfo) {
+            return true;
+        }
+    } catch (error) {
+        return false;
+    }
+    return false;
+}
+
+// This function is used to randomly select a cloud provider for AB testing.
+export function getRandomCloudProvider(): CloudProviderIdentifier {
+    return Math.random() < 0.5
+        ? CloudProviderIdentifier.GENEZIO
+        : CloudProviderIdentifier.CAPYBARA_LINUX;
+}

--- a/src/yamlProjectConfiguration/v1.ts
+++ b/src/yamlProjectConfiguration/v1.ts
@@ -414,8 +414,6 @@ export class YamlProjectConfiguration {
     }
 
     // The type parameter is used only if the yaml is a root type of genezio.yaml.
-    // It is used to decide if the genezio.yaml file that will be written is a frontend or
-    // a root type of genezio.yaml.
     //
     // this yaml mutation is becoming a mess and we should reconsider how
     // we implement it.

--- a/tests/performAbTesting.test.ts
+++ b/tests/performAbTesting.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { performCloudProviderABTesting } from "../src/commands/deploy";
+import { CloudProviderIdentifier, cloudProviders } from "../src/models/cloudProviderIdentifier";
+import { vol } from "memfs";
+import * as abTestingModule from "../src/utils/abTesting";
+
+vi.mock("fs");
+
+describe("test changing cloud providers for AB testing", () => {
+    beforeEach(() => {
+        vol.reset();
+        vi.clearAllMocks();
+    });
+
+    test("project is deployed, should not change cloud provider from genezio", async () => {
+        const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
+        isProjectDeployedSpy.mockResolvedValue(true);
+
+        const name = "test";
+        const region = "us-east-1";
+        const cloudProvider = CloudProviderIdentifier.GENEZIO;
+
+        await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
+            CloudProviderIdentifier.GENEZIO,
+        );
+        expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
+    });
+
+    test("project is deployed, should not change cloud provider from capybaraLinux", async () => {
+        const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
+        isProjectDeployedSpy.mockResolvedValue(true);
+
+        const name = "test";
+        const region = "us-east-1";
+        const cloudProvider = CloudProviderIdentifier.CAPYBARA_LINUX;
+
+        await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
+            CloudProviderIdentifier.CAPYBARA_LINUX,
+        );
+        expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
+    });
+
+    test("project is not deployed, should change for capybaraLinux", async () => {
+        const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
+        isProjectDeployedSpy.mockResolvedValue(false);
+        const getRandomCloudProviderSpy = vi.spyOn(abTestingModule, "getRandomCloudProvider");
+        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.CAPYBARA_LINUX);
+
+        const name = "test";
+        const region = "us-east-1";
+        const cloudProvider = CloudProviderIdentifier.GENEZIO;
+
+        await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
+            CloudProviderIdentifier.CAPYBARA_LINUX,
+        );
+        expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
+        expect(getRandomCloudProviderSpy).toHaveBeenCalledOnce();
+    });
+
+    test("project is not deployed, cloud provider change to genezio", async () => {
+        const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
+        isProjectDeployedSpy.mockResolvedValue(false);
+        const getRandomCloudProviderSpy = vi.spyOn(abTestingModule, "getRandomCloudProvider");
+        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.GENEZIO);
+
+        const name = "test";
+        const region = "us-east-1";
+        const cloudProvider = CloudProviderIdentifier.GENEZIO;
+
+        await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
+            CloudProviderIdentifier.GENEZIO,
+        );
+        expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
+        expect(getRandomCloudProviderSpy).toHaveBeenCalledOnce();
+    });
+
+    test("cloud provider is not genezio initially, should not change", async () => {
+        const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
+        isProjectDeployedSpy.mockResolvedValue(false);
+        const getRandomCloudProviderSpy = vi.spyOn(abTestingModule, "getRandomCloudProvider");
+        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.CAPYBARA_LINUX);
+
+        const name = "test";
+        const region = "us-east-1";
+        const cloudProvider = CloudProviderIdentifier.SELF_HOSTED_AWS;
+
+        await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
+            CloudProviderIdentifier.SELF_HOSTED_AWS,
+        );
+        expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
+    });
+});


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 AB Testing

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR introduces AB testing on the `dev` side for testing the genezio cloud and genezio runtime.

The cloud provider will change seamlessly for newly deployed projects to either `genezio` or `capybaraLinux`.
This change will modify the `cloudProvider` field in the `genezio.yaml`.

This change will only take place if:
- genezio is installed for dev environment
- the initial cloud provider is `genezio` (we don't want to perform ab testing for other experimental tracks such as capybara, cluster or selfHosted)
- `DISABLE_AB_TESTING` is not set

If the developer wants to temporary disable AB testing to make sure the cloud provider is not changed under his feet, he can use `DISABLE_AB_TESTING=true genezio deploy`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
