### PR TITLE
When filling default vaules, convert `frontend` field to always have an array type

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -186,9 +186,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
 
     const frontendUrls = [];
     if (configuration.frontend && !options.backend) {
-        const frontends = Array.isArray(configuration.frontend)
-            ? configuration.frontend
-            : [configuration.frontend];
+        const frontends = configuration.frontend;
 
         for (const [index, frontend] of frontends.entries()) {
             const success = await doAdaptiveLogAction(

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -107,10 +107,8 @@ export async function prepareLocalBackendEnvironment(
         const backend = yamlProjectConfiguration.backend;
         const frontend = yamlProjectConfiguration.frontend;
         let sdkLanguage: Language = Language.ts;
-        if (frontend && Array.isArray(frontend)) {
+        if (frontend && frontend.length > 0) {
             sdkLanguage = frontend[0].language;
-        } else if (frontend) {
-            sdkLanguage = frontend.language;
         }
         if (!backend) {
             throw new Error("No backend component found in the genezio.yaml file.");
@@ -206,10 +204,8 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
     }
     const frontend = yamlProjectConfiguration.frontend;
     let sdkLanguage: Language = Language.ts;
-    if (frontend && Array.isArray(frontend)) {
+    if (frontend && frontend.length > 0) {
         sdkLanguage = frontend[0].language;
-    } else if (frontend) {
-        sdkLanguage = frontend.language;
     }
 
     // We need to check if the user is using an older version of @genezio/types
@@ -433,9 +429,6 @@ async function watchNodeModules(
     const sdkName = `${yamlProjectConfiguration.name}_${yamlProjectConfiguration.region}`;
     const nodeModulesSdkDirectoryPath = path.join("node_modules", "@genezio-sdk", sdkName);
 
-    if (yamlProjectConfiguration.frontend && !Array.isArray(yamlProjectConfiguration.frontend)) {
-        yamlProjectConfiguration.frontend = [yamlProjectConfiguration.frontend];
-    }
     const frontends = yamlProjectConfiguration.frontend || [];
     for (const f of frontends) {
         watchPaths.push(path.join(f.path, nodeModulesSdkDirectoryPath));
@@ -499,9 +492,6 @@ async function writeSdkToNodeModules(
         await fsExtra.copy(from, toFinal, { overwrite: true });
     };
 
-    if (yamlProjectConfiguration.frontend && !Array.isArray(yamlProjectConfiguration.frontend)) {
-        yamlProjectConfiguration.frontend = [yamlProjectConfiguration.frontend];
-    }
     const from = path.resolve(originSdkPath, "..", "genezio-sdk");
 
     // Write the SDK to the node_modules folder of each frontend

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -18,10 +18,7 @@ export type RawYamlProjectConfiguration = ReturnType<typeof parseGenezioConfig>;
 export type YAMLBackend = NonNullable<YamlProjectConfiguration["backend"]>;
 export type YamlClass = NonNullable<YAMLBackend["classes"]>[number];
 export type YamlMethod = NonNullable<YamlClass["methods"]>[number];
-export type YamlFrontend = Exclude<
-    NonNullable<YamlProjectConfiguration["frontend"]>,
-    Array<unknown>
->;
+export type YamlFrontend = NonNullable<YamlProjectConfiguration["frontend"]>[number];
 
 export type YamlProjectConfiguration = ReturnType<typeof fillDefaultGenezioConfig>;
 
@@ -152,13 +149,19 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
         defaultConfig.backend.cloudProvider ??= CloudProviderIdentifier.GENEZIO;
     }
 
+    if (defaultConfig.frontend && !Array.isArray(defaultConfig.frontend)) {
+        defaultConfig.frontend = [defaultConfig.frontend];
+    }
+
     return defaultConfig as DeepRequired<
-        RawYamlProjectConfiguration,
+        typeof defaultConfig,
         | "region"
         | "backend.language.packageManager"
         | "backend.language.runtime"
         | "backend.cloudProvider"
-    >;
+    > & {
+        frontend: typeof defaultConfig.frontend;
+    };
 }
 
 export class YamlConfigurationIOController {


### PR DESCRIPTION

## Type of change

-   [x] 🧑‍💻 Improvement

## Description

This helps us because we don't need to check the type every time we want to access the `frontend` field.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
