### PR TITLE
Check @genezio/types version only for typescript and javascript backends

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -71,20 +71,21 @@ export async function deployCommand(options: GenezioDeployOptions) {
     // because we migrated the decorators implemented in the @genezio/types package to the stage 3 implementation.
     // Otherwise, the user will get an error at runtime. This check can be removed in the future once no one is using version
     // 0.1.* of @genezio/types.
-    const packageJsonPath = path.join(backendCwd, "package.json");
-    if (
-        isDependencyVersionCompatible(
-            packageJsonPath,
-            "@genezio/types",
-            REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
-        ) === false
-    ) {
-        log.error(
-            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
-        );
-        exit(1);
+    if (configuration.backend?.language.name === Language.ts || configuration.backend?.language.name === Language.js) {
+        const packageJsonPath = path.join(backendCwd, "package.json");
+        if (
+            isDependencyVersionCompatible(
+                packageJsonPath,
+                "@genezio/types",
+                REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
+            ) === false
+        ) {
+            log.error(
+                `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
+            );
+            exit(1);
+        }
     }
-
     // TODO: check this in deployClasses function
     //
     // // check if user is logged in
@@ -419,7 +420,7 @@ export async function deployClasses(
         await compileSdk(path.join(localPath, "sdk"), packageJson, backend.language.name, true);
     }
 
-    let isMonoRepo = configuration.backend && configuration.frontend ? true : false;
+    const isMonoRepo = configuration.backend && configuration.frontend ? true : false;
     reportSuccess(
         result.classes,
         sdkResponse,

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -216,20 +216,21 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
     // because we migrated the decorators implemented in the @genezio/types package to the stage 3 implementation.
     // Otherwise, the user will get an error at runtime. This check can be removed in the future once no one is using version
     // 0.1.* of @genezio/types.
-    const packageJsonPath = path.join(backendConfiguration.path, "package.json");
-    if (
-        isDependencyVersionCompatible(
-            packageJsonPath,
-            "@genezio/types",
-            REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
-        ) === false
-    ) {
-        log.error(
-            `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
-        );
-        exit(1);
+    if (backendConfiguration.language.name === Language.ts || backendConfiguration.language.name === Language.js) {
+        const packageJsonPath = path.join(backendConfiguration.path, "package.json");
+        if (
+            isDependencyVersionCompatible(
+                packageJsonPath,
+                "@genezio/types",
+                REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
+            ) === false
+        ) {
+            log.error(
+                `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
+            );
+            exit(1);
+        }
     }
-
     const success = await doAdaptiveLogAction("Running backend local scripts", async () => {
         return await runScript(backendConfiguration.scripts?.local, backendConfiguration.path);
     });


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR makes sure that we are checking `@genezio/types` version only for `js`/`ts` backends.
For other languages, this check makes no sense and it also yields an error on `genezio deploy` or `genezio local`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
