### PR TITLE
Set nodejs20.x as default for deploying js/ts projects.

### DIFF
--- a/src/cloudAdapter/aws/selfHostedAwsAdapter.ts
+++ b/src/cloudAdapter/aws/selfHostedAwsAdapter.ts
@@ -38,6 +38,7 @@ import {
 } from "./cloudFormationBuilder.js";
 import mime from "mime-types";
 import path from "path";
+import { DEFAULT_NODE_RUNTIME } from "../../models/nodeRuntime.js";
 
 const BUNDLE_SIZE_LIMIT = 256901120;
 
@@ -128,7 +129,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
         switch (language) {
             case ".js":
             case ".ts":
-                return "nodejs14.x";
+                return DEFAULT_NODE_RUNTIME;
             case ".dart":
                 return "provided.al2";
             default:

--- a/src/models/nodeRuntime.ts
+++ b/src/models/nodeRuntime.ts
@@ -1,7 +1,7 @@
-export type NodeRuntime = "nodejs16.x" | "nodejs18.x";
-export const NODEJS_MAJOR_VERSIONS = ["16", "18"];
-export const DEFAULT_NODE_RUNTIME: NodeRuntime = "nodejs16.x";
+export type NodeRuntime = "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
+export const NODEJS_MAJOR_VERSIONS = ["16", "18", "20"];
+export const DEFAULT_NODE_RUNTIME: NodeRuntime = "nodejs20.x";
 export type NodeOptions = {
     nodeRuntime: NodeRuntime;
 };
-export const supportedNodeRuntimes = ["nodejs16.x", "nodejs18.x"] as const;
+export const supportedNodeRuntimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x"] as const;

--- a/src/models/nodeRuntime.ts
+++ b/src/models/nodeRuntime.ts
@@ -1,5 +1,4 @@
 export type NodeRuntime = "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
-export const NODEJS_MAJOR_VERSIONS = ["16", "18", "20"];
 export const DEFAULT_NODE_RUNTIME: NodeRuntime = "nodejs20.x";
 export type NodeOptions = {
     nodeRuntime: NodeRuntime;

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -5,7 +5,7 @@ import { IFs } from "memfs";
 import { regions } from "../utils/configs.js";
 import { zodFormatError } from "../errors.js";
 import { Language, SdkType } from "./models.js";
-import { supportedNodeRuntimes } from "../models/nodeRuntime.js";
+import { DEFAULT_NODE_RUNTIME, supportedNodeRuntimes } from "../models/nodeRuntime.js";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
 import { PackageManagerType } from "../packageManagers/packageManager.js";
 import { TriggerType } from "./models.js";
@@ -146,7 +146,7 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
             case Language.ts:
             case Language.js:
                 defaultConfig.backend.language.packageManager ??= PackageManagerType.npm;
-                defaultConfig.backend.language.runtime ??= "nodejs18.x";
+                defaultConfig.backend.language.runtime ??= DEFAULT_NODE_RUNTIME;
         }
 
         defaultConfig.backend.cloudProvider ??= CloudProviderIdentifier.GENEZIO;


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement
-   [x] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

We support `nodejs20x` as default for deploying on AWS Lambda.

The user is still able to set other runtime versions using the configuration yaml file via `nodeRuntime: nodejs18.x` field.
If the `nodeRuntime` is not set by the user, we are using nodejs20 by default.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] I have updated the documentation;
-   [x] New and existing unit tests pass locally with my changes;
