### PR TITLE
Make language optional for frontend, in case the user doesn't want a generated SDK

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -26,11 +26,7 @@ import { genezioRequestParser } from "../utils/genezioRequestParser.js";
 import { debugLogger, doAdaptiveLogAction } from "../utils/logging.js";
 import { rectifyCronString } from "../utils/rectifyCronString.js";
 import cron from "node-cron";
-import {
-    createTemporaryFolder,
-    fileExists,
-    readUTF8File,
-} from "../utils/file.js";
+import { createTemporaryFolder, fileExists, readUTF8File } from "../utils/file.js";
 import { GenezioCommand, reportSuccess as _reportSuccess } from "../utils/reporter.js";
 import { SdkGeneratorResponse } from "../models/sdkGeneratorResponse.js";
 import { GenezioLocalOptions } from "../models/commandOptions.js";
@@ -69,7 +65,6 @@ import { NodeJsBundler } from "../bundlers/node/nodeJsBundler.js";
 import { KotlinBundler } from "../bundlers/kotlin/localKotlinBundler.js";
 import { reportSuccessForSdk } from "../generateSdk/sdkSuccessReport.js";
 
-
 type ClassProcess = {
     process: ChildProcess;
     startingCommand: string;
@@ -99,8 +94,13 @@ export async function prepareLocalBackendEnvironment(
         const backend = yamlProjectConfiguration.backend;
         const frontend = yamlProjectConfiguration.frontend;
         let sdkLanguage: Language = Language.ts;
-        if (frontend && frontend.length > 0) {
-            sdkLanguage = frontend[0].language;
+        if (frontend) {
+            for (const f of frontend) {
+                if (f.language) {
+                    sdkLanguage = f.language;
+                    break;
+                }
+            }
         }
         if (!backend) {
             throw new Error("No backend component found in the genezio.yaml file.");
@@ -185,7 +185,10 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
     // because we migrated the decorators implemented in the @genezio/types package to the stage 3 implementation.
     // Otherwise, the user will get an error at runtime. This check can be removed in the future once no one is using version
     // 0.1.* of @genezio/types.
-    if (backendConfiguration.language.name === Language.ts || backendConfiguration.language.name === Language.js) {
+    if (
+        backendConfiguration.language.name === Language.ts ||
+        backendConfiguration.language.name === Language.js
+    ) {
         const packageJsonPath = path.join(backendConfiguration.path, "package.json");
         if (
             isDependencyVersionCompatible(
@@ -260,8 +263,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
         let processForClasses: Map<string, ClassProcess>;
         let projectConfiguration: ProjectConfiguration;
 
-        const promiseListenForChanges: Promise<BundlerRestartResponse> =
-            listenForChanges();
+        const promiseListenForChanges: Promise<BundlerRestartResponse> = listenForChanges();
         const bundlerPromise: Promise<BundlerRestartResponse> = prepareLocalBackendEnvironment(
             yamlProjectConfiguration,
             options,
@@ -325,7 +327,8 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
             yamlProjectConfiguration.region,
             yamlProjectConfiguration.frontend,
             sdk,
-            options)
+            options,
+        );
         reportSuccess(projectConfiguration, options.port);
 
         // This check makes sense only for js/ts backend, skip for dart, go etc.
@@ -774,35 +777,43 @@ async function listenForChanges() {
 async function handleSdk(
     projectName: string,
     projectRegion: string,
-    frontends: YamlFrontend[]|undefined,
+    frontends: YamlFrontend[] | undefined,
     sdk: SdkGeneratorResponse,
-    options: GenezioLocalOptions): Promise<NodeJS.Timeout|undefined> {
+    options: GenezioLocalOptions,
+): Promise<NodeJS.Timeout | undefined> {
     let sdkLanguage: Language = Language.ts;
-    let nodeJsWatcher: NodeJS.Timeout|undefined = undefined;
-    let frontendPath: string|undefined = undefined;
+    let nodeJsWatcher: NodeJS.Timeout | undefined = undefined;
+    let frontendPath: string | undefined = undefined;
 
     if (frontends && frontends.length > 0) {
-        sdkLanguage = frontends[0].language;
+        sdkLanguage = frontends[0].language || Language.ts;
         frontendPath = frontends[0].path;
     }
 
     const classUrls = sdk.files.map((c) => ({
         name: c.className,
         cloudUrl: `http://127.0.0.1:${options.port}/${c.className}`,
-    }))
+    }));
 
     const sdkFolderPath = await writeSdk({
         language: sdkLanguage,
-        packageName: `@genezio-sdk/${projectName}_${projectRegion}`, 
-        packageVersion: undefined, 
+        packageName: `@genezio-sdk/${projectName}_${projectRegion}`,
+        packageVersion: undefined,
         sdkResponse: sdk,
         classUrls,
         publish: false,
         installPackage: true,
-        outputPath: frontendPath ? path.join(frontendPath, "sdk") : undefined})
+        outputPath: frontendPath ? path.join(frontendPath, "sdk") : undefined,
+    });
 
     if (sdkFolderPath) {
-        const timeout = await watchPackage(sdkLanguage, projectName, projectRegion, frontends, sdkFolderPath);
+        const timeout = await watchPackage(
+            sdkLanguage,
+            projectName,
+            projectRegion,
+            frontends,
+            sdkFolderPath,
+        );
         if (timeout) {
             nodeJsWatcher = timeout;
         }
@@ -814,13 +825,10 @@ async function handleSdk(
         stage: "local",
     });
 
-    return nodeJsWatcher
+    return nodeJsWatcher;
 }
 
-function reportSuccess(
-    projectConfiguration: ProjectConfiguration,
-    port: number,
-) {
+function reportSuccess(projectConfiguration: ProjectConfiguration, port: number) {
     const classesInfo = projectConfiguration.classes.map((c) => ({
         className: c.name,
         methods: c.methods.map((m) => ({
@@ -832,9 +840,7 @@ function reportSuccess(
         functionUrl: `http://127.0.0.1:${port}/${c.name}`,
     }));
 
-    _reportSuccess(
-        classesInfo,
-    );
+    _reportSuccess(classesInfo);
 
     log.info(colors.cyan(`Test your code at http://localhost:${port}/explore`));
 }

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -100,7 +100,7 @@ function parseGenezioConfig(config: unknown) {
 
     const frontendSchema = zod.object({
         path: zod.string(),
-        language: zod.nativeEnum(Language),
+        language: zod.nativeEnum(Language).optional(),
         subdomain: zod.string().optional(),
         publish: zod.string().optional(),
         scripts: zod


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

If a user just wants to deploy a website, without using a backend, the `language` field is confusing, because it only accepts values that we support for `SDK Generator`. Maybe they do not use a SDK, as they do not have a backend.

Example scenario: I am using Rust Leptos to build a static website, when asked to fill `language`, I am inclined to fill `rust`, but this will give an error, as `rust` is not yet a supported language.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
