### PR TITLE
Create a new axios instance to do ab testing without throwing errors

### DIFF
--- a/src/utils/abTesting.ts
+++ b/src/utils/abTesting.ts
@@ -1,11 +1,36 @@
+import axios, { AxiosResponse } from "axios";
+import version from "../utils/version.js";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
-import getProjectInfoByName from "../requests/getProjectInfoByName.js";
+import { ProjectDetails, StatusOk } from "../requests/models.js";
+import { getAuthToken } from "./accounts.js";
+import { BACKEND_ENDPOINT } from "../constants.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
 
 // This function is used to check if the project is already deployed.
+// Do not reuse this method in the future, this is only used for AB testing and it will be removed soon.
 export async function isProjectDeployed(name: string, region: string): Promise<boolean> {
     try {
-        const projectInfo = await getProjectInfoByName(name, region);
-        if (projectInfo) {
+        // Sending an axios request without the interceptor to silently fail if the project is not found.
+        const uninterceptedAxiosInstance = axios.create();
+        const authToken = await getAuthToken();
+
+        if (!authToken) {
+            throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+        }
+
+        const response: AxiosResponse<StatusOk<{ project: ProjectDetails }>> =
+            await uninterceptedAxiosInstance({
+                method: "GET",
+                url: `${BACKEND_ENDPOINT}/projects/name/${name}`,
+                params: {
+                    region: region,
+                },
+                headers: {
+                    Authorization: `Bearer ${authToken}`,
+                    "Accept-Version": `genezio-cli/${version}`,
+                },
+            });
+        if (response.data.project) {
             return true;
         }
     } catch (error) {


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

The AB Testing PR introduced a verbose error when the project was not found.
This behaviour is expected for projects that were not yet deployed at all. Hence, I want to fail silently.

To do that I created a new axios instance that does not use an interceptor. Unfortunately the code is mostly duplicated in the AB testing method, but this part of the codebase will be deleted after the ab testing is concluded.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
