### PR TITLE
Add a mechanism that lets us read either the original config or one filled with default values

### DIFF
--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -4,7 +4,6 @@ import { exit } from "process";
 import { languages } from "../utils/languages.js";
 import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
 import { Language, TriggerType } from "../yamlProjectConfiguration/models.js";
-import { YamlProjectConfiguration } from "../yamlProjectConfiguration/v2.js";
 import { getProjectEnvFromProject } from "../requests/getProjectInfo.js";
 import listProjects from "../requests/listProjects.js";
 import { scanClassesForDecorators } from "../utils/configuration.js";
@@ -145,7 +144,7 @@ export async function generateRemoteSdkCommand(projectName: string, options: Gen
         if (!config.endsWith("genezio.yaml")) {
             config = path.join(config, "genezio.yaml");
         }
-        let configuration: YamlProjectConfiguration | undefined;
+        let configuration;
         const yamlIOController = new YamlConfigurationIOController(config);
         try {
             configuration = await yamlIOController.read();

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -292,7 +292,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
                 },
             ]);
 
-            const yamlConfig = await yamlConfigIOController.read();
+            const yamlConfig = await yamlConfigIOController.read(/* fillDefaults= */ false);
             yamlConfig.backend!.language.packageManager = optionalPackageManager["packageManager"];
             await yamlConfigIOController.write(yamlConfig);
         }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,66 @@
+/**
+ * DeepRequired is a utility type that makes specified nested properties required in a defined type.
+ *
+ * @example
+ * type Example = {
+ *     a?: {
+ *         b?: {
+ *             c?: string;
+ *         };
+ *     };
+ *     d?: number;
+ * };
+ *
+ * type Result = DeepRequired<Example, 'a.b' | 'd'>;
+ *
+ * // Result is equal to:
+ * // {
+ * //    a?: {
+ * //       b: {
+ * //          c?: string;
+ * //       };
+ * //    };
+ * //    d: number;
+ * // }
+ *
+ * @template T - The type to make the specified nested properties required.
+ * @template K - A string that represents the path to the nested property to make required, separated by `.`
+ * @returns The type with the specified nested properties required.
+ */
+export type DeepRequired<T extends object, K extends NestedKeyOf<T>> = UnionToIntersection<
+    RequiredUnion<T, K> | T
+>;
+
+type UnionToIntersection<U> = (U extends U ? (arg: U) => void : never) extends (
+    arg: infer I,
+) => void
+    ? I
+    : never;
+
+/*
+ * Dark magic code
+ *
+ * Increase the counter if you had to modify this code: 1
+ */
+type RequiredUnion<
+    T,
+    K extends string,
+> = K extends `${infer KFirst extends Extract<keyof NonNullable<T>, string>}.${infer KRest extends string}`
+    ? {
+          [Key in KFirst]: Key extends keyof NonNullable<T>
+              ? undefined extends NonNullable<T>[Key]
+                  ? RequiredUnion<NonNullable<T>[Key], KRest> | undefined
+                  : RequiredUnion<NonNullable<T>[Key], KRest>
+              : never;
+      }
+    : K extends keyof NonNullable<T>
+      ? undefined extends T
+          ? { [Key in K]: NonNullable<NonNullable<T>[Key]> } | undefined
+          : { [Key in K]: NonNullable<NonNullable<T>[Key]> }
+      : never;
+
+type NestedKeyOf<T extends object> = {
+    [P in keyof T & (string | number)]: NonNullable<T[P]> extends object
+        ? `${P}` | `${P}.${NestedKeyOf<NonNullable<T[P]>>}`
+        : `${P}`;
+}[keyof T & (string | number)];

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -12,8 +12,9 @@ import { TriggerType } from "./models.js";
 import { isValidCron } from "cron-validator";
 import { tryV2Migration } from "./migration.js";
 import yaml from "yaml";
+import { DeepRequired } from "../utils/types.js";
 
-export type YamlProjectConfiguration = ReturnType<typeof parseGenezioConfig>;
+export type RawYamlProjectConfiguration = ReturnType<typeof parseGenezioConfig>;
 export type YAMLBackend = NonNullable<YamlProjectConfiguration["backend"]>;
 export type YamlClass = NonNullable<YAMLBackend["classes"]>[number];
 export type YamlMethod = NonNullable<YamlClass["methods"]>[number];
@@ -22,11 +23,13 @@ export type YamlFrontend = Exclude<
     Array<unknown>
 >;
 
+export type YamlProjectConfiguration = ReturnType<typeof fillDefaultGenezioConfig>;
+
 function parseGenezioConfig(config: unknown) {
     const languageSchema = zod.object({
         name: zod.nativeEnum(Language),
-        runtime: zod.enum(supportedNodeRuntimes).default("nodejs16.x"),
-        packageManager: zod.nativeEnum(PackageManagerType).default(PackageManagerType.npm),
+        runtime: zod.enum(supportedNodeRuntimes).optional(),
+        packageManager: zod.nativeEnum(PackageManagerType).optional(),
     });
 
     const scriptSchema = zod.array(zod.string()).or(zod.string()).optional();
@@ -94,11 +97,11 @@ function parseGenezioConfig(config: unknown) {
                     return { message: ctx.defaultError };
                 },
             })
-            .default(CloudProviderIdentifier.GENEZIO),
+            .optional(),
         classes: zod.array(classSchema).optional(),
         sdk: zod
             .object({
-                type: zod.nativeEnum(SdkType),
+                type: zod.nativeEnum(SdkType).optional(),
                 path: zod.string(),
                 language: zod.nativeEnum(Language),
             })
@@ -124,7 +127,7 @@ function parseGenezioConfig(config: unknown) {
             const nameRegex = new RegExp("^[a-zA-Z][-a-zA-Z0-9]*$");
             return nameRegex.test(value);
         }, "Must start with a letter and contain only letters, numbers and dashes."),
-        region: zod.enum(regions.map((r) => r.value) as [string, ...string[]]).default("us-east-1"),
+        region: zod.enum(regions.map((r) => r.value) as [string, ...string[]]).optional(),
         yamlVersion: zod.number(),
         backend: backendSchema.optional(),
         frontend: zod.array(frontendSchema).or(frontendSchema).optional(),
@@ -133,9 +136,34 @@ function parseGenezioConfig(config: unknown) {
     return v2Schema.parse(config);
 }
 
+function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
+    const defaultConfig = structuredClone(config);
+
+    defaultConfig.region ??= "us-east-1";
+
+    if (defaultConfig.backend) {
+        switch (defaultConfig.backend.language.name) {
+            case Language.ts:
+            case Language.js:
+                defaultConfig.backend.language.packageManager ??= PackageManagerType.npm;
+                defaultConfig.backend.language.runtime ??= "nodejs18.x";
+        }
+
+        defaultConfig.backend.cloudProvider ??= CloudProviderIdentifier.GENEZIO;
+    }
+
+    return defaultConfig as DeepRequired<
+        RawYamlProjectConfiguration,
+        | "region"
+        | "backend.language.packageManager"
+        | "backend.language.runtime"
+        | "backend.cloudProvider"
+    >;
+}
+
 export class YamlConfigurationIOController {
     private ctx: YAMLContext | undefined = undefined;
-    private cachedConfig: YamlProjectConfiguration | undefined = undefined;
+    private cachedConfig: RawYamlProjectConfiguration | undefined = undefined;
     private latestRead: Date | undefined = undefined;
 
     constructor(
@@ -143,7 +171,35 @@ export class YamlConfigurationIOController {
         private fs: typeof nativeFs | IFs = nativeFs,
     ) {}
 
-    async read(cache: boolean = true) {
+    /**
+     * Reads the YAML project configuration from the file.
+     *
+     * @param fillDefaults - Whether to fill default values in the configuration. Default is true.
+     * Set it to false if you want to read the real configuration just to write it back slightly modified.
+     * This way you can avoid saving the default values in the file.
+     * @param cache - Whether to cache the configuration. Default is true. Subsequent reads will not
+     * impact performance if the configuration is not externaly changed. The cache is invalidated when
+     * the file is externally modified.
+     * @returns A Promise that resolves to the parsed YAML project configuration.
+     */
+    async read(fillDefaults?: true, cache?: boolean): Promise<YamlProjectConfiguration>;
+    /**
+     * Reads the YAML project configuration from the file.
+     *
+     * @param fillDefaults - Whether to fill default values in the configuration. Default is true.
+     * Set it to false if you want to read the real configuration just to write it back slightly modified.
+     * This way you can avoid saving the default values in the file.
+     * @param cache - Whether to cache the configuration. Default is true. Subsequent reads will not
+     * impact performance if the configuration is not externaly changed. The cache is invalidated when
+     * the file is externally modified.
+     * @returns A Promise that resolves to the parsed YAML project configuration.
+     */
+    async read(fillDefaults?: false, cache?: boolean): Promise<RawYamlProjectConfiguration>;
+
+    async read(
+        fillDefaults: boolean = true,
+        cache: boolean = true,
+    ): Promise<YamlProjectConfiguration | RawYamlProjectConfiguration> {
         const lastModified = this.fs.statSync(this.filePath).mtime;
         if (this.cachedConfig && cache && this.latestRead && this.latestRead >= lastModified) {
             return structuredClone(this.cachedConfig);
@@ -153,7 +209,7 @@ export class YamlConfigurationIOController {
         this.latestRead = lastModified;
 
         const [rawConfig, ctx] = parseYaml(fileContent);
-        let genezioConfig: YamlProjectConfiguration;
+        let genezioConfig: RawYamlProjectConfiguration;
         try {
             genezioConfig = parseGenezioConfig(rawConfig);
         } catch (e) {
@@ -178,10 +234,15 @@ export class YamlConfigurationIOController {
         this.ctx = ctx;
         this.cachedConfig = structuredClone(genezioConfig);
 
+        // Fill default values
+        if (fillDefaults) {
+            return fillDefaultGenezioConfig(genezioConfig);
+        }
+
         return genezioConfig;
     }
 
-    async write(data: YamlProjectConfiguration) {
+    async write(data: RawYamlProjectConfiguration) {
         await this.fs.promises.writeFile(this.filePath, stringifyYaml(data, this.ctx));
         this.latestRead = new Date();
         this.cachedConfig = structuredClone(data);


### PR DESCRIPTION
## Type of change
-   [x] 🍕 New feature

## Description

We have 2 use-cases when interacting with the genezio.yaml config:
- Reading it for consuming the information

  In this case we want the configuration to be filled with default
  values if the user does not provide values for optional fields.

  Example: If region is not specified, it should default to `us-east-1`

- Reading the file just to modify one field and the write it back

  In this case we do want to read the original configuration (with no
  default filled values) so that we don't modify the user configuration
  entierly, only the necessary fields.

  Example:
  ```yaml
  name: foo
  frontend:
      path: .
  ```

  We want to write the `subdomain` field to `frontend`. If we use
  the normal `read()`, some values will be defaulted (region for example)

  `read()`:
  ```diff
    name: foo
  + region: us-east-1
    frontend:
      path: .
  +   subdomain: bar
  ```

  `read(/* fillDefaults= */ false)`:
  ```diff
    name: foo
    frontend:
      path: .
  +   subdomain: bar
  ```

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
