### PR TITLE
fix genezio link

### DIFF
--- a/src/commands/create/create.ts
+++ b/src/commands/create/create.ts
@@ -77,11 +77,7 @@ export async function createCommand(options: GenezioCreateOptions) {
                     break;
                 case true:
                     // Genezio link inside the client project
-                    await setLinkPathForProject(
-                        options.name,
-                        options.region,
-                        path.join(projectPath, "client"),
-                    );
+                    await setLinkPathForProject(options.name, path.join(projectPath, "client"));
                     log.info(SUCCESSFULL_CREATE_MULTIREPO(projectPath, options.name));
                     break;
             }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -6,42 +6,31 @@ import {
 import { log } from "../utils/logging.js";
 import yamlConfigIOController from "../yamlProjectConfiguration/v2.js";
 
-export async function linkCommand(
-    projectName: string | undefined,
-    projectRegion: string | undefined,
-) {
+export async function linkCommand(projectName: string | undefined) {
     const cwd = process.cwd();
     let name = projectName;
-    let region = projectRegion;
-    if (!name || !region) {
+    if (!name) {
         const projectConfiguration = await yamlConfigIOController.read();
         name = projectConfiguration.name;
-        region = projectConfiguration.region;
     }
 
-    await setLinkPathForProject(name, region, cwd);
+    await setLinkPathForProject(name, cwd);
 
     log.info("Successfully linked the path to your genezio project.");
 }
 
-export async function unlinkCommand(
-    unlinkAll: boolean,
-    projectName: string | undefined,
-    projectRegion: string | undefined,
-) {
+export async function unlinkCommand(unlinkAll: boolean, projectName: string | undefined) {
     if (unlinkAll) {
         await deleteAllLinkPaths();
         return;
     }
     let name = projectName;
-    let region = projectRegion;
-    if (!name || !region) {
+    if (!name) {
         const projectConfiguration = await yamlConfigIOController.read();
         name = projectConfiguration.name;
-        region = projectConfiguration.region;
     }
 
-    await deleteLinkPathForProject(name, region);
+    await deleteLinkPathForProject(name);
 
     if (unlinkAll) {
         log.info("Successfully unlinked all paths to your genezio projects.");

--- a/src/generateSdk/sdkMonitor.ts
+++ b/src/generateSdk/sdkMonitor.ts
@@ -18,10 +18,6 @@ export async function watchPackage(
     frontend: YamlFrontend[] | undefined,
     sdkPath: string,
 ): Promise<NodeJS.Timeout | undefined> {
-    if (frontend === undefined || frontend.length === 0) {
-        return;
-    }
-
     switch (language) {
         case Language.js:
         case Language.ts:
@@ -45,13 +41,11 @@ async function watchNodeModules(
     const sdkName = `${projectName}`;
     const nodeModulesSdkDirectoryPath = path.join("node_modules", "@genezio-sdk", sdkName);
 
-    if (!frontends) {
-        return;
-    }
-
-    for (const f of frontends) {
-        watchPaths.push(path.join(f.path, nodeModulesSdkDirectoryPath));
-        watchPaths.push(path.join(f.path, "node_modules", ".package-lock.json"));
+    if (frontends) {
+        for (const f of frontends) {
+            watchPaths.push(path.join(f.path, nodeModulesSdkDirectoryPath));
+            watchPaths.push(path.join(f.path, "node_modules", ".package-lock.json"));
+        }
     }
 
     const linkPaths = await getLinkPathsForProject(projectName, projectRegion);
@@ -85,7 +79,12 @@ async function watchNodeModules(
                 const res: Result = compareSync(genezioSdkPath, watchPath, options);
                 if (!res.same) {
                     debugLogger.debug(`[WATCH_NODE_MODULES] Rewriting the SDK to node_modules...`);
-                    await writeSdkToNodeModules(projectName, projectRegion, frontends, sdkPath);
+                    await writeSdkToNodeModules(
+                        projectName,
+                        projectRegion,
+                        frontends ?? [],
+                        sdkPath,
+                    );
                 }
             }
         }

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -383,7 +383,7 @@ program
 This command is useful when the project has dedicated repositories for the backend and the frontend.",
     )
     .action(async (options: GenezioLinkOptions) => {
-        await linkCommand(options.projectName, options.region).catch((error) => {
+        await linkCommand(options.projectName).catch((error) => {
             logError(error);
             log.error(
                 "Error: Command execution failed. Please ensure you are running this command from a directory containing 'genezio.yaml' or provide the '--projectName <name>' and '--region <region>' flags.",
@@ -409,7 +409,7 @@ program
 This reset allows 'genezio local' to stop automatically generating the SDK in that location.",
     )
     .action(async (options: GenezioUnlinkOptions) => {
-        await unlinkCommand(options.all, options.projectName, options.region).catch((error) => {
+        await unlinkCommand(options.all, options.projectName).catch((error) => {
             logError(error);
             log.error(
                 "Error: Command execution failed. Please ensure you are running this command from a directory containing 'genezio.yaml' or provide the '--projectName <name>' and '--region <region>' flags.",

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -376,7 +376,6 @@ program
         "--projectName <projectName>",
         "The name of the project that you want to communicate with.",
     )
-    .option("--region <region>", "The region of the project that you want to communicate with.")
     .summary("Links the genezio generated SDK in the current working directory")
     .description(
         "Linking a client with a deployed project will enable `genezio local` to figure out where to generate the SDK to call the backend methods.\n\
@@ -398,10 +397,6 @@ program
     .option(
         "--projectName <projectName>",
         "The name of the project that you want to communicate with. If --all is used, this option is ignored.",
-    )
-    .option(
-        "--region <region>",
-        "The region of the project that you want to communicate with. If --all is used, this option is ignored.",
     )
     .summary("Unlink the generated SDK from a client.")
     .description(

--- a/src/models/commandOptions.ts
+++ b/src/models/commandOptions.ts
@@ -55,13 +55,11 @@ export interface GenezioSdkOptions extends BaseOptions {
 
 export interface GenezioLinkOptions extends BaseOptions {
     projectName?: string;
-    region?: string;
 }
 
 export interface GenezioUnlinkOptions extends BaseOptions {
     all: boolean;
     projectName?: string;
-    region?: string;
 }
 
 export interface GenezioCreateInteractiveOptions extends BaseOptions {

--- a/src/utils/linkDatabase.ts
+++ b/src/utils/linkDatabase.ts
@@ -32,13 +32,9 @@ export async function getLinkPathsForProject(
     return content.get(key) || [];
 }
 
-export async function setLinkPathForProject(
-    projectName: string,
-    region: string,
-    linkPath: string,
-): Promise<void> {
+export async function setLinkPathForProject(projectName: string, linkPath: string): Promise<void> {
     const content = await getLinkContent();
-    const key = `${projectName}:${region}`;
+    const key = `${projectName}`;
     const paths = content.get(key) || [];
     if (paths.includes(linkPath)) {
         return;
@@ -52,9 +48,9 @@ export async function deleteAllLinkPaths(): Promise<void> {
     await saveLinkContent(new Map<string, string[]>());
 }
 
-export async function deleteLinkPathForProject(projectName: string, region: string): Promise<void> {
+export async function deleteLinkPathForProject(projectName: string): Promise<void> {
     const content = await getLinkContent();
-    const key = `${projectName}:${region}`;
+    const key = `${projectName}`;
     content.delete(key);
     await saveLinkContent(content);
 }


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix


## Description

A bug was introduced where genezio would not generate SDK for linked projects if the YAML did not provide a frontend configuration. This PR fixes it and removes the region from the link map key and the command option

Documentation PR regarding this change: https://github.com/Genez-io/genezio-documentation/pull/54

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] I have updated the documentation;
-   [x] New and existing unit tests pass locally with my changes;
