### PR TITLE
Fix node runtime warning

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -398,6 +398,13 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
             await writeSdkToDisk(sdk, sdkConfiguration.path);
         }
 
+        // This check makes sense only for js/ts backend, skip for dart, go etc.
+        if (
+            backendConfiguration.language.name === Language.ts ||
+            backendConfiguration.language.name === Language.js
+        ) {
+            reportDifferentNodeRuntime(projectConfiguration.options?.nodeRuntime);
+        }
         reportSuccess(projectConfiguration, sdk, options.port, !backendConfiguration.sdk);
 
         // Start listening for changes in user's code
@@ -966,34 +973,6 @@ function reportSuccess(
         functionUrl: `http://127.0.0.1:${port}/${c.name}`,
     }));
 
-    // get installed version of node
-    const nodeVersion = process.version;
-
-    // get only the major version
-    const nodeMajorVersion = nodeVersion.split(".")[0].slice(1);
-
-    // get server used version
-    let serverRuntime: string = DEFAULT_NODE_RUNTIME as string;
-    if (projectConfiguration.options?.nodeRuntime) {
-        serverRuntime = projectConfiguration.options.nodeRuntime;
-    }
-
-    const serverVersion = serverRuntime.split(".")[0].split("nodejs")[1];
-
-    debugLogger.debug(`Node version: ${nodeVersion}`);
-    debugLogger.debug(`Server version: ${serverRuntime}`);
-
-    // check if server version is different from installed version
-    if (nodeMajorVersion !== serverVersion) {
-        log.warn(
-            `${colors.yellow(`Warning: You are using node version ${nodeVersion} but your server is configured to use ${serverRuntime}. This might cause unexpected behavior.
-To change the server version, go to your ${colors.cyan(
-                "genezio.yaml",
-            )} file and change the ${colors.cyan(
-                "backend.lanuage.nodeRuntime",
-            )} property to the version you want to use.`)}`,
-        );
-    }
     _reportSuccess(
         classesInfo,
         sdk,
@@ -1006,6 +985,33 @@ To change the server version, go to your ${colors.cyan(
     );
 
     log.info(colors.cyan(`Test your code at http://localhost:${port}/explore`));
+}
+
+// This method is used to check if the user has a different node version installed than the one used by the server.
+// If the user has a different version, a warning message will be displayed.
+function reportDifferentNodeRuntime(userDefinedNodeRuntime: string | undefined) {
+    const installedNodeVersion = process.version;
+
+    // get server used version
+    let serverNodeRuntime: string = DEFAULT_NODE_RUNTIME as string;
+    if (userDefinedNodeRuntime) {
+        serverNodeRuntime = userDefinedNodeRuntime;
+    }
+
+    const nodeMajorVersion = installedNodeVersion.split(".")[0].slice(1);
+    const serverMajorVersion = serverNodeRuntime.split(".")[0].split("nodejs")[1];
+
+    // check if server version is different from installed version
+    if (nodeMajorVersion !== serverMajorVersion) {
+        log.warn(
+            `${colors.yellow(`Warning: The installed node version ${installedNodeVersion} but your server is configured to use ${serverNodeRuntime}. This might cause unexpected behavior.
+To change the server version, go to your ${colors.cyan(
+                "genezio.yaml",
+            )} file and change the ${colors.cyan(
+                "backend.language.nodeRuntime",
+            )} property to the version you want to use.`)}`,
+        );
+    }
 }
 
 function getFunctionUrl(

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -1,7 +1,7 @@
 import { getAstSummary } from "../generateSdk/utils/getAstSummary.js";
 import { AstSummary } from "./astSummary.js";
 import { CloudProviderIdentifier } from "./cloudProviderIdentifier.js";
-import { NodeOptions, supportedNodeRuntimes } from "./nodeRuntime.js";
+import { DEFAULT_NODE_RUNTIME, NodeOptions } from "./nodeRuntime.js";
 import { SdkGeneratorResponse } from "./sdkGeneratorResponse.js";
 import { TriggerType } from "../yamlProjectConfiguration/models.js";
 import { YamlProjectConfiguration } from "../yamlProjectConfiguration/v2.js";
@@ -111,7 +111,7 @@ export class ProjectConfiguration {
         this.region = yamlConfiguration.region;
         this.sdk = yamlConfiguration.backend?.sdk;
         this.options = {
-            nodeRuntime: yamlConfiguration.backend?.language.runtime || supportedNodeRuntimes[1],
+            nodeRuntime: yamlConfiguration.backend?.language.runtime || DEFAULT_NODE_RUNTIME,
         };
         this.cloudProvider =
             yamlConfiguration.backend?.cloudProvider || CloudProviderIdentifier.GENEZIO;


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->
This PR includes the following changes (corresponding to the 2 commits)
- Change `nodejs18.x` as default to `node20js.x`.
- Refactor/beautify the code for warning the user that he's testing with a different node version than configured on the server. This check makes sense only for nodejs projects, so I restricted it for those specific languages (ts, js).

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
