### PR TITLE
remove esm compiled version of sdk; keep only cjs

### DIFF
--- a/sdk-external-modules/remote-ts/package.json
+++ b/sdk-external-modules/remote-ts/package.json
@@ -3,29 +3,18 @@
     "version": "1.0.0",
     "exports": {
         ".": {
-            "browser": {
-                "require": "./dist/cjs/index.js",
-                "import": "./dist/esm/index.js"
-            },
-            "react-native": {
-                "require": "./dist/cjs/index.js",
-                "import": "./dist/esm/index.js"
-            },
-            "default": {
-                "require": "./dist/cjs/index.node.js",
-                "import": "./dist/esm/index.node.js"
-            }
+            "browser": "./dist/lib/index.js",
+            "react-native": "./dist/lib/index.js",
+            "default": "./dist/lib/index.node.js"
         }
     },
     "scripts": {
         "build:cjs": "tsc -p tsconfig.cjs.json",
-        "build:esm": "tsc -p tsconfig.esm.json",
-        "build": "npm run build:cjs && npm run build:esm && shx cp package.json ../../build/src/genezio-remote/"
+        "build": "npm run build:cjs && shx cp package.json ../../build/src/genezio-remote/"
     },
     "files": [
         "dist"
     ],
     "description": "",
-    "main": "./dist/cjs/index.js",
-    "module": "./dist/esm/index.js"
+    "main": "./dist/lib/index.js"
 }

--- a/sdk-external-modules/remote-ts/tsconfig.cjs.json
+++ b/sdk-external-modules/remote-ts/tsconfig.cjs.json
@@ -3,6 +3,6 @@
     "compilerOptions": {
         "target": "ES2019",
         "module": "CommonJS",
-        "outDir": "../../build/src/genezio-remote/dist/cjs"
+        "outDir": "../../build/src/genezio-remote/dist/lib"
     }
 }

--- a/sdk-external-modules/remote-ts/tsconfig.esm.json
+++ b/sdk-external-modules/remote-ts/tsconfig.esm.json
@@ -1,9 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "target": "ES2019",
-        "moduleResolution": "nodenext",
-        "module": "nodenext",
-        "outDir": "../../build/src/genezio-remote/dist/esm"
-    }
-}

--- a/src/generateSdk/templates/packageJson.ts
+++ b/src/generateSdk/templates/packageJson.ts
@@ -34,18 +34,11 @@ export const getPackageJsonSdkGenerator = (
 export const getNodeModulePackageJson = (packageName: string, version?: string): string => `{
   "name": "${packageName}",
   "version": "${version || getRandomSemVer()}",
-  "exports": {
-    ".": {
-      "require": "./cjs/index.js",
-      "import": "./esm/index.js"
-    }
-   },
   "bundleDependencies": [
     "genezio-remote"
   ],
   "description": "",
-  "main": "./cjs/index.js",
-  "module": "./esm/index.js",
+  "main": "./lib/index.js",
   "dependencies": {
     "genezio-remote": "1.0.0"
   }

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -11,7 +11,6 @@ import { listFilesWithExtension } from "../../utils/file.js";
 import { fileURLToPath } from "url";
 import { doAdaptiveLogAction } from "../../utils/logging.js";
 
-
 const compilerWorkerScript = `const { parentPort, workerData } = require("worker_threads");
 
 const { compilerOptions, fileNames, typescriptPath } = workerData;
@@ -66,7 +65,7 @@ export async function compileSdk(
     const require = createRequire(import.meta.url);
     const typescriptPath = path.resolve(require.resolve("typescript"));
     const cjsOptions = {
-        outDir: path.resolve(genezioSdkPath, "cjs"),
+        outDir: path.resolve(genezioSdkPath, "lib"),
         module: ts.ModuleKind.CommonJS,
         rootDir: sdkPath,
         allowJs: true,
@@ -76,20 +75,6 @@ export async function compileSdk(
         createWorker(compilerWorkerScript, {
             fileNames: filenames,
             compilerOptions: cjsOptions,
-            typescriptPath,
-        }),
-    );
-    const esmOptions = {
-        outDir: path.resolve(genezioSdkPath, "esm"),
-        module: ts.ModuleKind.ESNext,
-        rootDir: sdkPath,
-        allowJs: true,
-        declaration: true,
-    };
-    workers.push(
-        createWorker(compilerWorkerScript, {
-            fileNames: filenames,
-            compilerOptions: esmOptions,
             typescriptPath,
         }),
     );


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

Apparently SDK imports were always resolving to the CJS version of the SDK. Another bug led us to the realization that even if an import statement had resolved to the ESM folder, it would have failed. The CJS version seems to be working in all scenarios, so there is no reason to keep this separation.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
