### PR TITLE
catch genezio.yaml ENOENT error + small fixes

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -226,7 +226,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
     if (deployClassesResult) {
         log.info(
             colors.cyan(
-                `Genezio project URL: ${DASHBOARD_URL}/project/${deployClassesResult.projectId}/${deployClassesResult.projectEnvId}`,
+                `App Dashboard URL: ${DASHBOARD_URL}/project/${deployClassesResult.projectId}/${deployClassesResult.projectEnvId}`,
             ),
         );
     }

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -34,7 +34,6 @@ import { DartBundler } from "../bundlers/dart/localDartBundler.js";
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { findAvailablePort } from "../utils/findAvailablePort.js";
 import { Language, TriggerType } from "../yamlProjectConfiguration/models.js";
-import { PackageManagerType } from "../packageManagers/packageManager.js";
 import {
     YamlConfigurationIOController,
     YamlFrontend,
@@ -44,7 +43,6 @@ import hash from "hash-it";
 import { GenezioTelemetry, TelemetryEventTypes } from "../telemetry/telemetry.js";
 import dotenv from "dotenv";
 import { TsRequiredDepsBundler } from "../bundlers/node/typescriptRequiredDepsBundler.js";
-import inquirer, { Answers } from "inquirer";
 import { DEFAULT_NODE_RUNTIME } from "../models/nodeRuntime.js";
 import { exit } from "process";
 import { log } from "../utils/logging.js";
@@ -244,22 +242,6 @@ export async function startLocalEnvironment(options: GenezioLocalOptions) {
             }
             logChangeDetection();
             continue;
-        }
-
-        if (!backendConfiguration.language.packageManager) {
-            const optionalPackageManager: Answers = await inquirer.prompt([
-                {
-                    type: "list",
-                    name: "packageManager",
-                    message:
-                        "Which package manager are you using to install your frontend dependencies?",
-                    choices: Object.keys(PackageManagerType).filter((key) => isNaN(Number(key))),
-                },
-            ]);
-
-            const yamlConfig = await yamlConfigIOController.read(/* fillDefaults= */ false);
-            yamlConfig.backend!.language.packageManager = optionalPackageManager["packageManager"];
-            await yamlConfigIOController.write(yamlConfig);
         }
 
         let sdk: SdkGeneratorResponse;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -35,6 +35,8 @@ export const GENEZIO_NOT_ENOUGH_PERMISSION_FOR_FILE = function (filePath: string
 export const GENEZIO_GIT_NOT_FOUND = `Git is not installed. Please install it and try again.
 https://git-scm.com/book/en/v2/Getting-Started-Installing-Git`;
 
+export const GENEZIO_CONFIGURATION_FILE_NOT_FOUND = `The genezio.yaml configuration file was not found. Please execute this command at the root of your project.\nIf you don't have a project yet, you can create one by running the command 'genezio create'.`;
+
 function collectIssueMap(e: zod.ZodError, issueMap: Map<string, string[]>) {
     for (const issue of e.issues) {
         if (issue.code === "invalid_union") {

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -199,7 +199,7 @@ export class YamlConfigurationIOController {
         let lastModified: Date;
         try {
             lastModified = this.fs.statSync(this.filePath).mtime;
-        } catch (e) {
+        } catch {
             throw new UserError(GENEZIO_CONFIGURATION_FILE_NOT_FOUND);
         }
         if (this.cachedConfig && cache && this.latestRead && this.latestRead >= lastModified) {

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -3,7 +3,7 @@ import zod from "zod";
 import nativeFs from "fs";
 import { IFs } from "memfs";
 import { regions } from "../utils/configs.js";
-import { UserError, zodFormatError } from "../errors.js";
+import { GENEZIO_CONFIGURATION_FILE_NOT_FOUND, UserError, zodFormatError } from "../errors.js";
 import { Language } from "./models.js";
 import { DEFAULT_NODE_RUNTIME, supportedNodeRuntimes } from "../models/nodeRuntime.js";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
@@ -196,7 +196,12 @@ export class YamlConfigurationIOController {
         fillDefaults: boolean = true,
         cache: boolean = true,
     ): Promise<YamlProjectConfiguration | RawYamlProjectConfiguration> {
-        const lastModified = this.fs.statSync(this.filePath).mtime;
+        let lastModified: Date;
+        try {
+            lastModified = this.fs.statSync(this.filePath).mtime;
+        } catch (e) {
+            throw new UserError(GENEZIO_CONFIGURATION_FILE_NOT_FOUND);
+        }
         if (this.cachedConfig && cache && this.latestRead && this.latestRead >= lastModified) {
             if (fillDefaults) {
                 return fillDefaultGenezioConfig(this.cachedConfig);


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

Caught ENOENT error when genezio.yaml file is not found and wrapp it with `UserError`
Changed the `Genezio project URL` log with something more intuitive
Removed annoying package manager prompt on `genezio local` (defaults to npm if not explicit)

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
