### PR TITLE
Import remote conditionally

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -10,6 +10,7 @@ import {
 } from "../constants.js";
 import { GENEZIO_NOT_AUTH_ERROR_MSG, GENEZIO_NO_CLASSES_FOUND } from "../errors.js";
 import {
+    SdkTypeMetadata,
     mapYamlClassToSdkClassConfiguration,
     sdkGeneratorApiHandler,
 } from "../generateSdk/generateSdkApi.js";
@@ -247,8 +248,21 @@ export async function deployClasses(
     if (backend.classes.length === 0) {
         throw new Error(GENEZIO_NO_CLASSES_FOUND);
     }
+    let metadata: SdkTypeMetadata
+    if (backend.sdk?.type === SdkType.folder) {
+        metadata = {
+            type: SdkType.folder,
+        };
+    } else {
+        metadata = {
+            type: SdkType.package,
+            projectName: configuration.name,
+            region: configuration.region,
+        };
+    }
 
     const sdkResponse: SdkGeneratorResponse = await sdkGeneratorApiHandler(
+        metadata,
         backend.language.name,
         mapYamlClassToSdkClassConfiguration(backend.classes, backend.language.name, backend.path),
         backend.path,

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -364,6 +364,8 @@ export async function deployClasses(
             options.stage,
         );
         await compileSdk(path.join(localPath, "sdk"), packageJson, backend.language.name, true);
+        console.log("path", localPath);
+        await new Promise((resolve) => setTimeout(resolve, 1000000));
     }
 
     reportSuccess(

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -365,7 +365,6 @@ export async function deployClasses(
         );
         await compileSdk(path.join(localPath, "sdk"), packageJson, backend.language.name, true);
         console.log("path", localPath);
-        await new Promise((resolve) => setTimeout(resolve, 1000000));
     }
 
     reportSuccess(

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -382,7 +382,6 @@ export async function deployClasses(
             options.stage,
         );
         await compileSdk(path.join(localPath, "sdk"), packageJson, backend.language.name, true);
-        console.log("path", localPath);
     }
 
     reportSuccess(

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -281,6 +281,7 @@ async function generateRemoteSdkHandler(
 
     // write the sdk to disk in the specified path
     await writeSdkToDisk(sdkGeneratorResponse, sdkPath);
+    console.log(sdkPath);
 
     if (sdkType === SdkType.PACKAGE) {
         debugLogger.debug("Sdk type is package for remote sdk");

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -17,7 +17,9 @@ import { generateSdk } from "../generateSdk/sdkGeneratorHandler.js";
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
 import inquirer from "inquirer";
 import { GenezioSdkOptions, SdkType, SourceType } from "../models/commandOptions.js";
+import { SdkType as SdkTypeModel } from "../yamlProjectConfiguration/models.js";
 import {
+    SdkTypeMetadata,
     mapYamlClassToSdkClassConfiguration,
     sdkGeneratorApiHandler,
 } from "../generateSdk/generateSdkApi.js";
@@ -47,6 +49,9 @@ export async function generateLocalSdkCommand(options: GenezioSdkOptions) {
     }
 
     const sdkResponse: SdkGeneratorResponse = await sdkGeneratorApiHandler(
+        { 
+            type : SdkTypeModel.folder
+        },
         options.language,
         mapYamlClassToSdkClassConfiguration(
             await scanClassesForDecorators({ path: process.cwd(), classes: [] }),
@@ -240,7 +245,21 @@ async function generateRemoteSdkHandler(
         );
     }
 
+    let metadata: SdkTypeMetadata;
+    if (sdkType === SdkType.PACKAGE) {
+        metadata = {
+            type: SdkTypeModel.package,
+            projectName,
+            region,
+        };
+    } else {
+        metadata = {
+            type: SdkTypeModel.folder,
+        };
+    }
+
     const sdkGeneratorInput: SdkGeneratorInput = {
+        sdkTypeMetadata: metadata,
         classesInfo: projectEnv.classes.map(
             (c): SdkGeneratorClassesInfoInput => ({
                 program: mapDbAstToSdkGeneratorAst(c.ast),

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -281,7 +281,6 @@ async function generateRemoteSdkHandler(
 
     // write the sdk to disk in the specified path
     await writeSdkToDisk(sdkGeneratorResponse, sdkPath);
-    console.log(sdkPath);
 
     if (sdkType === SdkType.PACKAGE) {
         debugLogger.debug("Sdk type is package for remote sdk");

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -20,6 +20,7 @@ import {
 } from "../constants.js";
 import { GENEZIO_NO_CLASSES_FOUND, PORT_ALREADY_USED } from "../errors.js";
 import {
+    SdkTypeMetadata,
     mapYamlClassToSdkClassConfiguration,
     sdkGeneratorApiHandler,
 } from "../generateSdk/generateSdkApi.js";
@@ -113,7 +114,22 @@ export async function prepareLocalBackendEnvironment(
             throw new Error(GENEZIO_NO_CLASSES_FOUND);
         }
 
+        let metadata: SdkTypeMetadata;
+
+        if (backend.sdk?.type === SdkType.package) {
+            metadata = {
+                type: SdkType.package,
+                projectName: yamlProjectConfiguration.name,
+                region: yamlProjectConfiguration.region,
+            };
+        } else {
+            metadata = {
+                type: SdkType.folder,
+            };
+        }
+
         const sdk = await sdkGeneratorApiHandler(
+            metadata,
             backend.sdk?.language || backend.language.name,
             mapYamlClassToSdkClassConfiguration(
                 backend.classes,

--- a/src/generateSdk/generateSdkApi.ts
+++ b/src/generateSdk/generateSdkApi.ts
@@ -8,9 +8,21 @@ import {
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
 import { AstGeneratorInput } from "../models/genezioModels.js";
 import fs from "fs";
-import { Language, TriggerType } from "../yamlProjectConfiguration/models.js";
+import { Language, SdkType, TriggerType } from "../yamlProjectConfiguration/models.js";
 import path from "path";
 import { YamlClass } from "../yamlProjectConfiguration/v2.js";
+
+interface SdkTypeFolder {
+    type: SdkType.folder;
+}
+
+interface SdkTypePackage {
+    type: SdkType.package;
+    projectName: string;
+    region: string;
+}
+
+export type SdkTypeMetadata = SdkTypeFolder | SdkTypePackage;
 
 /**
  * Asynchronously handles a request to generate an SDK based on the provided YAML project configuration.
@@ -22,6 +34,7 @@ import { YamlClass } from "../yamlProjectConfiguration/v2.js";
  * @throws {Error} If there was an error generating the SDK.
  */
 export async function sdkGeneratorApiHandler(
+    sdkTypeMetadata: SdkTypeMetadata,
     language: Language,
     classes: SdkClassConfiguration[],
     backendPath: string,
@@ -29,6 +42,7 @@ export async function sdkGeneratorApiHandler(
     const inputs: AstGeneratorInput[] = generateAstInputs(classes || [], backendPath);
 
     const sdkGeneratorInput: SdkGeneratorInput = {
+        sdkTypeMetadata,
         classesInfo: [],
     };
 

--- a/src/generateSdk/generateSdkApi.ts
+++ b/src/generateSdk/generateSdkApi.ts
@@ -22,6 +22,14 @@ interface SdkTypePackage {
     region: string;
 }
 
+/**
+ * SdkTypeMetadata is a union type that represents the metadata of the SDK type.
+ * This helps to determine what type of SDK is being generated.
+ * It can be either a folder or a package.
+ *
+ * If it is a folder, it will have the type property set to SdkType.folder.
+ * If it is a package, it will have the type property set to SdkType.package and the projectName and region properties set.
+ */
 export type SdkTypeMetadata = SdkTypeFolder | SdkTypePackage;
 
 /**

--- a/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
@@ -7,7 +7,12 @@ import {
     SdkGeneratorOutput,
     IndexModel,
 } from "../../models/genezioModels.js";
-import { nodeSdkJsRemoteNode, nodeSdkJsRemoteBrowser, nodeSdkJsRemoteGeneric, storageJs } from "../templates/nodeSdkJs.js";
+import {
+    nodeSdkJsRemoteNode,
+    nodeSdkJsRemoteBrowser,
+    nodeSdkJsRemoteGeneric,
+    storageJs,
+} from "../templates/nodeSdkJs.js";
 import Mustache from "mustache";
 
 const indexTemplate = `/**
@@ -121,11 +126,12 @@ class SdkGenerator implements SdkGeneratorInterface {
             if (classDefinition === undefined) {
                 continue;
             }
-            
-            const remoteImport = sdkGeneratorInput.sdkTypeMetadata.type === SdkType.package ?
-                `import { Remote } from "@genezio-sdk/${sdkGeneratorInput.sdkTypeMetadata.projectName}_${sdkGeneratorInput.sdkTypeMetadata.region}";` :
-                `import { Remote } from "./remote";`;
-            
+
+            const remoteImport =
+                sdkGeneratorInput.sdkTypeMetadata.type === SdkType.package
+                    ? `import { Remote } from "@genezio-sdk/${sdkGeneratorInput.sdkTypeMetadata.projectName}_${sdkGeneratorInput.sdkTypeMetadata.region}/remote";`
+                    : `import { Remote } from "./remote";`;
+
             const view: ViewType = {
                 remoteImport,
                 className: classDefinition.name,
@@ -204,12 +210,12 @@ class SdkGenerator implements SdkGeneratorInterface {
             // generate remote.js
             generateSdkOutput.files.push({
                 className: "Remote",
-                path: "remote.ts",
+                path: "remote.js",
                 data: nodeSdkJsRemoteBrowser.replace("%%%url%%%", "undefined"),
             });
             generateSdkOutput.files.push({
                 className: "Remote",
-                path: "remote.node.ts",
+                path: "remote.node.js",
                 data: nodeSdkJsRemoteNode.replace("%%%url%%%", "undefined"),
             });
         } else {

--- a/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/JsSdkGenerator.ts
@@ -1,4 +1,4 @@
-import { TriggerType } from "../../yamlProjectConfiguration/models.js";
+import { SdkType, TriggerType } from "../../yamlProjectConfiguration/models.js";
 import {
     SdkGeneratorInterface,
     ClassDefinition,
@@ -7,7 +7,7 @@ import {
     SdkGeneratorOutput,
     IndexModel,
 } from "../../models/genezioModels.js";
-import { nodeSdkJs, storageJs } from "../templates/nodeSdkJs.js";
+import { nodeSdkJsRemoteNode, nodeSdkJsRemoteBrowser, nodeSdkJsRemoteGeneric, storageJs } from "../templates/nodeSdkJs.js";
 import Mustache from "mustache";
 
 const indexTemplate = `/**
@@ -27,8 +27,7 @@ const template = `/**
 * if new genezio commands are executed.
 */
 
-import { Remote } from "./remote.js"
-
+{{{remoteImport}}}
 {{#hasGnzContext}}
 import { StorageManager } from "./storage.js"
 {{/hasGnzContext}}
@@ -85,6 +84,7 @@ type MethodViewType = {
 };
 
 type ViewType = {
+    remoteImport: string;
     className: string;
     _url: string;
     methods: MethodViewType[];
@@ -121,8 +121,13 @@ class SdkGenerator implements SdkGeneratorInterface {
             if (classDefinition === undefined) {
                 continue;
             }
-
+            
+            const remoteImport = sdkGeneratorInput.sdkTypeMetadata.type === SdkType.package ?
+                `import { Remote } from "@genezio-sdk/${sdkGeneratorInput.sdkTypeMetadata.projectName}_${sdkGeneratorInput.sdkTypeMetadata.region}";` :
+                `import { Remote } from "./remote";`;
+            
             const view: ViewType = {
+                remoteImport,
                 className: classDefinition.name,
                 _url: _url,
                 methods: [],
@@ -195,12 +200,26 @@ class SdkGenerator implements SdkGeneratorInterface {
             });
         }
 
-        // generate remote.js
-        generateSdkOutput.files.push({
-            className: "Remote",
-            path: "remote.js",
-            data: nodeSdkJs.replace("%%%url%%%", "undefined"),
-        });
+        if (sdkGeneratorInput.sdkTypeMetadata.type === SdkType.package) {
+            // generate remote.js
+            generateSdkOutput.files.push({
+                className: "Remote",
+                path: "remote.ts",
+                data: nodeSdkJsRemoteBrowser.replace("%%%url%%%", "undefined"),
+            });
+            generateSdkOutput.files.push({
+                className: "Remote",
+                path: "remote.node.ts",
+                data: nodeSdkJsRemoteNode.replace("%%%url%%%", "undefined"),
+            });
+        } else {
+            // generate remote.js
+            generateSdkOutput.files.push({
+                className: "Remote",
+                path: "remote.js",
+                data: nodeSdkJsRemoteGeneric.replace("%%%url%%%", "undefined"),
+            });
+        }
 
         generateSdkOutput.files.push({
             className: "StorageManager",

--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -23,7 +23,7 @@ import {
     SdkGeneratorClassesInfoInput,
 } from "../../models/genezioModels.js";
 import { TriggerType } from "../../yamlProjectConfiguration/models.js";
-import { nodeSdkTs, storageTs } from "../templates/nodeSdkTs.js";
+import { nodeSdkTsRemoteNode, nodeSdkTsRemoteBrowser, storageTs } from "../templates/nodeSdkTs.js";
 import path from "path";
 
 const TYPESCRIPT_RESERVED_WORDS = [
@@ -461,7 +461,12 @@ class SdkGenerator implements SdkGeneratorInterface {
         generateSdkOutput.files.push({
             className: "Remote",
             path: "remote.ts",
-            data: nodeSdkTs.replace("%%%url%%%", "undefined"),
+            data: nodeSdkTsRemoteBrowser.replace("%%%url%%%", "undefined"),
+        });
+        generateSdkOutput.files.push({
+            className: "Remote",
+            path: "remote.node.ts",
+            data: nodeSdkTsRemoteNode.replace("%%%url%%%", "undefined"),
         });
 
         generateSdkOutput.files.push({

--- a/src/generateSdk/templates/nodeSdkJs.ts
+++ b/src/generateSdk/templates/nodeSdkJs.ts
@@ -1,4 +1,4 @@
-export const nodeSdkJs = `/**
+export const nodeSdkJsRemoteGeneric = `/**
 * This is an auto generated code. This code should not be modified since the file can be overwritten
 * if new genezio commands are executed.
 */
@@ -105,6 +105,142 @@ export class Remote {
        } else {
            response = await makeRequestBrowser(requestContent, this.url);
        }
+
+       if (response.error) {
+           throw this.deserialize(response.error)
+       }
+
+       return response.result;
+   }
+}
+`;
+
+export const nodeSdkJsRemoteBrowser = `/**
+* This is an auto generated code. This code should not be modified since the file can be overwritten
+* if new genezio commands are executed.
+*/
+
+async function makeRequestBrowser(request, url) {
+   const response = await fetch(\`\${url}\`, {
+       method: 'POST',
+       headers: {
+           'Content-Type': 'application/json'
+       },
+       body: JSON.stringify(request),
+   });
+
+   if (!response.ok) {
+       return response.json().then((error) => Promise.reject(error));
+   }
+
+   return response.json();
+}
+
+
+/**
+* The class through which all request to the Genezio backend will be passed.
+*/
+export class Remote {
+   url = undefined;
+   agent = undefined;
+
+   constructor(url) {
+       this.url = url;
+   }
+
+   deserialize(s) {
+       const e = new Error(s.message);
+       e.stack = s.stack
+       e.info = s.info
+       e.code = s.code
+       return e
+   }
+
+   async call(method, ...args) {
+       const requestContent = {"jsonrpc": "2.0", "method": method, "params": args, "id": 3};
+       const response = await makeRequestBrowser(requestContent, this.url);
+
+       if (response.error) {
+           throw this.deserialize(response.error)
+       }
+
+       return response.result;
+   }
+}
+`;
+
+export const nodeSdkJsRemoteNode = `/**
+* This is an auto generated code. This code should not be modified since the file can be overwritten
+* if new genezio commands are executed.
+*/
+
+import * as http from 'http';
+import * as https from 'https';
+
+
+async function makeRequestNode(request, url, agent) {
+   const data = JSON.stringify(request);
+   const hostUrl = new URL(url);
+
+   const options = {
+       hostname: hostUrl.hostname,
+       path: hostUrl.search ? hostUrl.pathname + hostUrl.search : hostUrl.pathname,
+       port: hostUrl.port,
+       method: 'POST',
+       headers: {
+           'Content-Type': 'application/json',
+       },
+       agent: agent,
+   };
+   const client = url.includes('https') ? https : http;
+
+   return new Promise((resolve, reject) => {
+       const req = client.request(options, res => {
+           let body = '';
+
+           res.on('data', d => {
+               body += d
+           });
+           res.on('end', async function() {
+               const response = JSON.parse(body);
+               resolve(response);
+           });
+
+       });
+
+       req.on('error', error => {
+           reject(error);
+       });
+
+       req.write(data);
+       req.end();
+   });
+}
+
+/**
+* The class through which all request to the Genezio backend will be passed.
+*/
+export class Remote {
+   url = undefined;
+   agent = undefined;
+
+   constructor(url) {
+       this.url = url;
+       const client = url.includes("https") ? https : http;
+       this.agent = new client.Agent({ keepAlive: true });
+   }
+
+   deserialize(s) {
+       const e = new Error(s.message);
+       e.stack = s.stack
+       e.info = s.info
+       e.code = s.code
+       return e
+   }
+
+   async call(method, ...args) {
+       const requestContent = {"jsonrpc": "2.0", "method": method, "params": args, "id": 3};
+       const response = await makeRequestNode(requestContent, this.url, this.agent);
 
        if (response.error) {
            throw this.deserialize(response.error)

--- a/src/generateSdk/templates/nodeSdkTs.ts
+++ b/src/generateSdk/templates/nodeSdkTs.ts
@@ -1,3 +1,122 @@
+export const nodeSdkTsRemoteGeneric = `/**
+* This is an auto generated code. This code should not be modified since the file can be overwritten
+* if new genezio commands are executed.
+*/
+
+let http: any = null;
+let https: any = null;
+let importDone: boolean = false;
+
+async function importModules() {
+    if (typeof process !== "undefined" && process.versions != null && process.versions.node != null) {
+        http = await import("http");
+        https = await import("https");
+    }
+    importDone = true;
+}
+
+async function makeRequestBrowser(request: any, url: any) {
+    // @ts-ignore
+    const response = await fetch(\`\${url}\`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        return response.json().then((error) => Promise.reject(error));
+    }
+
+    return response.json();
+}
+
+async function makeRequestNode(request: any, url: any, agent: any) {
+
+    const data = JSON.stringify(request);
+    const hostUrl = new URL(url);
+
+    const options = {
+        hostname: hostUrl.hostname,
+        path: hostUrl.search ? hostUrl.pathname + hostUrl.search : hostUrl.pathname,
+        port: hostUrl.port,
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        agent: agent,
+    };
+    const client = url.includes('https') ? https : http;
+
+    return new Promise((resolve, reject) => {
+        const req = client.request(options, (res: any)=> {
+            let body = '';
+
+            res.on('data', (d: any) => {
+                body += d
+            });
+            res.on('end', async function() {
+                const response = JSON.parse(body);
+                resolve(response);
+            });
+
+        });
+
+        req.on('error', (error: any) => {
+            reject(error);
+        });
+
+        req.write(data);
+        req.end();
+    });
+}
+
+/**
+ * The class through which all request to the Genezio backend will be passed.
+ *
+ */
+ export class Remote {
+    url: any = undefined;
+    agent: any = undefined;
+
+    constructor(url: any) {
+        this.url = url;
+        if (http !== null && https !== null) {
+            const client = url.includes("https") ? https : http;
+            this.agent = new client.Agent({ keepAlive: true });
+        }
+    }
+
+     deserialize(s: any) {
+        const e: any = new Error(s.message);
+        e.stack = s.stack
+        e.info = s.info
+        e.code = s.code
+        return e
+    }
+
+    async call(method: any, ...args: any[]) {
+        const requestContent = {"jsonrpc": "2.0", "method": method, "params": args, "id": 3};
+        let response: any = undefined;
+        if (!importDone) {
+            await importModules();
+        }
+
+        if (http !== null && https !== null) {
+            response = await makeRequestNode(requestContent, this.url, this.agent);
+        } else {
+            response = await makeRequestBrowser(requestContent, this.url);
+        }
+
+        if (response.error) {
+            throw this.deserialize(response.error);
+        }
+
+        return response.result;
+    }
+}
+`;
 export const nodeSdkTsRemoteBrowser = `/**
 * This is an auto generated code. This code should not be modified since the file can be overwritten
 * if new genezio commands are executed.

--- a/src/generateSdk/templates/packageJson.ts
+++ b/src/generateSdk/templates/packageJson.ts
@@ -44,16 +44,15 @@ export const getNodeModulePackageJsonLocal = (projectName: string, region: strin
   "exports": {
     "./remote": {
       "browser": {
-        "require": "./remote.browser.js",
-        "import": "./remote.browser.js",
-        "default": "./index.js"
+        "require": "./cjs/remote.browser.js",
+        "import": "./esm/remote.browser.js"
       },
       "default": {
-        "require": "./remote.node.js",
-        "import": "./remote.node.js",
-        "default": "./index.js"
+        "require": "./cjs/remote.node.js",
+        "import": "./esm/remote.node.js"
       }
-    },
+    }
+  },
   "description": "",
   "main": "./cjs/index.js",
   "module": "./esm/index.js"
@@ -70,14 +69,12 @@ export const getNodeModulePackageJson = (
   "exports": {
     "./remote": {
       "browser": {
-        "require": "./remote.browser.js",
-        "import": "./remote.browser.js",
-        "default": "./index.js"
+        "require": "./cjs/remote.browser.js",
+        "import": "./esm/remote.browser.js"
       },
       "default": {
-        "require": "./remote.node.js",
-        "import": "./remote.node.js",
-        "default": "./index.js"
+        "require": "./cjs/remote.node.js",
+        "import": "./esm/remote.node.js"
       }
     }
   },

--- a/src/generateSdk/templates/packageJson.ts
+++ b/src/generateSdk/templates/packageJson.ts
@@ -41,6 +41,19 @@ export const getPackageJsonSdkGenerator = (
 export const getNodeModulePackageJsonLocal = (projectName: string, region: string): string => `{
   "name": "@genezio-sdk/${projectName}_${region}",
   "version": "${getRandomSemVer()}",
+  "exports": {
+    "./remote": {
+      "browser": {
+        "require": "./remote.browser.js",
+        "import": "./remote.browser.js",
+        "default": "./index.js"
+      },
+      "default": {
+        "require": "./remote.node.js",
+        "import": "./remote.node.js",
+        "default": "./index.js"
+      }
+    },
   "description": "",
   "main": "./cjs/index.js",
   "module": "./esm/index.js"
@@ -54,6 +67,20 @@ export const getNodeModulePackageJson = (
 ): string => `{
   "name": "@genezio-sdk/${projectName}_${region}",
   "version": "1.0.0-${stage}",
+  "exports": {
+    "./remote": {
+      "browser": {
+        "require": "./remote.browser.js",
+        "import": "./remote.browser.js",
+        "default": "./index.js"
+      },
+      "default": {
+        "require": "./remote.node.js",
+        "import": "./remote.node.js",
+        "default": "./index.js"
+      }
+    }
+  },
   "description": "",
   "main": "./cjs/index.js",
   "module": "./esm/index.js"

--- a/src/generateSdk/templates/packageJson.ts
+++ b/src/generateSdk/templates/packageJson.ts
@@ -48,8 +48,8 @@ export const getNodeModulePackageJsonLocal = (projectName: string, region: strin
     },
     "./remote": {
       "browser": {
-        "require": "./cjs/remote.browser.js",
-        "import": "./esm/remote.browser.js"
+        "require": "./cjs/remote.js",
+        "import": "./esm/remote.js"
       },
       "default": {
         "require": "./cjs/remote.node.js",
@@ -77,8 +77,8 @@ export const getNodeModulePackageJson = (
     },
     "./remote": {
       "browser": {
-        "require": "./cjs/remote.browser.js",
-        "import": "./esm/remote.browser.js"
+        "require": "./cjs/remote.js",
+        "import": "./esm/remote.js"
       },
       "default": {
         "require": "./cjs/remote.node.js",

--- a/src/generateSdk/templates/packageJson.ts
+++ b/src/generateSdk/templates/packageJson.ts
@@ -42,6 +42,10 @@ export const getNodeModulePackageJsonLocal = (projectName: string, region: strin
   "name": "@genezio-sdk/${projectName}_${region}",
   "version": "${getRandomSemVer()}",
   "exports": {
+    ".": {
+      "require": "./cjs/index.js",
+      "import": "./esm/index.js"
+    },
     "./remote": {
       "browser": {
         "require": "./cjs/remote.browser.js",
@@ -67,6 +71,10 @@ export const getNodeModulePackageJson = (
   "name": "@genezio-sdk/${projectName}_${region}",
   "version": "1.0.0-${stage}",
   "exports": {
+    ".": {
+      "require": "./cjs/index.js",
+      "import": "./esm/index.js"
+    },
     "./remote": {
       "browser": {
         "require": "./cjs/remote.browser.js",

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -65,7 +65,6 @@ export async function compileSdk(
         outDir: path.resolve(sdkPath, outDir, "cjs"),
         module: ts.ModuleKind.CommonJS,
         rootDir: sdkPath,
-        include: "*.ts",
         allowJs: true,
         declaration: true,
     };
@@ -80,7 +79,6 @@ export async function compileSdk(
         outDir: path.resolve(sdkPath, outDir, "esm"),
         module: ts.ModuleKind.ESNext,
         rootDir: sdkPath,
-        include: "*.ts",
         allowJs: true,
         declaration: true,
     };

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -55,6 +55,7 @@ export async function compileSdk(
         outDir: path.resolve(sdkPath, outDir, "cjs"),
         module: ts.ModuleKind.CommonJS,
         rootDir: sdkPath,
+        include: "*.ts",
         allowJs: true,
         declaration: true,
     };
@@ -69,6 +70,7 @@ export async function compileSdk(
         outDir: path.resolve(sdkPath, outDir, "esm"),
         module: ts.ModuleKind.ESNext,
         rootDir: sdkPath,
+        include: "*.ts",
         allowJs: true,
         declaration: true,
     };

--- a/src/models/genezioModels.ts
+++ b/src/models/genezioModels.ts
@@ -1,3 +1,4 @@
+import { SdkTypeMetadata } from "../generateSdk/generateSdkApi.js";
 import { TriggerType } from "../yamlProjectConfiguration/models.js";
 
 export enum GenezioCommandTemplates {
@@ -337,6 +338,7 @@ export type SdkGeneratorClassesInfoInput = {
 };
 
 export type SdkGeneratorInput = {
+    sdkTypeMetadata: SdkTypeMetadata;
     classesInfo: SdkGeneratorClassesInfoInput[];
     sdk?: {
         language: string;

--- a/src/utils/listFilesWithExtension.ts
+++ b/src/utils/listFilesWithExtension.ts
@@ -1,0 +1,15 @@
+import { promises as fs, Dirent } from "fs";
+import path from "path";
+
+export function listFilesWithExtension(
+    folderPath: string,
+    fileExtension: string,
+): Promise<string[]> {
+    return fs.readdir(folderPath, { withFileTypes: true }).then((dirents: Dirent[]) => {
+        return dirents
+            .filter(
+                (dirent: Dirent) => dirent.isFile() && path.extname(dirent.name) === fileExtension,
+            )
+            .map((dirent: Dirent) => path.join(folderPath, dirent.name));
+    });
+}

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -41,5 +41,5 @@ export async function writeSdkToDisk(sdk: SdkGeneratorResponse, outputPath: stri
             return writeToFile(outputPath, file.path, file.data, true);
         }),
     );
-    debugLogger.debug("The SDK was successfully written to files!!!!");
+    debugLogger.debug("The SDK was successfully written to files.");
 }

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -35,7 +35,7 @@ export async function writeSdkToDisk(sdk: SdkGeneratorResponse, outputPath: stri
         return;
     }
 
-    debugLogger.debug("Writing the SDK to files...");
+    debugLogger.debug("Writing the SDK to files...", outputPath);
     await Promise.all(
         sdk.files.map((file: File) => {
             return writeToFile(outputPath, file.path, file.data, true);

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -41,5 +41,5 @@ export async function writeSdkToDisk(sdk: SdkGeneratorResponse, outputPath: stri
             return writeToFile(outputPath, file.path, file.data, true);
         }),
     );
-    debugLogger.debug("The SDK was successfully written to files.");
+    debugLogger.debug("The SDK was successfully written to files!!!!");
 }

--- a/src/yamlProjectConfiguration/models.ts
+++ b/src/yamlProjectConfiguration/models.ts
@@ -16,4 +16,5 @@ export enum TriggerType {
 
 export enum SdkType {
     folder = "folder",
+    package = "package",
 }


### PR DESCRIPTION
# Pull Request Template

## Type of change

-   [x] 🧑‍💻 Improvement

## Description

We had problems with the fact that the SDK can be used both in NodeJS and Web Browser environments. To solve this, we were using some conditional checks and dynamic imports to determine if we should import `http` `https` or if we should use the `fetch` API.

This PR takes advantage of the conditional import mecanism supported by node and bundlers. We have two implementations for the `remote.js` file: one for NodeJS envs and one for browser.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
