### PR TITLE
add user error class

### DIFF
--- a/src/bundlers/bundlerComposer.ts
+++ b/src/bundlers/bundlerComposer.ts
@@ -1,3 +1,4 @@
+import { UserError } from "../errors.js";
 import { BundlerInput, BundlerInterface, BundlerOutput } from "./bundler.interface.js";
 
 export class BundlerComposer implements BundlerInterface {
@@ -9,7 +10,7 @@ export class BundlerComposer implements BundlerInterface {
 
     async bundle(input: BundlerInput): Promise<BundlerOutput> {
         if (this.bundlers.length === 0) {
-            throw new Error("Invalid number of bundlers.");
+            throw new UserError("Invalid number of bundlers.");
         }
 
         let arg = await this.bundlers[0].bundle(input);

--- a/src/bundlers/dart/dartBundler.ts
+++ b/src/bundlers/dart/dartBundler.ts
@@ -42,7 +42,7 @@ import {
     castArrayRecursivelyInitial,
     castMapRecursivelyInitial,
 } from "../../utils/dartAstCasting.js";
-import { GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE } from "../../errors.js";
+import { GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE, UserError } from "../../errors.js";
 import { Status } from "../../requests/models.js";
 
 export class DartBundler implements BundlerInterface {
@@ -57,7 +57,7 @@ export class DartBundler implements BundlerInterface {
 
         if (result.status != 0) {
             log.info(result.stdout.toString().split("\n").slice(1).join("\n"));
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
     }
 
@@ -74,7 +74,7 @@ export class DartBundler implements BundlerInterface {
             });
 
         if (response.data.status === "error") {
-            throw new Error(response.data.error.message);
+            throw new UserError(response.data.error.message);
         }
 
         return response.data;
@@ -147,7 +147,7 @@ export class DartBundler implements BundlerInterface {
             .find((m) => m.name == method.name)
             ?.params.find((p) => p.name == parameterType.name);
 
-        if (!type) throw new Error("Type not found");
+        if (!type) throw new UserError("Type not found");
 
         return `${this.#castParameterToPropertyType(type.paramType, `params[${index}]`)}`;
     }
@@ -225,7 +225,7 @@ export class DartBundler implements BundlerInterface {
         );
 
         if (!success) {
-            throw new Error("Error while adding aws_lambda_dart_runtime dependency");
+            throw new UserError("Error while adding aws_lambda_dart_runtime dependency");
         }
     }
 
@@ -253,7 +253,7 @@ export class DartBundler implements BundlerInterface {
                 const fileDestinationPath = path.join(tempFolderPath, filePath.path);
                 return fs.promises.copyFile(filePath.path, fileDestinationPath).catch((error) => {
                     if (error.code === "EACCES") {
-                        throw new Error(GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE(filePath.path));
+                        throw new UserError(GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE(filePath.path));
                     }
 
                     throw error;
@@ -277,7 +277,7 @@ export class DartBundler implements BundlerInterface {
                 (c: ClassConfiguration) => c.path == input.path,
             );
 
-            if (!userClass) throw new Error("Class not found while bundling");
+            if (!userClass) throw new UserError("Class not found while bundling");
 
             this.#createRouterFileForClass(userClass, input.ast, inputTemporaryFolder);
 
@@ -300,7 +300,7 @@ export class DartBundler implements BundlerInterface {
             debugLogger.debug("Compiling Dart finished.");
 
             if (s3Zip.success === false) {
-                throw new Error("Failed to upload code for compiling.");
+                throw new UserError("Failed to upload code for compiling.");
             }
 
             temporaryFolder = await createTemporaryFolder();

--- a/src/bundlers/dart/localDartBundler.ts
+++ b/src/bundlers/dart/localDartBundler.ts
@@ -28,6 +28,7 @@ import {
     castArrayRecursivelyInitial,
     castMapRecursivelyInitial,
 } from "../../utils/dartAstCasting.js";
+import { UserError } from "../../errors.js";
 
 export class DartBundler implements BundlerInterface {
     async #analyze(path: string) {
@@ -41,7 +42,7 @@ export class DartBundler implements BundlerInterface {
             // Delete the temporary folder if the compilation fails
             await deleteFolder(path);
 
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
     }
 
@@ -149,7 +150,7 @@ export class DartBundler implements BundlerInterface {
             // Delete the temporary folder if the compilation fails
             await deleteFolder(folderPath);
 
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
     }
 

--- a/src/bundlers/go/genezioRuntimeGoBundler.ts
+++ b/src/bundlers/go/genezioRuntimeGoBundler.ts
@@ -3,6 +3,7 @@ import { template } from "./genezioRuntimeGoMain.js";
 import { GoBundler } from "./goBundlerBase.js";
 import { BundlerInput } from "../bundler.interface.js";
 import { $ } from "execa";
+import { UserError } from "../../errors.js";
 
 export class GenezioRuntimeGoBundler extends GoBundler {
     template = template;
@@ -22,11 +23,11 @@ export class GenezioRuntimeGoBundler extends GoBundler {
             log.info(
                 "There was an error while running the go script, make sure you have the correct permissions.",
             );
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         } else if (getDependencyResult.exitCode != 0) {
             log.info(getDependencyResult.stderr.toString());
             log.info(getDependencyResult.stdout.toString());
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
         process.env["GOOS"] = "linux";
         process.env["GOARCH"] = "amd64";
@@ -45,11 +46,11 @@ export class GenezioRuntimeGoBundler extends GoBundler {
             log.info(
                 "There was an error while running the go script, make sure you have the correct permissions.",
             );
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         } else if (result.exitCode != 0) {
             log.info(result.stderr.toString());
             log.info(result.stdout.toString());
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
     }
 }

--- a/src/bundlers/go/goBundlerBase.ts
+++ b/src/bundlers/go/goBundlerBase.ts
@@ -24,6 +24,7 @@ import {
 } from "../../models/genezioModels.js";
 import { checkIfGoIsInstalled } from "../../utils/go.js";
 import { TriggerType } from "../../yamlProjectConfiguration/models.js";
+import { UserError } from "../../errors.js";
 
 type ImportView = {
     name: string;
@@ -186,7 +187,7 @@ export abstract class GoBundler implements BundlerInterface {
 
         // Error check: User is using Windows but paths are unix style (possible when cloning projects from git)
         if (process.platform === "win32" && classConfigPath.includes("/")) {
-            throw new Error(
+            throw new UserError(
                 "Error: You are using Windows but your project contains unix style paths. Please use Windows style paths in genezio.yaml instead.",
             );
         }

--- a/src/bundlers/go/lambdaGoBundler.ts
+++ b/src/bundlers/go/lambdaGoBundler.ts
@@ -3,6 +3,7 @@ import { template } from "./lambdaGoMain.js";
 import { log } from "../../utils/logging.js";
 import { $ } from "execa";
 import { BundlerInput } from "../bundler.interface.js";
+import { UserError } from "../../errors.js";
 
 export class LambdaGoBundler extends GoBundler {
     template = template;
@@ -26,11 +27,11 @@ export class LambdaGoBundler extends GoBundler {
                 log.info(
                     "There was an error while running the go script, make sure you have the correct permissions.",
                 );
-                throw new Error("Compilation error! Please check your code and try again.");
+                throw new UserError("Compilation error! Please check your code and try again.");
             } else if (getDependencyResult.exitCode != 0) {
                 log.info(getDependencyResult.stderr.toString());
                 log.info(getDependencyResult.stdout.toString());
-                throw new Error("Compilation error! Please check your code and try again.");
+                throw new UserError("Compilation error! Please check your code and try again.");
             }
         }
         process.env["GOOS"] = "linux";
@@ -45,11 +46,11 @@ export class LambdaGoBundler extends GoBundler {
             log.info(
                 "There was an error while running the go script, make sure you have the correct permissions.",
             );
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         } else if (result.exitCode != 0) {
             log.info(result.stderr.toString());
             log.info(result.stdout.toString());
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
     }
 }

--- a/src/bundlers/go/localGoBundler.ts
+++ b/src/bundlers/go/localGoBundler.ts
@@ -4,6 +4,7 @@ import { template } from "./localGoMain.js";
 import { GoBundler } from "./goBundlerBase.js";
 import { BundlerInput } from "../bundler.interface.js";
 import { $ } from "execa";
+import { UserError } from "../../errors.js";
 
 export class LocalGoBundler extends GoBundler {
     template = template;
@@ -23,22 +24,22 @@ export class LocalGoBundler extends GoBundler {
             log.info(
                 "There was an error while running the go script, make sure you have the correct permissions.",
             );
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         } else if (getDependencyResult.exitCode != 0) {
             log.info(getDependencyResult.stderr.toString());
             log.info(getDependencyResult.stdout.toString());
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
         const result = $({ cwd: folderPath }).sync`go build -o main main.go`;
         if (result.exitCode == null) {
             log.info(
                 "There was an error while running the go script, make sure you have the correct permissions.",
             );
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         } else if (result.exitCode != 0) {
             log.info(result.stderr.toString());
             log.info(result.stdout.toString());
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
 
         input.extra = {

--- a/src/bundlers/kotlin/kotlinBundler.ts
+++ b/src/bundlers/kotlin/kotlinBundler.ts
@@ -34,6 +34,7 @@ import {
     Node,
     Program,
 } from "../../models/genezioModels.js";
+import { UserError } from "../../errors.js";
 
 export class KotlinBundler implements BundlerInterface {
     async #compile(folderPath: string) {
@@ -48,11 +49,11 @@ export class KotlinBundler implements BundlerInterface {
                     gradlew +
                     " script, make sure you have the correct permissions.",
             );
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         } else if (result.status != 0) {
             log.info(result.stderr.toString());
             log.info(result.stdout.toString());
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
         // Move the stand alone jar to its own folder
         fsExtra.mkdirSync(path.join(folderPath, "final_build"));
@@ -120,7 +121,7 @@ export class KotlinBundler implements BundlerInterface {
 
         // Error check: User is using Windows but paths are unix style (possible when cloning projects from git)
         if (process.platform === "win32" && classConfigPath.includes("/")) {
-            throw new Error(
+            throw new UserError(
                 "Error: You are using Windows but your project contains unix style paths. Please use Windows style paths in genezio.yaml instead.",
             );
         }

--- a/src/bundlers/kotlin/localKotlinBundler.ts
+++ b/src/bundlers/kotlin/localKotlinBundler.ts
@@ -33,6 +33,7 @@ import {
     Node,
     Program,
 } from "../../models/genezioModels.js";
+import { UserError } from "../../errors.js";
 
 export class KotlinBundler implements BundlerInterface {
     #castParameterToPropertyType(node: Node, variableName: string): string {
@@ -93,7 +94,7 @@ export class KotlinBundler implements BundlerInterface {
 
         // Error check: User is using Windows but paths are unix style (possible when cloning projects from git)
         if (process.platform === "win32" && classConfigPath.includes("/")) {
-            throw new Error(
+            throw new UserError(
                 "Error: You are using Windows but your project contains unix style paths. Please use Windows style paths in genezio.yaml instead.",
             );
         }
@@ -146,11 +147,11 @@ export class KotlinBundler implements BundlerInterface {
                     gradlew +
                     " script, make sure you have the correct permissions.",
             );
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         } else if (result.status != 0) {
             log.info(result.stderr.toString());
             log.info(result.stdout.toString());
-            throw new Error("Compilation error! Please check your code and try again.");
+            throw new UserError("Compilation error! Please check your code and try again.");
         }
         // Move the stand alone jar to its own folder
         fsExtra.mkdirSync(path.join(folderPath, "final_build"));

--- a/src/bundlers/node/nodeJsBinaryDependenciesBundler.ts
+++ b/src/bundlers/node/nodeJsBinaryDependenciesBundler.ts
@@ -8,6 +8,7 @@ import { debugLogger } from "../../utils/logging.js";
 // @ts-ignore
 import exec from "await-exec";
 import packageManager from "../../packageManagers/packageManager.js";
+import { UserError } from "../../errors.js";
 
 export class NodeJsBinaryDependenciesBundler implements BundlerInterface {
     async #handleBinaryDependencies(dependenciesInfo: Dependency[], tempFolderPath: string) {
@@ -75,7 +76,7 @@ export class NodeJsBinaryDependenciesBundler implements BundlerInterface {
             } catch (error) {
                 debugLogger.debug("[BinaryDepStdOut]", error);
                 log.error("An error has occurred while installing binary dependencies.");
-                throw new Error("An error has occurred while installing binary dependencies.");
+                throw new UserError("An error has occurred while installing binary dependencies.");
             }
         }
     }

--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -18,7 +18,7 @@ import esbuild, { BuildResult, Plugin, BuildFailure, Message, Loader } from "esb
 import { nodeExternalsPlugin } from "esbuild-node-externals";
 import colors from "colors";
 import { DependencyInstaller } from "./dependencyInstaller.js";
-import { GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE } from "../../errors.js";
+import { GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE, UserError } from "../../errors.js";
 import transformDecorators from "../../utils/transformDecorators.js";
 import { CloudProviderIdentifier } from "../../models/cloudProviderIdentifier.js";
 
@@ -89,7 +89,7 @@ export class NodeJsBundler implements BundlerInterface {
                 const sourceFilePath = path.join(cwd, filePath.path);
                 return fs.promises.copyFile(sourceFilePath, fileDestinationPath).catch((error) => {
                     if (error.code === "EACCES") {
-                        throw new Error(GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE(filePath.path));
+                        throw new UserError(GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE(filePath.path));
                     }
 
                     throw error;
@@ -341,7 +341,7 @@ export class NodeJsBundler implements BundlerInterface {
         }
 
         if (output.metafile === undefined) {
-            throw new Error("Could not get dependencies info");
+            throw new UserError("Could not get dependencies info");
         }
 
         const dependencyMap: Map<string, string> = new Map();
@@ -362,7 +362,7 @@ export class NodeJsBundler implements BundlerInterface {
             // This should not ever happen. If you got here... Good luck!
             const existingDependencyPath = dependencyMap.get(dependencyName);
             if (existingDependencyPath !== undefined && existingDependencyPath !== dependencyPath) {
-                throw new Error(
+                throw new UserError(
                     `Dependency ${dependencyName} has two different paths: ${existingDependencyPath} and ${dependencyPath}`,
                 );
             }
@@ -398,12 +398,12 @@ export class NodeJsBundler implements BundlerInterface {
         const cloudProvider = input.projectConfiguration.cloudProvider;
 
         if (mode === "development" && !tmpFolder) {
-            throw new Error("tmpFolder is required in development mode.");
+            throw new UserError("tmpFolder is required in development mode.");
         }
 
         const handlerGenerator = this.getHandlerGeneratorForProvider(cloudProvider);
         if (handlerGenerator === null) {
-            throw new Error(`Can't generate handler for cloud provider ${cloudProvider}.`);
+            throw new UserError(`Can't generate handler for cloud provider ${cloudProvider}.`);
         }
 
         const temporaryFolder = mode === "production" ? await createTemporaryFolder() : tmpFolder!;

--- a/src/bundlers/node/typeCheckerBundler.ts
+++ b/src/bundlers/node/typeCheckerBundler.ts
@@ -6,6 +6,7 @@ import { tsconfig } from "../../utils/configs.js";
 import path from "path";
 import { writeToFile } from "../../utils/file.js";
 import { debugLogger } from "../../utils/logging.js";
+import { UserError } from "../../errors.js";
 
 export class TypeCheckerBundler implements BundlerInterface {
     // Call this class only once
@@ -44,7 +45,7 @@ export class TypeCheckerBundler implements BundlerInterface {
             onUnRecoverableConfigFileDiagnostic: () => {},
         });
         if (!config) {
-            throw new Error("Failed to parse tsconfig.json");
+            throw new UserError("Failed to parse tsconfig.json");
         }
 
         const program = ts.createProgram({
@@ -69,7 +70,7 @@ export class TypeCheckerBundler implements BundlerInterface {
                 }
             });
 
-            throw new Error("Typescript compilation failed.");
+            throw new UserError("Typescript compilation failed.");
         }
 
         return input;

--- a/src/bundlers/utils.ts
+++ b/src/bundlers/utils.ts
@@ -14,6 +14,7 @@ import { debugLogger, printAdaptiveLog } from "../utils/logging.js";
 import { createTemporaryFolder } from "../utils/file.js";
 import { ProjectConfiguration } from "../models/projectConfiguration.js";
 import { Program } from "../models/genezioModels.js";
+import { UserError } from "../errors.js";
 
 export async function bundle(
     projectConfiguration: ProjectConfiguration,
@@ -25,7 +26,7 @@ export async function bundle(
         printAdaptiveLog("Bundling your code\n", "error");
         log.error(`\`${element.path}\` file does not exist at the indicated path.`);
 
-        throw new Error(`\`${element.path}\` file does not exist at the indicated path.`);
+        throw new UserError(`\`${element.path}\` file does not exist at the indicated path.`);
     }
 
     let bundler: BundlerInterface;
@@ -63,7 +64,7 @@ export async function bundle(
             break;
         }
         default:
-            throw new Error(`Unsupported ${element.language}`);
+            throw new UserError(`Unsupported ${element.language}`);
     }
 
     debugLogger.debug(`The bundling process has started for file ${element.path}...`);

--- a/src/cloudAdapter/aws/selfHostedAwsAdapter.ts
+++ b/src/cloudAdapter/aws/selfHostedAwsAdapter.ts
@@ -39,6 +39,7 @@ import {
 import mime from "mime-types";
 import path from "path";
 import { DEFAULT_NODE_RUNTIME } from "../../models/nodeRuntime.js";
+import { UserError } from "../../errors.js";
 
 const BUNDLE_SIZE_LIMIT = 256901120;
 
@@ -133,7 +134,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
             case ".dart":
                 return "provided.al2";
             default:
-                throw new Error("Unsupported language: " + language);
+                throw new UserError("Unsupported language: " + language);
         }
     }
 
@@ -213,7 +214,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
             !successCloudFormationStatus.includes(bucketStackDetails["Stacks"][0]["StackStatus"])
         ) {
             debugLogger.error("Stack does not exists!", JSON.stringify(bucketStackDetails));
-            throw new Error(
+            throw new UserError(
                 "A problem occurred while deploying your application. Please check the status of your CloudFormation stack.",
             );
         }
@@ -224,7 +225,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
                 "Could not find bucket name output in cloud formation describe output.",
                 JSON.stringify(bucketStackDetails),
             );
-            throw new Error(
+            throw new UserError(
                 "A problem occurred while deploying your application. Please check the status of your CloudFormation stack.",
             );
         }
@@ -253,7 +254,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
 
         const credentials = await s3Client.config.credentials();
         if (!credentials) {
-            throw new Error("AWS credentials not found");
+            throw new UserError("AWS credentials not found");
         }
         log.info(
             `Deploying your backend project to the account represented by access key ID ${credentials.accessKeyId}...`,
@@ -302,7 +303,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
 
         const uploadFilesPromises = input.map(async (inputItem) => {
             if (inputItem.unzippedBundleSize > BUNDLE_SIZE_LIMIT) {
-                throw new Error(
+                throw new UserError(
                     `Class ${inputItem.name} is too big: ${(
                         inputItem.unzippedBundleSize / 1048576
                     ).toFixed(2)}MB. The maximum size is ${
@@ -315,7 +316,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
 
             const size = await getFileSize(inputItem.archivePath);
             if (size > BUNDLE_SIZE_LIMIT) {
-                throw new Error(
+                throw new UserError(
                     `Your class ${inputItem.name} is too big: ${size} bytes. The maximum size is 250MB. Try to reduce the size of your class.`,
                 );
             }
@@ -488,7 +489,7 @@ export class SelfHostedAwsAdapter implements CloudAdapter {
 
         const credentials = await s3Client.config.credentials();
         if (!credentials) {
-            throw new Error("AWS credentials not found");
+            throw new UserError("AWS credentials not found");
         }
         log.info(
             `Deploying your frontend project to the account represented by access key ID ${credentials.accessKeyId}...`,

--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -25,6 +25,7 @@ import { getFileSize } from "../../utils/file.js";
 import { CloudProviderIdentifier } from "../../models/cloudProviderIdentifier.js";
 import { calculateBiggestFiles } from "../../utils/calculateBiggestProjectFiles.js";
 import Table from "cli-table";
+import { UserError } from "../../errors.js";
 
 const BUNDLE_SIZE_LIMIT = 256901120;
 
@@ -52,7 +53,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
             if (element.unzippedBundleSize > BUNDLE_SIZE_LIMIT) {
                 // Throw this error if bundle size is too big and the user is not using js or ts files.
                 if (!dependenciesInfo || !allNonJsFilesPaths) {
-                    throw new Error(
+                    throw new UserError(
                         `Your class ${element.name} is too big: ${element.unzippedBundleSize} bytes. The maximum size is 250MB. Try to reduce the size of your class.`,
                     );
                 }
@@ -105,7 +106,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
 
                 log.info(dependenciesTable.toString());
                 log.info(filesTable.toString());
-                throw new Error(`
+                throw new UserError(`
 Class ${element.name} is too big: ${(element.unzippedBundleSize / 1048576).toFixed(
                     2,
                 )}MB. The maximum size is ${
@@ -124,7 +125,7 @@ Class ${element.name} is too big: ${(element.unzippedBundleSize / 1048576).toFix
 
             const size = await getFileSize(element.archivePath);
             if (size > BUNDLE_SIZE_LIMIT) {
-                throw new Error(
+                throw new UserError(
                     `Your class ${element.name} is too big: ${size} bytes. The maximum size is 250MB. Try to reduce the size of your class.`,
                 );
             }
@@ -192,11 +193,11 @@ Class ${element.name} is too big: ${(element.unzippedBundleSize / 1048576).toFix
         const result = await getFrontendPresignedURL(finalSubdomain, projectName, stage);
 
         if (!result.presignedURL) {
-            throw new Error("An error occurred (missing presignedUrl). Please try again!");
+            throw new UserError("An error occurred (missing presignedUrl). Please try again!");
         }
 
         if (!result.userId) {
-            throw new Error("An error occurred (missing userId). Please try again!");
+            throw new UserError("An error occurred (missing userId). Please try again!");
         }
 
         debugLogger.debug("Content of the folder zipped. Uploading to S3.");

--- a/src/commands/addClass.ts
+++ b/src/commands/addClass.ts
@@ -7,6 +7,7 @@ import { fileExists, writeToFile } from "../utils/file.js";
 import { supportedExtensions } from "../utils/languages.js";
 import configIOController, { YamlClass } from "../yamlProjectConfiguration/v2.js";
 import { scanClassesForDecorators } from "../utils/configuration.js";
+import { UserError } from "../errors.js";
 
 export async function addClassCommand(classPath: string, classType: string) {
     await GenezioTelemetry.sendEvent({
@@ -16,30 +17,30 @@ export async function addClassCommand(classPath: string, classType: string) {
     if (classType === undefined) {
         classType = "jsonrpc";
     } else if (!["http", "jsonrpc"].includes(classType)) {
-        throw new Error("Invalid class type. Valid class types are 'http' and 'jsonrpc'.");
+        throw new UserError("Invalid class type. Valid class types are 'http' and 'jsonrpc'.");
     }
 
     if (classPath === undefined || classPath === "") {
-        throw new Error("Please provide a path to the class you want to add.");
+        throw new UserError("Please provide a path to the class you want to add.");
     }
 
     const backendConfiguration = (await configIOController.read()).backend;
 
     if (!backendConfiguration) {
-        throw new Error("Please provide a valid backend configuration.");
+        throw new UserError("Please provide a valid backend configuration.");
     }
     backendConfiguration.classes = await scanClassesForDecorators(backendConfiguration);
 
     const className = classPath.split(path.sep).pop();
 
     if (!className) {
-        throw new Error("Please provide a valid class path.");
+        throw new UserError("Please provide a valid class path.");
     }
 
     const classExtension = className.split(".").pop();
 
     if (!classExtension || className.split(".").length < 2) {
-        throw new Error("Please provide a class name with a valid class extension.");
+        throw new UserError("Please provide a class name with a valid class extension.");
     }
 
     // check if class is supported
@@ -48,7 +49,7 @@ export async function addClassCommand(classPath: string, classType: string) {
             supportedExtensions.slice(0, -1).join(", ") +
             (supportedExtensions.length > 1 ? " and " : "") +
             supportedExtensions.slice(-1);
-        throw new Error(
+        throw new UserError(
             `Class language(${classExtension}) not supported. Currently supporting: ${supportedExtensionsString}`,
         );
     }
@@ -60,7 +61,7 @@ export async function addClassCommand(classPath: string, classType: string) {
                 .map((c: YamlClass) => c.path.split(path.sep).pop())
                 .includes(className)
         ) {
-            throw new Error("Class already exists.");
+            throw new UserError("Class already exists.");
         }
     }
 

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -12,12 +12,13 @@ import { writeToFile, zipDirectory } from "../utils/file.js";
 import path from "path";
 import yamlConfigIOController from "../yamlProjectConfiguration/v2.js";
 import { scanClassesForDecorators } from "../utils/configuration.js";
+import { UserError } from "../errors.js";
 
 export async function bundleCommand(options: GenezioBundleOptions) {
     const yamlProjectConfiguration = await yamlConfigIOController.read();
     const backendConfiguration = yamlProjectConfiguration.backend;
     if (!backendConfiguration) {
-        throw new Error("Please provide a valid backend configuration.");
+        throw new UserError("Please provide a valid backend configuration.");
     }
     backendConfiguration.classes = await scanClassesForDecorators(backendConfiguration);
 
@@ -47,7 +48,7 @@ export async function bundleCommand(options: GenezioBundleOptions) {
     );
 
     if (!element) {
-        throw new Error(`Class ${options.className} not found.`);
+        throw new UserError(`Class ${options.className} not found.`);
     }
 
     const ast = sdkResponse.sdkGeneratorInput.classesInfo.find(

--- a/src/commands/create/create.ts
+++ b/src/commands/create/create.ts
@@ -14,6 +14,7 @@ import { backendTemplates, frontendTemplates } from "./templates.js";
 import { YamlConfigurationIOController } from "../../yamlProjectConfiguration/v2.js";
 import { YAMLContext, mergeContexts } from "yaml-transmute";
 import _ from "lodash";
+import { UserError } from "../../errors.js";
 
 type ProjectInfo = {
     name: string;
@@ -127,7 +128,7 @@ export async function createCommand(options: GenezioCreateOptions) {
 export function checkProjectName(projectName: string) {
     const projectNameRegex = /^[a-zA-Z][a-zA-Z0-9-]+$/;
     if (!projectNameRegex.test(projectName)) {
-        throw new Error(
+        throw new UserError(
             "Project name must start with a letter and contain only letters, numbers and dashes",
         );
     }
@@ -140,7 +141,7 @@ export function checkPathIsEmpty(projectPath: string) {
         for (const file of files) {
             const allowedFiles = ["README.md", "README", ".git", ".gitignore", "LICENSE"];
             if (!allowedFiles.includes(file)) {
-                throw new Error(
+                throw new UserError(
                     `A folder named '${projectPath}' already exists. You can't create a project in a non-empty folder.`,
                 );
             }
@@ -242,7 +243,7 @@ async function createProject(fs: IFs, projectInfo: ProjectInfo, projectPath = "/
     // TODO: Remove this before release
     // Checkout dev branch if it exists
     await git.checkout({ fs, dir: projectPath, ref: "dev" }).catch(() => {
-        throw new Error(
+        throw new UserError(
             "The selected template does not support `genezio.yaml` v2. Please choose another one",
         );
     });

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,6 +1,6 @@
 import { Spinner } from "cli-spinner";
 import { log } from "../utils/logging.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 import deleteProject from "../requests/deleteProject.js";
 import listProjects from "../requests/listProjects.js";
 import { getAuthToken } from "../utils/accounts.js";
@@ -11,7 +11,7 @@ export async function deleteCommand(projectId: string, options: GenezioDeleteOpt
     // check if user is logged in
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+        throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
     }
 
     const result = await deleteProjectHandler(projectId, options.force);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -8,7 +8,7 @@ import {
     RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE,
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
 } from "../constants.js";
-import { GENEZIO_NO_CLASSES_FOUND } from "../errors.js";
+import { GENEZIO_NO_CLASSES_FOUND, UserError } from "../errors.js";
 import {
     mapYamlClassToSdkClassConfiguration,
     sdkGeneratorApiHandler,
@@ -87,7 +87,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
                 REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
             ) === false
         ) {
-            throw new Error(
+            throw new UserError(
                 `You are currently using an older version of @genezio/types, which is not compatible with this version of the genezio CLI. To solve this, please update the @genezio/types package on your backend component using the following command: npm install @genezio/types@${RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE}`,
             );
         }
@@ -135,7 +135,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
         ) {
             const yamlConfig = await configIOController.read(/* fillDefaults= */ false);
             if (!yamlConfig.backend) {
-                throw new Error("No backend entry in genezio configuration file.");
+                throw new UserError("No backend entry in genezio configuration file.");
             }
             yamlConfig.backend.cloudProvider = await performCloudProviderABTesting(
                 configuration.name,
@@ -245,7 +245,7 @@ export async function deployClasses(
     backend.classes = await scanClassesForDecorators(backend);
 
     if (backend.classes.length === 0) {
-        throw new Error(GENEZIO_NO_CLASSES_FOUND);
+        throw new UserError(GENEZIO_NO_CLASSES_FOUND);
     }
     let sdkLanguage: Language = Language.ts;
     if (configuration.frontend) {
@@ -277,7 +277,7 @@ export async function deployClasses(
     const classesWithNoMethods = getNoMethodClasses(projectConfiguration.classes);
     if (classesWithNoMethods.length) {
         const errorClasses = classesWithNoMethods.join(", ");
-        throw new Error(
+        throw new UserError(
             `Unable to deploy classes [${errorClasses}] as they do not have any methods.`,
         );
     }
@@ -406,7 +406,7 @@ export async function deployClasses(
                 const projectEnv = await getProjectEnvFromProject(projectId, options.stage);
 
                 if (!projectEnv) {
-                    throw new Error("Project environment not found.");
+                    throw new UserError("Project environment not found.");
                 }
 
                 // Upload environment variables to the project
@@ -446,7 +446,7 @@ export async function deployClasses(
                 const projectEnv = await getProjectEnvFromProject(projectId, options.stage);
 
                 if (!projectEnv) {
-                    throw new Error("Project environment not found.");
+                    throw new UserError("Project environment not found.");
                 }
 
                 // get remoteEnvVars from project
@@ -522,13 +522,13 @@ export async function deployFrontend(
 
     // check if subdomain contains only numbers, letters and hyphens
     if (frontend.subdomain && !frontend.subdomain.match(/^[a-z0-9-]+$/)) {
-        throw new Error(`The subdomain can only contain letters, numbers and hyphens.`);
+        throw new UserError(`The subdomain can only contain letters, numbers and hyphens.`);
     }
 
     // check if the publish folder exists
     const frontendPath = path.join(frontend.path, frontend.publish);
     if (!(await fileExists(frontendPath))) {
-        throw new Error(
+        throw new UserError(
             `The publish folder ${colors.cyan(
                 `${frontendPath}`,
             )} does not exist. Please run the build command first or add a \`deploy\` script in the genezio.yaml file.`,
@@ -537,7 +537,7 @@ export async function deployFrontend(
 
     // check if the publish folder is empty
     if (await isDirectoryEmpty(frontendPath)) {
-        throw new Error(
+        throw new UserError(
             `The publish folder ${colors.cyan(
                 `${frontendPath}`,
             )} is empty. Please run the build command first or add a \`deploy\` script in the genezio.yaml file.`,
@@ -572,7 +572,7 @@ export async function deployFrontend(
 
             frontend.subdomain = subdomain;
         } else {
-            throw new Error("No frontend entry in genezio configuration file.");
+            throw new UserError("No frontend entry in genezio configuration file.");
         }
 
         await configIOController.write(yamlConfig);
@@ -631,7 +631,7 @@ function getCloudAdapter(provider: string): CloudAdapter {
         case CloudProviderIdentifier.SELF_HOSTED_AWS:
             return new SelfHostedAwsAdapter();
         default:
-            throw new Error(`Unsupported cloud provider: ${provider}`);
+            throw new UserError(`Unsupported cloud provider: ${provider}`);
     }
 }
 

--- a/src/commands/generateSdk.ts
+++ b/src/commands/generateSdk.ts
@@ -18,12 +18,11 @@ import {
     mapYamlClassToSdkClassConfiguration,
     sdkGeneratorApiHandler,
 } from "../generateSdk/generateSdkApi.js";
-import colors from "colors";
-import { deleteFile, deleteFolder } from "../utils/file.js";
 import { YamlConfigurationIOController } from "../yamlProjectConfiguration/v2.js";
 import { writeSdk } from "../generateSdk/sdkWriter/sdkWriter.js";
 import { reportSuccessForSdk } from "../generateSdk/sdkSuccessReport.js";
 import { GenezioCommand } from "../utils/reporter.js";
+import { UserError } from "../errors.js";
 
 export async function generateSdkCommand(projectName: string, options: GenezioSdkOptions) {
     switch (options.source) {
@@ -39,7 +38,7 @@ export async function generateSdkCommand(projectName: string, options: GenezioSd
 export async function generateLocalSdkCommand(options: GenezioSdkOptions) {
     const url = options.url;
     if (!url) {
-        throw new Error("You must provide a url when generating a local SDK.");
+        throw new UserError("You must provide a url when generating a local SDK.");
     }
 
     const sdkResponse: SdkGeneratorResponse = await sdkGeneratorApiHandler(
@@ -79,7 +78,7 @@ export async function generateLocalSdkCommand(options: GenezioSdkOptions) {
         outputPath: options.output,
     });
 
-    reportSuccessForSdk(options.language, sdkResponse, GenezioCommand.sdk)
+    reportSuccessForSdk(options.language, sdkResponse, GenezioCommand.sdk);
 }
 
 export async function generateRemoteSdkCommand(projectName: string, options: GenezioSdkOptions) {
@@ -95,7 +94,7 @@ export async function generateRemoteSdkCommand(projectName: string, options: Gen
 
     // check if language is supported using languages array
     if (!languages.includes(language)) {
-        throw new Error(
+        throw new UserError(
             `The language you specified is not supported. Please use one of the following: ${languages}.`,
         );
     }
@@ -185,7 +184,7 @@ async function generateRemoteSdkHandler(
     );
 
     if (!project) {
-        throw new Error(
+        throw new UserError(
             `The project ${projectName} on region ${region} doesn't exist. You must deploy it first with 'genezio deploy'.`,
         );
     }
@@ -195,7 +194,7 @@ async function generateRemoteSdkHandler(
 
     // if the project doesn't exist, throw an error
     if (!projectEnv) {
-        throw new Error(
+        throw new UserError(
             `The project ${projectName} on stage ${stage} doesn't exist in the region ${region}. You must deploy it first with 'genezio deploy'.`,
         );
     }
@@ -247,5 +246,5 @@ async function generateRemoteSdkHandler(
         outputPath: sdkPath,
     });
 
-    reportSuccessForSdk(language, sdkGeneratorResponse, GenezioCommand.sdk)
+    reportSuccessForSdk(language, sdkGeneratorResponse, GenezioCommand.sdk);
 }

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -13,7 +13,7 @@ import {
     RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE,
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
 } from "../constants.js";
-import { GENEZIO_NO_CLASSES_FOUND, PORT_ALREADY_USED } from "../errors.js";
+import { GENEZIO_NO_CLASSES_FOUND, PORT_ALREADY_USED, UserError } from "../errors.js";
 import {
     mapYamlClassToSdkClassConfiguration,
     sdkGeneratorApiHandler,
@@ -106,12 +106,12 @@ export async function prepareLocalBackendEnvironment(
             }
         }
         if (!backend) {
-            throw new Error("No backend component found in the genezio.yaml file.");
+            throw new UserError("No backend component found in the genezio.yaml file.");
         }
         backend.classes = await scanClassesForDecorators(backend);
 
         if (backend.classes.length === 0) {
-            throw new Error(GENEZIO_NO_CLASSES_FOUND);
+            throw new UserError(GENEZIO_NO_CLASSES_FOUND);
         }
 
         const sdk = await sdkGeneratorApiHandler(
@@ -181,7 +181,7 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
     const yamlProjectConfiguration = await yamlConfigIOController.read();
     const backendConfiguration = yamlProjectConfiguration.backend;
     if (!backendConfiguration) {
-        throw new Error("No backend component found in the genezio.yaml file.");
+        throw new UserError("No backend component found in the genezio.yaml file.");
     }
 
     // We need to check if the user is using an older version of @genezio/types
@@ -379,14 +379,14 @@ async function startProcesses(
         const bundler = getBundler(classInfo);
 
         if (!bundler) {
-            throw new Error("Unsupported language ${classConfiguration.language}.");
+            throw new UserError("Unsupported language ${classConfiguration.language}.");
         }
 
         const astClass = sdk.sdkGeneratorInput.classesInfo.find(
             (c) => c.classConfiguration.path === classInfo.path,
         );
         if (astClass === undefined) {
-            throw new Error("AST class not found.");
+            throw new UserError("AST class not found.");
         }
         const ast = astClass.program;
 
@@ -419,11 +419,11 @@ async function startProcesses(
         const extra = bundlerOutput.extra;
 
         if (!extra) {
-            throw new Error("Bundler output is missing extra field.");
+            throw new UserError("Bundler output is missing extra field.");
         }
 
         if (!extra.startingCommand) {
-            throw new Error("No starting command found for this language.");
+            throw new UserError("No starting command found for this language.");
         }
 
         await startClassProcess(
@@ -588,7 +588,7 @@ async function startServerHttp(
         server.on("error", (error) => {
             const err = error as NodeJS.ErrnoException;
             if (err.code === "EADDRINUSE") {
-                reject(new Error(PORT_ALREADY_USED(port)));
+                reject(new UserError(PORT_ALREADY_USED(port)));
             }
 
             reject(error);

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,3 +1,4 @@
+import { UserError } from "../errors.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js";
 import { removeAuthToken } from "../utils/accounts.js";
 import { debugLogger } from "../utils/logging.js";
@@ -10,7 +11,7 @@ export async function logoutCommand() {
 
     await removeAuthToken().then(([login, ...scopedRegistries]) => {
         if (login.status === "rejected") {
-            throw new Error("Logout failed!");
+            throw new UserError("Logout failed!");
         }
 
         scopedRegistries.forEach((scopedRegistry) => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,12 @@
 import zod from "zod";
 
+export class UserError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "Oops!";
+    }
+}
+
 // Constant strings used for output/error messages
 export const GENEZIO_NOT_AUTH_ERROR_MSG =
     "You are not logged in or your token is invalid. Please run `genezio login` before running this command.";

--- a/src/generateSdk/astGenerator/DartAstGenerator.ts
+++ b/src/generateSdk/astGenerator/DartAstGenerator.ts
@@ -35,6 +35,7 @@ import { runNewProcess, runNewProcessWithResultAndReturnCode } from "../../utils
 import {
     GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE,
     GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART,
+    UserError,
 } from "../../errors.js";
 
 // These are dart:core build-in errors that are not currently supported by the Genezio AST
@@ -92,7 +93,7 @@ export class AstGenerator implements AstGeneratorInterface {
             const lastIndex = type.length - 1;
             // If the List is optional, we need to remove the last character
             if (type[type.length - 1] === "?") {
-                throw new Error(GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART);
+                throw new UserError(GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART);
             }
 
             // Check for not supported built-in types
@@ -100,7 +101,9 @@ export class AstGenerator implements AstGeneratorInterface {
                 dartNotSupportedBuiltInTypes.includes(type) ||
                 dartNotSupportedBuiltInErrors.includes(type)
             ) {
-                throw new Error(`${type} not supported.\n` + GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE);
+                throw new UserError(
+                    `${type} not supported.\n` + GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE,
+                );
             }
 
             const extractedString = type.substring(listToken.length, lastIndex);
@@ -120,7 +123,7 @@ export class AstGenerator implements AstGeneratorInterface {
             const lastIndex = cleanedType.length - 1;
             // If the Map is optional, we need to remove the last character
             if (cleanedType[cleanedType.length - 1] === "?") {
-                throw new Error(GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART);
+                throw new UserError(GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART);
             }
 
             // Check for not supported built-in types
@@ -128,7 +131,9 @@ export class AstGenerator implements AstGeneratorInterface {
                 dartNotSupportedBuiltInTypes.includes(type) ||
                 dartNotSupportedBuiltInErrors.includes(type)
             ) {
-                throw new Error(`${type} not supported.\n` + GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE);
+                throw new UserError(
+                    `${type} not supported.\n` + GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE,
+                );
             }
 
             const extractedString = cleanedType.substring(mapToken.length, lastIndex);
@@ -187,7 +192,7 @@ export class AstGenerator implements AstGeneratorInterface {
 
         // Remove the Optional property for now, we don't support it.
         if (type[type.length - 1] === "?") {
-            throw new Error(GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART);
+            throw new UserError(GENEZIO_NO_SUPPORT_FOR_OPTIONAL_DART);
         }
 
         // Check for not supported built-in types
@@ -195,7 +200,7 @@ export class AstGenerator implements AstGeneratorInterface {
             dartNotSupportedBuiltInTypes.includes(type) ||
             dartNotSupportedBuiltInErrors.includes(type)
         ) {
-            throw new Error(`${type} not supported.\n` + GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE);
+            throw new UserError(`${type} not supported.\n` + GENEZIO_NO_SUPPORT_FOR_BUILT_IN_TYPE);
         }
 
         switch (type) {
@@ -260,7 +265,7 @@ export class AstGenerator implements AstGeneratorInterface {
         // Get the dart sdk version.
         const dartSdkVersion = getDartSdkVersion()?.toString();
         if (!dartSdkVersion) {
-            throw new Error("Unable to get the dart sdk version.");
+            throw new UserError("Unable to get the dart sdk version.");
         }
 
         // Get the path of the dart ast extractor.
@@ -286,13 +291,13 @@ export class AstGenerator implements AstGeneratorInterface {
 
         // If the result is not 0, it means that the ast generator failed.
         if (result.code !== 0) {
-            throw new Error(`Dart runtime error: ${result.stderr}`);
+            throw new UserError(`Dart runtime error: ${result.stderr}`);
         }
         const ast = JSON.parse(result.stdout);
 
         const mainClasses = ast.classes.filter((c: any) => c.name === input.class.name);
         if (mainClasses.length == 0) {
-            throw new Error(
+            throw new UserError(
                 `No class named ${input.class.name} found. Check in the 'genezio.yaml' file and make sure the path is correct.`,
             );
         }

--- a/src/generateSdk/astGenerator/GoAstGenerator.ts
+++ b/src/generateSdk/astGenerator/GoAstGenerator.ts
@@ -17,6 +17,7 @@ import {
 import { runNewProcess, runNewProcessWithResultAndReturnCode } from "../../utils/process.js";
 import { checkIfGoIsInstalled } from "../../utils/go.js";
 import { createTemporaryFolder } from "../../utils/file.js";
+import { UserError } from "../../errors.js";
 
 const releaseTag = "v0.1";
 const binaryName = `golang_ast_generator_${releaseTag}`;
@@ -29,7 +30,7 @@ export class AstGenerator implements AstGeneratorInterface {
             folder,
         );
         if (!astClone) {
-            throw new Error(
+            throw new UserError(
                 "Error: Failed to clone Go AST parser repository to " +
                     folder +
                     " temporary folder!",
@@ -38,7 +39,7 @@ export class AstGenerator implements AstGeneratorInterface {
         await runNewProcess(`git checkout --quiet tags/${releaseTag}`, folder);
         const goBuildSuccess = await runNewProcess(`go build -o ${binaryName} cmd/main.go`, folder);
         if (!goBuildSuccess) {
-            throw new Error(
+            throw new UserError(
                 "Error: Failed to build Go AST parser in " + folder + " temporary folder!",
             );
         }
@@ -78,18 +79,18 @@ export class AstGenerator implements AstGeneratorInterface {
         );
         if (result.code !== 0) {
             console.error(result.stderr);
-            throw new Error("Error: Failed to generate AST for class " + input.class.path);
+            throw new UserError("Error: Failed to generate AST for class " + input.class.path);
         }
 
         const ast = JSON.parse(result.stdout);
         const error = ast.error;
         if (error) {
             log.error(error);
-            throw new Error("Error: Failed to generate AST for class " + input.class.path);
+            throw new UserError("Error: Failed to generate AST for class " + input.class.path);
         }
         const goAstBody = ast.body;
         if (!goAstBody) {
-            throw new Error("Error: Failed to generate AST for class " + input.class.path);
+            throw new UserError("Error: Failed to generate AST for class " + input.class.path);
         }
 
         const body: Node[] = [];

--- a/src/generateSdk/astGenerator/JsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/JsAstGenerator.ts
@@ -23,6 +23,7 @@ import {
     isExportNamedDeclaration,
     Comment,
 } from "@babel/types";
+import { UserError } from "../../errors.js";
 
 class AstGenerator implements AstGeneratorInterface {
     async generateAst(input: AstGeneratorInput): Promise<AstGeneratorOutput> {
@@ -191,7 +192,7 @@ class AstGenerator implements AstGeneratorInterface {
         });
 
         if (classDefinition == undefined) {
-            throw new Error("No class definition found");
+            throw new UserError("No class definition found");
         } else {
             return {
                 program: {

--- a/src/generateSdk/astGenerator/KotlinAstGenerator.ts
+++ b/src/generateSdk/astGenerator/KotlinAstGenerator.ts
@@ -29,6 +29,7 @@ import { createTemporaryFolder, fileExists } from "../../utils/file.js";
 import { runNewProcess, runNewProcessWithResult } from "../../utils/process.js";
 import { PropertyDefinition } from "../../models/genezioModels.js";
 import { default as fsExtra } from "fs-extra";
+import { UserError } from "../../errors.js";
 
 interface KotlinAstParameterDefinition {
     paramName: string;
@@ -55,7 +56,7 @@ export class AstGenerator implements AstGeneratorInterface {
             folder,
         );
         if (!ast_clone_success) {
-            throw new Error(
+            throw new UserError(
                 "Error: Failed to clone Kotlin AST parser repository to " +
                     folder +
                     " temporary folder!",
@@ -65,7 +66,7 @@ export class AstGenerator implements AstGeneratorInterface {
         const gradlew = "." + path.sep + "gradlew" + (os.platform() === "win32" ? ".bat" : "");
         const gradle_build_success = await runNewProcess(gradlew + " --quiet fatJar", folder);
         if (!gradle_build_success) {
-            throw new Error(
+            throw new UserError(
                 'Error: Failed to build Kotlin AST parser while executing "./gradlew --quiet fatJar" in ' +
                     folder +
                     " temporary folder!",
@@ -219,7 +220,7 @@ export class AstGenerator implements AstGeneratorInterface {
         ) as KotlinAstClassDescription;
 
         if (!mainClass) {
-            throw new Error(
+            throw new UserError(
                 `No class named ${input.class.name} found. Check in the 'genezio.yaml' file and make sure the path is correct.`,
             );
         }

--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -34,6 +34,7 @@ import typescript from "typescript";
 import { readdirSync } from "fs";
 import path from "path";
 import { statSync } from "fs";
+import { UserError } from "../../errors.js";
 
 type Declaration = StructLiteral | TypeAlias | Enum;
 
@@ -141,7 +142,7 @@ export class AstGenerator implements AstGeneratorInterface {
                     }
                 }
                 if (!typeAtLocationPath) {
-                    throw new Error(
+                    throw new UserError(
                         `Type ${escapedText} is not supported by genezio. Take a look at the documentation to see the supported types. https://docs.genezio.com/`,
                     );
                 }
@@ -277,7 +278,7 @@ export class AstGenerator implements AstGeneratorInterface {
                         }
                     }
                     if (classDeclaration.name === undefined) {
-                        throw new Error("Class name is undefined");
+                        throw new UserError("Class name is undefined");
                     }
                     const typeAtLocation = typeChecker.getTypeAtLocation(classDeclaration.name);
                     let typeAtLocationPath =
@@ -286,7 +287,7 @@ export class AstGenerator implements AstGeneratorInterface {
                         typeAtLocationPath = typeAtLocationPath.slice(0, -3);
                     }
                     if (!typeAtLocationPath) {
-                        throw new Error("Could not find class declaration file path");
+                        throw new UserError("Could not find class declaration file path");
                     }
                     const pathFile = path
                         .relative(process.cwd(), typeAtLocationPath)
@@ -346,7 +347,7 @@ export class AstGenerator implements AstGeneratorInterface {
                     member.type
                 ) {
                     if (member.name && typescript.isComputedPropertyName(member.name)) {
-                        throw new Error("Computed property names are not supported");
+                        throw new UserError("Computed property names are not supported");
                     }
 
                     const field: PropertyDefinition = {
@@ -420,7 +421,7 @@ export class AstGenerator implements AstGeneratorInterface {
                 methodName = methodDeclarationCopy.name.text;
                 break;
             case typescript.SyntaxKind.ComputedPropertyName:
-                throw new Error("Computed property names as method names are not supported");
+                throw new UserError("Computed property names as method names are not supported");
         }
 
         let docString: string | undefined = undefined;
@@ -461,7 +462,7 @@ export class AstGenerator implements AstGeneratorInterface {
             name: enumDeclarationCopy.name.text,
             cases: enumDeclarationCopy.members.map((member, index: number) => {
                 if (typescript.isComputedPropertyName(member.name)) {
-                    throw new Error("Computed property names as enum cases are not supported");
+                    throw new UserError("Computed property names as enum cases are not supported");
                 }
 
                 if (!member.initializer) {
@@ -486,7 +487,7 @@ export class AstGenerator implements AstGeneratorInterface {
                             type: AstNodeType.StringLiteral,
                         };
                     default:
-                        throw new Error("Unsupported enum value type");
+                        throw new UserError("Unsupported enum value type");
                 }
             }),
         };
@@ -521,7 +522,7 @@ export class AstGenerator implements AstGeneratorInterface {
         });
 
         if (!this.rootNode) {
-            throw new Error("No root node found");
+            throw new UserError("No root node found");
         }
         let classDefinition: ClassDefinition | undefined = undefined;
         const declarations: Declaration[] = [];
@@ -539,7 +540,7 @@ export class AstGenerator implements AstGeneratorInterface {
         });
 
         if (!classDefinition) {
-            throw new Error("No exported class found in file.");
+            throw new UserError("No exported class found in file.");
         }
 
         return {

--- a/src/generateSdk/astGeneratorHandler.ts
+++ b/src/generateSdk/astGeneratorHandler.ts
@@ -9,6 +9,7 @@ import { debugLogger } from "../utils/logging.js";
 import { supportedExtensions } from "../utils/languages.js";
 import zod from "zod";
 import GoAstGenerator from "./astGenerator/GoAstGenerator.js";
+import { UserError } from "../errors.js";
 
 interface AstGeneratorPlugin {
     AstGenerator: new () => AstGeneratorInterface;
@@ -34,13 +35,13 @@ export async function generateAst(
             plugins?.map(async (plugin) => {
                 const dynamicPlugin = await import(plugin).catch((err) => {
                     debugLogger.debug(err);
-                    throw new Error(
+                    throw new UserError(
                         `Plugin(${plugin}) not found. Install it with npm install ${plugin}`,
                     );
                 });
 
                 if (!dynamicPlugin) {
-                    throw new Error(`Plugin(${plugin}) could not be imported.`);
+                    throw new UserError(`Plugin(${plugin}) could not be imported.`);
                 }
 
                 // Check type of plugin at runtime
@@ -49,7 +50,7 @@ export async function generateAst(
                     supportedExtensions: zod.array(zod.string()),
                 });
                 if (pluginSchema.safeParse(dynamicPlugin).success === false) {
-                    throw new Error(
+                    throw new UserError(
                         `Plugin(${plugin}) is not a valid AST generator plugin. It must export a AstGenerator class and supportedExtensions array.`,
                     );
                 }
@@ -75,7 +76,7 @@ export async function generateAst(
             (supportedExtensions.length > 1 ? " and " : "") +
             supportedExtensions.slice(-1);
 
-        throw new Error(
+        throw new UserError(
             `Class language(${extension}) not supported. Currently supporting: ${supportedExtensionsString}. You can delete the class from genezio.yaml`,
         );
     }

--- a/src/generateSdk/generateSdkApi.ts
+++ b/src/generateSdk/generateSdkApi.ts
@@ -11,6 +11,7 @@ import fs from "fs";
 import { Language, TriggerType } from "../yamlProjectConfiguration/models.js";
 import path from "path";
 import { YamlClass } from "../yamlProjectConfiguration/v2.js";
+import { UserError } from "../errors.js";
 
 /**
  * Asynchronously handles a request to generate an SDK based on the provided YAML project configuration.
@@ -49,7 +50,7 @@ export async function sdkGeneratorApiHandler(
         // prepare input for sdkGenerator
         const classConfiguration = classes.find((c) => c.path === input.class.path);
         if (!classConfiguration) {
-            throw new Error(
+            throw new UserError(
                 `[Sdk Generator] Class configuration not found for ${input.class.path}`,
             );
         }

--- a/src/generateSdk/sdkGenerator/PythonSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/PythonSdkGenerator.ts
@@ -24,6 +24,7 @@ import {
 import { TriggerType } from "../../yamlProjectConfiguration/models.js";
 import { pythonSdk } from "../templates/pythonSdk.js";
 import path from "path";
+import { UserError } from "../../errors.js";
 
 const PYTHON_RESERVED_WORDS = [
     "False",
@@ -347,7 +348,7 @@ class SdkGenerator implements SdkGeneratorInterface {
         const allTypesAreTheSame = e.cases.map((v) => v.type).every((type) => type === enumType);
 
         if (!allTypesAreTheSame) {
-            throw new Error(
+            throw new UserError(
                 "All enum cases must be the same type. Fix enum " + e.name + " and try again.",
             );
         }
@@ -362,7 +363,7 @@ class SdkGenerator implements SdkGeneratorInterface {
                     .map((e: EnumCase) => `${e.name} = ${e.value}`)
                     .join("\n\t")}`;
             default:
-                throw new Error("Unsupported enum type");
+                throw new UserError("Unsupported enum type");
         }
     }
 

--- a/src/generateSdk/sdkGeneratorHandler.ts
+++ b/src/generateSdk/sdkGeneratorHandler.ts
@@ -12,6 +12,7 @@ import {
 } from "../models/genezioModels.js";
 import { debugLogger } from "../utils/logging.js";
 import zod from "zod";
+import { UserError } from "../errors.js";
 
 interface SdkGeneratorPlugin {
     SdkGenerator: new () => SdkGeneratorInterface;
@@ -37,13 +38,13 @@ export async function generateSdk(
             plugins?.map(async (plugin) => {
                 const dynamicPlugin = await import(plugin).catch((err) => {
                     debugLogger.debug(err);
-                    throw new Error(
+                    throw new UserError(
                         `Plugin(${plugin}) not found. Install it with npm install ${plugin}`,
                     );
                 });
 
                 if (!dynamicPlugin) {
-                    throw new Error(`Plugin(${plugin}) could not be imported.`);
+                    throw new UserError(`Plugin(${plugin}) could not be imported.`);
                 }
 
                 // Check type of plugin at runtime
@@ -52,7 +53,7 @@ export async function generateSdk(
                     supportedExtensions: zod.array(zod.string()),
                 });
                 if (pluginSchema.safeParse(dynamicPlugin).success === false) {
-                    throw new Error(
+                    throw new UserError(
                         `Plugin(${plugin}) is not a valid SDK generator plugin. It must export a SdkGenerator class and supportedLanguages array.`,
                     );
                 }
@@ -77,7 +78,7 @@ export async function generateSdk(
     });
 
     if (!sdkGeneratorElem) {
-        throw new Error(`SDK language(${language}) not supported`);
+        throw new UserError(`SDK language(${language}) not supported`);
     }
 
     const sdkGeneratorClass = new sdkGeneratorElem.SdkGenerator();

--- a/src/generateSdk/sdkSuccessReport.ts
+++ b/src/generateSdk/sdkSuccessReport.ts
@@ -5,6 +5,7 @@ import colors from "colors";
 import boxen from "boxen";
 import packageManager from "../packageManagers/packageManager.js";
 import { Language, TriggerType } from "../yamlProjectConfiguration/models.js";
+import { UserError } from "../errors.js";
 
 export function reportSuccessForSdk(
     language: Language,
@@ -24,7 +25,7 @@ export function reportSuccessForSdk(
             return reportSuccessForSdkOtherLanguages();
             return;
         default:
-            throw new Error("Language not supported");
+            throw new UserError("Language not supported");
     }
 }
 

--- a/src/generateSdk/sdkWriter/sdkWriter.ts
+++ b/src/generateSdk/sdkWriter/sdkWriter.ts
@@ -1,3 +1,4 @@
+import { UserError } from "../../errors.js";
 import { SdkGeneratorResponse } from "../../models/sdkGeneratorResponse.js";
 import { ClassUrlMap } from "../../utils/sdk.js";
 import { Language } from "../../yamlProjectConfiguration/models.js";
@@ -65,6 +66,6 @@ export async function writeSdk(input: WriteSdkInput): Promise<string | undefined
             }
             break;
         default:
-            throw new Error(`Language ${input.language} is not supported`);
+            throw new UserError(`Language ${input.language} is not supported`);
     }
 }

--- a/src/generateSdk/utils/compileSdk.ts
+++ b/src/generateSdk/utils/compileSdk.ts
@@ -10,6 +10,7 @@ import packageManager from "../../packageManagers/packageManager.js";
 import { listFilesWithExtension } from "../../utils/file.js";
 import { fileURLToPath } from "url";
 import { doAdaptiveLogAction } from "../../utils/logging.js";
+import { UserError } from "../../errors.js";
 
 const compilerWorkerScript = `const { parentPort, workerData } = require("worker_threads");
 
@@ -29,7 +30,7 @@ function createWorker(workerScript: string, workerData: object) {
         worker.on("error", reject);
         worker.on("exit", (code) => {
             if (code !== 0) {
-                reject(new Error(`Worker stopped with exit code ${code}`));
+                reject(new UserError(`Worker stopped with exit code ${code}`));
             }
         });
     });
@@ -57,7 +58,7 @@ export async function compileSdk(
     } else if (language === Language.js) {
         extension = ".js";
     } else {
-        throw new Error("Language not supported");
+        throw new UserError("Language not supported");
     }
     const filenames = await listFilesWithExtension(sdkPath, extension);
     // compile the sdk to cjs and esm using worker threads

--- a/src/generateSdk/utils/mapDbAstToFullAst.ts
+++ b/src/generateSdk/utils/mapDbAstToFullAst.ts
@@ -1,3 +1,4 @@
+import { UserError } from "../../errors.js";
 import { AstSummaryClassResponse } from "../../models/astSummary.js";
 import {
     AstNodeType,
@@ -12,7 +13,7 @@ import {
 
 export function mapDbAstToSdkGeneratorAst(ast: AstSummaryClassResponse): Program {
     if (ast.version !== "2") {
-        throw new Error(
+        throw new UserError(
             "Cannot generate SDK due to unsupported version. Please update your genezio CLI tool, redeploy your project, and try again.",
         );
     }

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -103,6 +103,7 @@ program
             "info",
             "warn",
             "error",
+            "disable",
         ]),
     )
     .hook("preAction", (thisCommand: Command) => {

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -6,6 +6,7 @@ import { SdkGeneratorResponse } from "./sdkGeneratorResponse.js";
 import { TriggerType } from "../yamlProjectConfiguration/models.js";
 import { YamlProjectConfiguration } from "../yamlProjectConfiguration/v2.js";
 import path from "path";
+import { UserError } from "../errors.js";
 export class ParameterType {
     name: string;
     type: any;
@@ -126,7 +127,7 @@ export class ProjectConfiguration {
                 (yamlC) => path.join(yamlConfiguration.backend?.path || ".", yamlC.path) === c.path,
             );
             if (!yamlClass) {
-                throw new Error(
+                throw new UserError(
                     `[Project Configuration] Class configuration not found for ${c.path}`,
                 );
             }

--- a/src/models/semanticVersion.ts
+++ b/src/models/semanticVersion.ts
@@ -1,3 +1,5 @@
+import { UserError } from "../errors.js";
+
 export class SemanticVersion {
     major: number;
     minor: number;
@@ -6,7 +8,7 @@ export class SemanticVersion {
     constructor(versionString: string) {
         const match = versionString.match(/^(\d+)\.(\d+)\.(\d+)$/);
         if (!match) {
-            throw new Error(`Invalid SemVer version string: ${versionString}`);
+            throw new UserError(`Invalid SemVer version string: ${versionString}`);
         }
 
         this.major = Number(match[1]);

--- a/src/packageManagers/yarn.ts
+++ b/src/packageManagers/yarn.ts
@@ -1,6 +1,7 @@
 import { cmp } from "semver";
 import { PackageManager } from "./packageManager.js";
 import { $ } from "execa";
+import { UserError } from "../errors.js";
 
 export default class YarnPackageManager implements PackageManager {
     readonly command = "yarn";
@@ -40,7 +41,7 @@ export default class YarnPackageManager implements PackageManager {
 
     async addScopedRegistry(scope: string, url: string, authToken?: string) {
         if (cmp(await this.getVersion(), "<", "2.0.0")) {
-            throw new Error(
+            throw new UserError(
                 "yarn v1 (classic) is not supported. Please update yarn to v2.0.0 or above.",
             );
         }
@@ -55,7 +56,7 @@ export default class YarnPackageManager implements PackageManager {
 
     async removeScopedRegistry(scope: string) {
         if (cmp(await this.getVersion(), "<", "2.0.0")) {
-            throw new Error(
+            throw new UserError(
                 "yarn v1 (classic) is not supported. Please update yarn to v2.0.0 or above.",
             );
         }

--- a/src/requests/axios.ts
+++ b/src/requests/axios.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios";
 import { debugLogger } from "../utils/logging.js";
 import { StatusError } from "./models.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 
 enum GenezioErrorCode {
     UnknownError = 0,
@@ -23,28 +23,28 @@ axios.interceptors.response.use(
     function (error: AxiosError<StatusError>) {
         const response = error.response;
         if (!response) {
-            throw new Error("There was an error connecting to the server.");
+            throw new UserError("There was an error connecting to the server.");
         }
 
         if (response.status === 402) {
-            throw new Error(
+            throw new UserError(
                 "You've hit the maximum number of projects. To continue, please upgrade your subscription.",
             );
         }
         if (response.data.error.code === GenezioErrorCode.UpdateRequired) {
-            throw new Error("Please update your genezio CLI. Run 'npm update -g genezio'.");
+            throw new UserError("Please update your genezio CLI. Run 'npm update -g genezio'.");
         }
         if (response.data.error.code === GenezioErrorCode.Unauthorized) {
-            throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+            throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
         }
 
         debugLogger.debug("Axios error received:", JSON.stringify(response.data.error));
 
         if (response.data.status === "error") {
-            throw new Error(response.data.error.message);
+            throw new UserError(response.data.error.message);
         }
 
-        throw new Error("An unknown error occurred. Please file a bug report.");
+        throw new UserError("An unknown error occurred. Please file a bug report.");
     },
 );
 

--- a/src/requests/createFrontendProject.ts
+++ b/src/requests/createFrontendProject.ts
@@ -1,6 +1,6 @@
 import axios from "./axios.js";
 import { getAuthToken } from "../utils/accounts.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 
@@ -13,7 +13,7 @@ export async function createFrontendProject(
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+        throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
     }
 
     const json = JSON.stringify({

--- a/src/requests/deleteProject.ts
+++ b/src/requests/deleteProject.ts
@@ -5,7 +5,7 @@ import { debugLogger, printAdaptiveLog, printUninformativeLog } from "../utils/l
 import { AbortController } from "node-abort-controller";
 import version from "../utils/version.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 import { AxiosResponse } from "axios";
 import { StatusOk } from "./models.js";
 
@@ -18,7 +18,7 @@ export default async function deleteProject(projectId: string): Promise<boolean>
     const authToken = await getAuthToken();
     if (!authToken) {
         printAdaptiveLog("Checking your credentials", "error");
-        throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+        throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
     }
     printAdaptiveLog("Checking your credentials", "end");
 

--- a/src/requests/deployCode.ts
+++ b/src/requests/deployCode.ts
@@ -9,6 +9,7 @@ import { AbortController } from "node-abort-controller";
 import version from "../utils/version.js";
 import { AxiosResponse } from "axios";
 import { StatusOk } from "./models.js";
+import { UserError } from "../errors.js";
 
 export async function deployRequest(
     projectConfiguration: ProjectConfiguration,
@@ -19,7 +20,7 @@ export async function deployRequest(
     const authToken = await getAuthToken();
     if (!authToken) {
         printAdaptiveLog("Checking your credentials", "error");
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }

--- a/src/requests/getAuthStatus.ts
+++ b/src/requests/getAuthStatus.ts
@@ -5,12 +5,13 @@ import version from "../utils/version.js";
 import { AuthStatus } from "./models.js";
 import { AxiosResponse } from "axios";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
+import { UserError } from "../errors.js";
 
 export default async function getAuthStatus(envId: string): Promise<AuthStatus> {
     const authToken = await getAuthToken();
 
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }
@@ -38,7 +39,7 @@ export default async function getAuthStatus(envId: string): Promise<AuthStatus> 
                 authStatus.token = id;
                 break;
             default:
-                throw new Error("Wrong auth token format. Check your token and try again");
+                throw new UserError("Wrong auth token format. Check your token and try again");
         }
     }
 

--- a/src/requests/getCompileDartPresignedURL.ts
+++ b/src/requests/getCompileDartPresignedURL.ts
@@ -4,16 +4,17 @@ import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 import { AxiosResponse } from "axios";
 import { StatusOk } from "./models.js";
+import { UserError } from "../errors.js";
 
 export async function getCompileDartPresignedURL(archiveName: string) {
     if (!archiveName) {
-        throw new Error("Missing required parameters");
+        throw new UserError("Missing required parameters");
     }
 
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }
@@ -36,7 +37,7 @@ export async function getCompileDartPresignedURL(archiveName: string) {
         });
 
     if (response.data.presignedURL === undefined) {
-        throw new Error("The endpoint did not return a presigned url.");
+        throw new UserError("The endpoint did not return a presigned url.");
     }
 
     return { ...response.data, presignedURL: response.data.presignedURL };

--- a/src/requests/getEnvironmentVariables.ts
+++ b/src/requests/getEnvironmentVariables.ts
@@ -4,6 +4,7 @@ import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 import { AxiosResponse } from "axios";
 import { ObfuscatedEnvironmentVariable, StatusOk } from "./models.js";
+import { UserError } from "../errors.js";
 
 export async function getEnvironmentVariables(
     projectId: string,
@@ -11,13 +12,13 @@ export async function getEnvironmentVariables(
 ): Promise<ObfuscatedEnvironmentVariable[]> {
     // validate parameters
     if (!projectId) {
-        throw new Error("Missing required parameters");
+        throw new UserError("Missing required parameters");
     }
 
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }

--- a/src/requests/getFrontendPresignedURL.ts
+++ b/src/requests/getFrontendPresignedURL.ts
@@ -1,7 +1,7 @@
 import axios from "./axios.js";
 import { getAuthToken } from "../utils/accounts.js";
 import { BACKEND_ENDPOINT } from "../constants.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 import { AxiosResponse } from "axios";
 import version from "../utils/version.js";
 import { StatusOk } from "./models.js";
@@ -13,13 +13,13 @@ export async function getFrontendPresignedURL(
 ) {
     const region = "us-east-1";
     if (!subdomain || !projectName) {
-        throw new Error("Missing required parameters");
+        throw new UserError("Missing required parameters");
     }
 
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+        throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
     }
 
     const json = JSON.stringify({

--- a/src/requests/getPresignedURL.ts
+++ b/src/requests/getPresignedURL.ts
@@ -4,6 +4,7 @@ import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 import { AxiosResponse } from "axios";
 import { StatusOk } from "./models.js";
+import { UserError } from "../errors.js";
 
 export async function getPresignedURL(
     region = "us-east-1",
@@ -12,13 +13,13 @@ export async function getPresignedURL(
     className: string,
 ) {
     if (!region || !archiveName || !projectName || !className) {
-        throw new Error("Missing required parameters");
+        throw new UserError("Missing required parameters");
     }
 
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }

--- a/src/requests/getProjectInfo.ts
+++ b/src/requests/getProjectInfo.ts
@@ -4,12 +4,13 @@ import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 import { ProjectDetails, StatusOk } from "./models.js";
 import { AxiosResponse } from "axios";
+import { UserError } from "../errors.js";
 
 export default async function getProjectInfo(projectId: string): Promise<ProjectDetails> {
     const authToken = await getAuthToken();
 
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }

--- a/src/requests/getProjectInfoByName.ts
+++ b/src/requests/getProjectInfoByName.ts
@@ -4,6 +4,7 @@ import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 import { ProjectDetails, StatusOk } from "./models.js";
 import { AxiosResponse } from "axios";
+import { UserError } from "../errors.js";
 
 export default async function getProjectInfoByName(
     projectName: string,
@@ -12,7 +13,7 @@ export default async function getProjectInfoByName(
     const authToken = await getAuthToken();
 
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }

--- a/src/requests/getUser.ts
+++ b/src/requests/getUser.ts
@@ -2,13 +2,13 @@ import axios, { AxiosResponse } from "axios";
 import { StatusOk, UserPayload } from "./models.js";
 import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 import { getAuthToken } from "../utils/accounts.js";
 
 export default async function getUser(): Promise<UserPayload> {
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+        throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
     }
 
     const response: AxiosResponse<StatusOk<{ user: UserPayload }>> = await axios({

--- a/src/requests/listProjects.ts
+++ b/src/requests/listProjects.ts
@@ -2,7 +2,7 @@ import axios from "./axios.js";
 import { getAuthToken } from "../utils/accounts.js";
 import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 import { ProjectListElement, StatusOk } from "./models.js";
 import { AxiosResponse } from "axios";
 
@@ -10,7 +10,7 @@ export default async function listProjects(index = 0, limit = 100): Promise<Proj
     const authToken = await getAuthToken();
 
     if (!authToken) {
-        throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+        throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
     }
 
     const response: AxiosResponse<StatusOk<{ projects: ProjectListElement[] }>> = await axios({

--- a/src/requests/setEnvironmentVariables.ts
+++ b/src/requests/setEnvironmentVariables.ts
@@ -3,6 +3,7 @@ import { getAuthToken } from "../utils/accounts.js";
 import { BACKEND_ENDPOINT } from "../constants.js";
 import version from "../utils/version.js";
 import { EnvironmentVariable } from "../models/environmentVariables.js";
+import { UserError } from "../errors.js";
 
 export async function setEnvironmentVariables(
     projectId: string,
@@ -11,13 +12,13 @@ export async function setEnvironmentVariables(
 ) {
     // validate parameters
     if (!projectId) {
-        throw new Error("Missing required parameters");
+        throw new UserError("Missing required parameters");
     }
 
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }

--- a/src/requests/uploadContentToS3.ts
+++ b/src/requests/uploadContentToS3.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import { getAuthToken } from "../utils/accounts.js";
 import https from "https";
 import { OutgoingHttpHeaders } from "http";
+import { UserError } from "../errors.js";
 
 export async function uploadContentToS3(
     presignedURL: string | undefined,
@@ -10,17 +11,17 @@ export async function uploadContentToS3(
     userId?: string,
 ) {
     if (!presignedURL) {
-        throw new Error("Missing presigned URL");
+        throw new UserError("Missing presigned URL");
     }
 
     if (!archivePath) {
-        throw new Error("Missing required parameters");
+        throw new UserError("Missing required parameters");
     }
 
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
-        throw new Error(
+        throw new UserError(
             "You are not logged in. Run 'genezio login' before you deploy your function.",
         );
     }

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -91,7 +91,7 @@ export class GenezioTelemetry {
         const timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
         // send event to telemetry
-        debugLogger.debug(
+        debugLogger.trace(
             `[GenezioTelemetry]`,
             `${timeZone} ${eventRequest.eventType} ${sessionId} ${userLanguage} ${operatingSystem} ${eventRequest.cloudProvider} ${eventRequest.errorTrace}`,
         );

--- a/src/utils/abTesting.ts
+++ b/src/utils/abTesting.ts
@@ -4,7 +4,7 @@ import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
 import { ProjectDetails, StatusOk } from "../requests/models.js";
 import { getAuthToken } from "./accounts.js";
 import { BACKEND_ENDPOINT } from "../constants.js";
-import { GENEZIO_NOT_AUTH_ERROR_MSG } from "../errors.js";
+import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 
 // This function is used to check if the project is already deployed.
 // Do not reuse this method in the future, this is only used for AB testing and it will be removed soon.
@@ -15,7 +15,7 @@ export async function isProjectDeployed(name: string, region: string): Promise<b
         const authToken = await getAuthToken();
 
         if (!authToken) {
-            throw new Error(GENEZIO_NOT_AUTH_ERROR_MSG);
+            throw new UserError(GENEZIO_NOT_AUTH_ERROR_MSG);
         }
 
         const response: AxiosResponse<StatusOk<{ project: ProjectDetails }>> =

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -19,6 +19,7 @@ import {
     isStringLiteral,
 } from "@babel/types";
 import { TriggerType } from "../yamlProjectConfiguration/models.js";
+import { UserError } from "../errors.js";
 
 type MethodDecoratorInfo = {
     name: string;
@@ -278,7 +279,7 @@ export async function scanClassesForDecorators(
 export function getTriggerTypeFromString(string: string): TriggerType {
     if (string && !TriggerType[string as keyof typeof TriggerType]) {
         const triggerTypes: string = Object.keys(TriggerType).join(", ");
-        throw new Error(
+        throw new UserError(
             "Specified class type for " +
                 string +
                 " is incorrect. Accepted values: " +

--- a/src/utils/dart.ts
+++ b/src/utils/dart.ts
@@ -1,7 +1,7 @@
 import which from "which";
 import os from "os";
 import path from "path";
-import { GENEZIO_DARTAOTRUNTIME_NOT_FOUND, GENEZIO_DART_NOT_FOUND } from "../errors.js";
+import { GENEZIO_DARTAOTRUNTIME_NOT_FOUND, GENEZIO_DART_NOT_FOUND, UserError } from "../errors.js";
 import { SemanticVersion } from "../models/semanticVersion.js";
 import { execSync } from "child_process";
 
@@ -24,14 +24,14 @@ export async function checkIfDartIsInstalled(): Promise<boolean> {
     try {
         await which("dartaotruntime");
     } catch (e) {
-        throw new Error(GENEZIO_DARTAOTRUNTIME_NOT_FOUND);
+        throw new UserError(GENEZIO_DARTAOTRUNTIME_NOT_FOUND);
     }
 
     if (version) {
         return true;
     }
 
-    throw new Error(GENEZIO_DART_NOT_FOUND);
+    throw new UserError(GENEZIO_DART_NOT_FOUND);
 }
 
 export function getDartAstGeneratorPath(dartSdkVersion: string): {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -14,6 +14,7 @@ import { EnvironmentVariable } from "../models/environmentVariables.js";
 import dotenv from "dotenv";
 import fsExtra from "fs-extra";
 import packageManager from "../packageManagers/packageManager.js";
+import { UserError } from "../errors.js";
 
 export async function getAllFilesRecursively(folderPath: string): Promise<string[]> {
     let files: string[] = [];
@@ -388,7 +389,7 @@ export async function validateYamlFile() {
     try {
         configurationFileContent = await parse(configurationFileContentUTF8);
     } catch (error) {
-        throw new Error(`The configuration yaml file is not valid.\n${error}`);
+        throw new UserError(`The configuration yaml file is not valid.\n${error}`);
     }
 
     if (configurationFileContent.classes.length === 0) {

--- a/src/utils/go.ts
+++ b/src/utils/go.ts
@@ -1,4 +1,5 @@
 import { execSync } from "child_process";
+import { UserError } from "../errors.js";
 
 export function checkIfGoIsInstalled() {
     const GoNotFoundError = `Error: Go not found`;
@@ -7,7 +8,7 @@ export function checkIfGoIsInstalled() {
     try {
         execSync("go version");
     } catch (error) {
-        const goErr = new Error(GoNotFoundError);
+        const goErr = new UserError(GoNotFoundError);
         goErr.stack = "";
         throw goErr;
     }

--- a/src/utils/jsProjectChecker.ts
+++ b/src/utils/jsProjectChecker.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import semver from "semver";
 import { debugLogger } from "./logging.js";
 import path from "path";
+import { UserError } from "../errors.js";
 
 /**
  * Reads the package.json file from a given path and checks if the version
@@ -50,7 +51,7 @@ export function checkExperimentalDecorators(backendPath: string) {
         // ignore error
     }
     if (tsconfig?.compilerOptions?.experimentalDecorators === true) {
-        throw new Error(
+        throw new UserError(
             `The experimentalDecorators option is enabled in your ${tsconfigPath} file. Please disable it to use genezio decorators.`,
         );
     }

--- a/src/utils/kotlin.ts
+++ b/src/utils/kotlin.ts
@@ -1,4 +1,5 @@
 import { execSync } from "child_process";
+import { UserError } from "../errors.js";
 
 export function checkIfKotlinReqsAreInstalled() {
     const JavaNotFoundError = `Error: Java not found`;
@@ -10,7 +11,7 @@ export function checkIfKotlinReqsAreInstalled() {
     try {
         execSync("javac -version");
     } catch (error) {
-        const java_err = new Error(JavaNotFoundError);
+        const java_err = new UserError(JavaNotFoundError);
         java_err.stack = "";
         throw java_err;
     }
@@ -19,7 +20,7 @@ export function checkIfKotlinReqsAreInstalled() {
     try {
         execSync("kotlin -version");
     } catch (error) {
-        const kotlin_err = new Error(KotlinNotFoundError);
+        const kotlin_err = new UserError(KotlinNotFoundError);
         kotlin_err.stack = "";
         throw kotlin_err;
     }
@@ -28,7 +29,7 @@ export function checkIfKotlinReqsAreInstalled() {
     try {
         execSync("gradle -version");
     } catch (error) {
-        const gradle_err = new Error(GradleNotFoundError);
+        const gradle_err = new UserError(GradleNotFoundError);
         gradle_err.stack = "";
         throw gradle_err;
     }

--- a/src/utils/scripts.ts
+++ b/src/utils/scripts.ts
@@ -1,3 +1,4 @@
+import { UserError } from "../errors.js";
 import { runNewProcess } from "./process.js";
 
 export async function runScript(
@@ -15,6 +16,6 @@ export async function runScript(
     for (const script of scripts) {
         // TODO: use execa instead of runNewProcess
         const success = await runNewProcess(script, cwd);
-        if (!success) throw new Error(`Failed to run script: ${script}`);
+        if (!success) throw new UserError(`Failed to run script: ${script}`);
     }
 }

--- a/src/utils/transformDecorators.ts
+++ b/src/utils/transformDecorators.ts
@@ -2,6 +2,7 @@ import { createRequire } from "module";
 import path from "path";
 import babel from "@babel/core";
 import fs from "fs";
+import { UserError } from "../errors.js";
 
 export default async function (filePath: string): Promise<string> {
     const fileData = fs.readFileSync(filePath, "utf8");
@@ -17,7 +18,7 @@ export default async function (filePath: string): Promise<string> {
     });
 
     if (!babelOutput?.code) {
-        throw new Error("Error while transforming decorators!");
+        throw new UserError("Error while transforming decorators!");
     }
 
     return babelOutput.code;

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -5,6 +5,7 @@ import latestVersion from "latest-version";
 import { log } from "./logging.js";
 import { createRequire } from "module";
 import { NODE_MINIMUM_VERSION } from "../constants.js";
+import { UserError } from "../errors.js";
 const requireESM = createRequire(import.meta.url);
 
 const pjson = requireESM("../../package.json");
@@ -35,7 +36,7 @@ export async function logOutdatedVersion() {
 
 export function checkNodeMinimumVersion() {
     if (cmp(process.version, "<", NODE_MINIMUM_VERSION)) {
-        throw new Error(
+        throw new UserError(
             `Genezio CLI requires Node.js version v${NODE_MINIMUM_VERSION} or higher. You are currently running Node.js ${process.version}. Please update your version of Node.js.`,
         );
     }

--- a/src/yamlProjectConfiguration/migration.ts
+++ b/src/yamlProjectConfiguration/migration.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { scanClassesForDecorators } from "../utils/configuration.js";
 import _ from "lodash";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
+import { UserError } from "../errors.js";
 
 export async function tryV2Migration(config: unknown): Promise<v2 | undefined> {
     if (process.env["CI"]) return undefined;
@@ -20,7 +21,7 @@ export async function tryV2Migration(config: unknown): Promise<v2 | undefined> {
         });
         if (!migrate) {
             // TODO: Add migration article link
-            throw new Error("genezio >= 1.0.0 needs a `genezio.yaml` file with version 2");
+            throw new UserError("genezio >= 1.0.0 needs a `genezio.yaml` file with version 2");
         }
 
         let frontendPath = undefined,

--- a/src/yamlProjectConfiguration/v1.ts
+++ b/src/yamlProjectConfiguration/v1.ts
@@ -6,7 +6,7 @@ import { isValidCron } from "cron-validator";
 import { DEFAULT_NODE_RUNTIME, NodeOptions, supportedNodeRuntimes } from "../models/nodeRuntime.js";
 import zod from "zod";
 import { log } from "../utils/logging.js";
-import { zodFormatError } from "../errors.js";
+import { UserError, zodFormatError } from "../errors.js";
 import { Language, TriggerType } from "./models.js";
 import { PackageManagerType } from "../packageManagers/packageManager.js";
 
@@ -22,7 +22,7 @@ enum CloudProviderIdentifier {
 export function getTriggerTypeFromString(string: string): TriggerType {
     if (string && !TriggerType[string as keyof typeof TriggerType]) {
         const triggerTypes: string = Object.keys(TriggerType).join(", ");
-        throw new Error(
+        throw new UserError(
             "Specified class type for " +
                 string +
                 " is incorrect. Accepted values: " +
@@ -217,7 +217,7 @@ export class YamlProjectConfiguration {
         );
 
         if (!classConfiguration) {
-            throw new Error("Class configuration not found for path " + path);
+            throw new UserError("Class configuration not found for path " + path);
         }
 
         return classConfiguration;
@@ -362,11 +362,11 @@ export class YamlProjectConfiguration {
             configurationFile = configurationFileSchema.parse(configurationFileContent);
         } catch (e) {
             if (e instanceof zod.ZodError) {
-                throw new Error(
+                throw new UserError(
                     `There was a problem parsing your YAML configuration!\n${zodFormatError(e)}`,
                 );
             }
-            throw new Error(`There was a problem parsing your YAML configuration!\n${e}`);
+            throw new UserError(`There was a problem parsing your YAML configuration!\n${e}`);
         }
 
         const unparsedClasses = configurationFile.classes || [];

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -3,7 +3,7 @@ import zod from "zod";
 import nativeFs from "fs";
 import { IFs } from "memfs";
 import { regions } from "../utils/configs.js";
-import { zodFormatError } from "../errors.js";
+import { UserError, zodFormatError } from "../errors.js";
 import { Language } from "./models.js";
 import { DEFAULT_NODE_RUNTIME, supportedNodeRuntimes } from "../models/nodeRuntime.js";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
@@ -222,11 +222,11 @@ export class YamlConfigurationIOController {
                 await this.fs.promises.writeFile(this.filePath, yaml.stringify(genezioConfig));
             } else {
                 if (e instanceof zod.ZodError) {
-                    throw new Error(
+                    throw new UserError(
                         `There was a problem parsing your YAML configuration!\n${zodFormatError(e)}`,
                     );
                 }
-                throw new Error(`There was a problem parsing your YAML configuration!\n${e}`);
+                throw new UserError(`There was a problem parsing your YAML configuration!\n${e}`);
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

Added a new class extending the base Error class, named `UserError`. When explicitly throwing an error, it should be instantiated with the `UserError` constructor. This way, we can differentiate errors we are aware of from the others.

We, as developers, will only see the error stacks logged for "unknown" errors using the debug logger. For `UserError`s, we and the users will see just the error message, using the main logger.

Unknown errors are also reported to sentry.

Also added an option to completely disable the debug logger, using `--logLevel disable`

## Checklist

-   [ ] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [ ] New and existing unit tests pass locally with my changes;
