### PR TITLE
Force lowercase headers feed into handler

### DIFF
--- a/src/bundlers/node/genezioRuntimeHandlerGenerator.ts
+++ b/src/bundlers/node/genezioRuntimeHandlerGenerator.ts
@@ -83,8 +83,14 @@ if (!genezioClass) {
             }
 
             const method = components[2];
+
+            const http2CompliantHeaders = {};
+            for (const header in event.headers) {
+                http2CompliantHeaders[header.toLowerCase()] = event.headers[header];
+            }
+
             const req = {
-                headers: event.headers,
+                headers: http2CompliantHeaders,
                 http: event.http,
                 queryStringParameters: Object.fromEntries([...event.url.searchParams]),
                 timeEpoch: event.requestTimestampMs,


### PR DESCRIPTION
-   [X] 🐛 Bug Fix

## Description
Fix request headers passed on to the actual user code. Previously, they were left untouched in this handler, but they came altered from the golang client code, which formatted them in HTTP/1.X upper-case compliant manner. This could potentially conflict with how users might format their requests and expect headers. 
