### PR TITLE
parse go decorators with treesitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "@babel/preset-typescript": "^7.23.3",
                 "@babel/traverse": "^7.24.0",
                 "@genezio/test-interface-component": "^0.0.6",
-                "@rollup/rollup-linux-x64-musl": "4.13.0",
                 "@sentry/node": "^7.74.1",
                 "@sentry/profiling-node": "~7.102.1",
                 "archiver": "^6.0.0",
@@ -61,6 +60,8 @@
                 "open": "^9.1.0",
                 "ora": "^8.0.1",
                 "semver": "^7.5.4",
+                "tree-sitter": "^0.20.6",
+                "tree-sitter-go": "^0.20.0",
                 "tslog": "^4.9.2",
                 "typescript": "^5.3.3",
                 "unique-names-generator": "^4.7.1",
@@ -6067,6 +6068,11 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+        },
         "node_modules/clean-git-ref": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
@@ -7717,6 +7723,14 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/express": {
             "version": "4.18.3",
             "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
@@ -8122,6 +8136,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
         },
         "node_modules/glob": {
             "version": "8.1.0",
@@ -9802,6 +9821,11 @@
                 "minimist": "^1.2.5"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
         "node_modules/mlly": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
@@ -9835,6 +9859,11 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
+        "node_modules/nan": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+            "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw=="
+        },
         "node_modules/nanoid": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -9852,6 +9881,11 @@
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
+        },
+        "node_modules/napi-build-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -10481,6 +10515,31 @@
             "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
             "dev": true
         },
+        "node_modules/prebuild-install": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+            "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^1.0.1",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10563,6 +10622,15 @@
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
             "dev": true
+        },
+        "node_modules/pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -11859,6 +11927,32 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-fs/node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/tar-stream": {
             "version": "3.1.6",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
@@ -11969,6 +12063,25 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/tree-sitter": {
+            "version": "0.20.6",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.6.tgz",
+            "integrity": "sha512-GxJodajVpfgb3UREzzIbtA1hyRnTxVbWVXrbC6sk4xTMH5ERMBJk9HJNq4c8jOJeUaIOmLcwg+t6mez/PDvGqg==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "nan": "^2.18.0",
+                "prebuild-install": "^7.1.1"
+            }
+        },
+        "node_modules/tree-sitter-go": {
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.20.0.tgz",
+            "integrity": "sha512-5OBBND9ykffXZnaKrVpk8RnSaZJ26Si8yCfJKPSkEypWrywqCmZOZ74NveqMY0ogmHK2X8mFFuIL5jUnxOKyYw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "nan": "^2.14.0"
+            }
+        },
         "node_modules/ts-api-utils": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -11995,6 +12108,17 @@
             },
             "funding": {
                 "url": "https://github.com/fullstack-build/tslog?sponsor=1"
+            }
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
         "open": "^9.1.0",
         "ora": "^8.0.1",
         "semver": "^7.5.4",
+        "tree-sitter": "^0.20.6",
+        "tree-sitter-go": "^0.20.0",
         "tslog": "^4.9.2",
         "typescript": "^5.3.3",
         "unique-names-generator": "^4.7.1",

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -1,206 +1,26 @@
 import path from "path";
-import { createRequire } from "module";
 import { YAMLBackend, YamlClass, YamlMethod } from "../yamlProjectConfiguration/v2.js";
 import { getAllFilesFromPath } from "./file.js";
-import babel from "@babel/core";
-import fs from "fs";
-import FileDetails from "../models/fileDetails.js";
 import { debugLogger } from "./logging.js";
-import { NodePath } from "@babel/traverse";
-import {
-    ClassDeclaration,
-    ClassMethod,
-    isCallExpression,
-    isIdentifier,
-    isClassDeclaration,
-    CallExpression,
-    isObjectExpression,
-    isObjectProperty,
-    isStringLiteral,
-} from "@babel/types";
 import { TriggerType } from "../yamlProjectConfiguration/models.js";
 import { UserError } from "../errors.js";
-
-type MethodDecoratorInfo = {
-    name: string;
-    arguments?: { [key: string]: string };
-};
-
-type MethodInfo = {
-    name: string;
-    decorators: MethodDecoratorInfo[];
-};
-
-type ClassDecoratorInfo = {
-    name: string;
-    arguments?: { [key: string]: string };
-};
-
-type ClassInfo = {
-    path: string;
-    name: string;
-    decorators: ClassDecoratorInfo[];
-    methods: MethodInfo[];
-};
-
-function parseArguments(args: CallExpression["arguments"]): { [key: string]: string } {
-    if (!args) {
-        return {};
-    }
-
-    return args
-        .map((arg) => {
-            if (isObjectExpression(arg)) {
-                return arg.properties.reduce((acc: Array<{ key: string; value: string }>, curr) => {
-                    if (
-                        isObjectProperty(curr) &&
-                        (isIdentifier(curr.key) || isStringLiteral(curr.key)) &&
-                        isStringLiteral(curr.value)
-                    ) {
-                        const key = isIdentifier(curr.key) ? curr.key.name : curr.key.value;
-                        return [...acc, { key, value: curr.value.value }];
-                    }
-
-                    return [...acc];
-                }, []);
-            } else {
-                return undefined;
-            }
-        })
-        .filter((a) => a !== undefined)
-        .flat()
-        .reduce((acc: { [key: string]: string }, curr) => {
-            acc[curr!.key] = curr!.value;
-            return acc;
-        }, {});
-}
-
-async function getDecoratorsFromFile(file: string): Promise<ClassInfo[]> {
-    const inputCode = fs.readFileSync(file, "utf8");
-    const classes: ClassInfo[] = [];
-    const extractorFunction = function extract() {
-        return {
-            name: "extract-decorators",
-            visitor: {
-                ClassDeclaration(path: NodePath<ClassDeclaration>) {
-                    if (path.node.decorators) {
-                        const info: ClassInfo = {
-                            path: file,
-                            name: path.node.id?.name ?? "default",
-                            decorators: [],
-                            methods: [],
-                        };
-                        for (const decorator of path.node.decorators) {
-                            if (isIdentifier(decorator.expression)) {
-                                info.decorators = [
-                                    ...(info.decorators ?? []),
-                                    { name: decorator.expression.name },
-                                ];
-                            } else if (
-                                isCallExpression(decorator.expression) &&
-                                isIdentifier(decorator.expression.callee)
-                            ) {
-                                info.decorators = [
-                                    ...(info.decorators ?? []),
-                                    {
-                                        name: decorator.expression.callee.name,
-                                        arguments: parseArguments(decorator.expression.arguments),
-                                    },
-                                ];
-                            }
-                        }
-                        classes.push(info);
-                    }
-                },
-                ClassMethod(path: NodePath<ClassMethod>) {
-                    if (path.node.decorators) {
-                        const classDeclarationNode = path.context.parentPath.parentPath?.node;
-                        const className = isClassDeclaration(classDeclarationNode)
-                            ? classDeclarationNode.id?.name ?? "defaultClass"
-                            : "defaultClass";
-
-                        const methodIdentifierNode = path.node.key;
-                        const methodName = isIdentifier(methodIdentifierNode)
-                            ? methodIdentifierNode.name
-                            : "defaultMethod";
-
-                        for (const decorator of path.node.decorators) {
-                            const info: MethodInfo = {
-                                name: methodName,
-                                decorators: [],
-                            };
-                            let existingClass = classes.find((c) => c.name === className);
-                            if (!existingClass) {
-                                existingClass = {
-                                    path: file,
-                                    name: className,
-                                    decorators: [],
-                                    methods: [],
-                                };
-                                classes.push(existingClass);
-                            }
-
-                            if (isIdentifier(decorator.expression)) {
-                                info.decorators = [
-                                    ...(info.decorators ?? []),
-                                    { name: decorator.expression.name },
-                                ];
-                            } else if (
-                                isCallExpression(decorator.expression) &&
-                                isIdentifier(decorator.expression.callee)
-                            ) {
-                                info.decorators = [
-                                    ...(info.decorators ?? []),
-                                    {
-                                        name: decorator.expression.callee.name,
-                                        arguments: parseArguments(decorator.expression.arguments),
-                                    },
-                                ];
-                            }
-
-                            existingClass.methods.push(info);
-                        }
-                    }
-                },
-            },
-        };
-    };
-
-    const require = createRequire(import.meta.url);
-    const packagePath = path.dirname(require.resolve("@babel/plugin-syntax-decorators"));
-    // const presetTypescript = path.dirname(require.resolve("@babel/preset-typescript"));
-    await babel.transformAsync(inputCode, {
-        presets: [require.resolve("@babel/preset-typescript")],
-        plugins: [
-            [packagePath, { version: "2023-05", decoratorsBeforeExport: false }],
-            extractorFunction,
-        ],
-        filename: file,
-        configFile: false,
-    });
-
-    return classes;
-}
+import { DecoratorExtractorFactory } from "./decorators/decoratorFactory.js";
 
 async function tryToReadClassInformationFromDecorators(
-    yamlBackend: Pick<YAMLBackend, "path" | "classes">,
+    yamlBackend: Pick<YAMLBackend, "path" | "classes" | "language">,
 ) {
     const cwd = yamlBackend.path || process.cwd();
 
-    const allJsFilesPaths = (await getAllFilesFromPath(cwd)).filter((file: FileDetails) => {
-        const folderPath = path.join(cwd, file.path);
-        return (
-            (file.extension === ".js" || file.extension === ".ts") &&
-            !file.path.includes("node_modules") &&
-            !file.path.includes(".git") &&
-            !fs.lstatSync(folderPath).isDirectory()
-        );
-    });
+    const decoratorExtractor = DecoratorExtractorFactory.createExtractor(yamlBackend.language.name);
+
+    const allFilesPaths = (await getAllFilesFromPath(cwd)).filter(
+        decoratorExtractor.fileFilter(cwd),
+    );
 
     return await Promise.all(
-        allJsFilesPaths.map((file) => {
+        allFilesPaths.map((file) => {
             const filePath = path.join(cwd, file.path);
-            return getDecoratorsFromFile(filePath).catch((error) => {
+            return decoratorExtractor.getDecoratorsFromFile(filePath).catch((error) => {
                 if (error.reasonCode == "MissingOneOfPlugins") {
                     debugLogger.error(`Error while parsing the file ${file.path}`, error);
                     return [];
@@ -213,9 +33,14 @@ async function tryToReadClassInformationFromDecorators(
 }
 
 export async function scanClassesForDecorators(
-    yamlBackend: Pick<YAMLBackend, "path" | "classes">,
+    yamlBackend: Pick<YAMLBackend, "path" | "classes" | "language">,
 ): Promise<YamlClass[]> {
-    const result = await tryToReadClassInformationFromDecorators(yamlBackend);
+    const result = await tryToReadClassInformationFromDecorators(yamlBackend).catch((error) => {
+        if (error instanceof UserError && error.message.includes("Language not supported")) {
+            debugLogger.debug("Language decorators not supported, skipping scan for decorators.");
+        }
+        return [];
+    });
     const classes: YamlClass[] = yamlBackend.classes || [];
 
     result.forEach((classInfo) => {

--- a/src/utils/decorators/decoratorFactory.ts
+++ b/src/utils/decorators/decoratorFactory.ts
@@ -1,0 +1,26 @@
+import { UserError } from "../../errors.js";
+import FileDetails from "../../models/fileDetails.js";
+import { Language } from "../../yamlProjectConfiguration/models.js";
+import { ClassInfo } from "./decoratorTypes.js";
+import { GoDecoratorExtractor } from "./goDecorators.js";
+import { JsTsDecoratorExtractor } from "./jsTsDecorators.js";
+
+export interface DecoratorExtractor {
+    getDecoratorsFromFile: (file: string) => Promise<ClassInfo[]>;
+    fileFilter: (cwd: string) => (file: FileDetails) => boolean;
+}
+
+export class DecoratorExtractorFactory {
+    static createExtractor = (language: Language): DecoratorExtractor => {
+        switch (language) {
+            case Language.js:
+                return new JsTsDecoratorExtractor();
+            case Language.ts:
+                return new JsTsDecoratorExtractor();
+            case Language.go:
+                return new GoDecoratorExtractor();
+            default:
+                throw new UserError("Language not supported");
+        }
+    };
+}

--- a/src/utils/decorators/decoratorTypes.ts
+++ b/src/utils/decorators/decoratorTypes.ts
@@ -1,0 +1,21 @@
+export type MethodDecoratorInfo = {
+    name: string;
+    arguments?: { [key: string]: string };
+};
+
+export type MethodInfo = {
+    name: string;
+    decorators: MethodDecoratorInfo[];
+};
+
+export type ClassDecoratorInfo = {
+    name: string;
+    arguments?: { [key: string]: string };
+};
+
+export type ClassInfo = {
+    path: string;
+    name: string;
+    decorators: ClassDecoratorInfo[];
+    methods: MethodInfo[];
+};

--- a/src/utils/decorators/goDecorators.ts
+++ b/src/utils/decorators/goDecorators.ts
@@ -1,0 +1,129 @@
+import path from "path";
+import FileDetails from "../../models/fileDetails.js";
+import { DecoratorExtractor } from "./decoratorFactory.js";
+import { ClassInfo } from "./decoratorTypes.js";
+import fs from "fs";
+import { createRequire } from "module";
+import { default as Parser } from "tree-sitter";
+
+export class GoDecoratorExtractor implements DecoratorExtractor {
+    async getDecoratorsFromFile(file: string): Promise<ClassInfo[]> {
+        const inputCode = fs.readFileSync(file, "utf8");
+        const classes: ClassInfo[] = [];
+
+        const require = createRequire(import.meta.url);
+        const go = require("tree-sitter-go");
+        const parser = new Parser();
+        parser.setLanguage(go);
+
+        const tree = parser.parse(inputCode);
+
+        const root = tree.rootNode;
+        root.namedChildren.forEach((child) => {
+            switch (child.type) {
+                case "type_declaration": {
+                    const className = child.child(1)?.firstChild?.text || "";
+                    const comment = child.previousSibling;
+                    if (!comment) {
+                        return;
+                    }
+                    const commentText = comment.text;
+                    if (commentText.endsWith("genezio: deploy")) {
+                        const classInfo: ClassInfo = {
+                            path: file,
+                            name: className,
+                            decorators: [
+                                {
+                                    name: "GenezioDeploy",
+                                },
+                            ],
+                            methods: [],
+                        };
+                        classes.push(classInfo);
+                    }
+                    break;
+                }
+                case "method_declaration": {
+                    const class_identifier = child.child(1)?.child(1)?.child(1);
+                    let className = "";
+                    if (!class_identifier) {
+                        break;
+                    } else if (class_identifier.type === "type_identifier") {
+                        className = class_identifier.text;
+                    } else if (class_identifier.type === "pointer_type") {
+                        className = class_identifier.child(1)?.text || "";
+                    }
+                    const methodName = child.child(2)?.text || "";
+                    const comment = child.previousSibling;
+                    if (comment?.type !== "comment") {
+                        break;
+                    }
+                    const commentText = comment?.text || "";
+                    if (!commentText.includes("genezio:")) {
+                        break;
+                    }
+                    const genezioMethodArguments = commentText
+                        .split("genezio:")[1]
+                        .split(" ")
+                        .filter((arg) => arg !== "");
+                    if (genezioMethodArguments.length < 1) {
+                        break;
+                    }
+                    switch (genezioMethodArguments[0]) {
+                        case "http": {
+                            const classInfo = classes.find((c) => c.name === className);
+                            if (classInfo) {
+                                classInfo.methods.push({
+                                    name: methodName,
+                                    decorators: [
+                                        {
+                                            name: "GenezioMethod",
+                                            arguments: {
+                                                type: "http",
+                                            },
+                                        },
+                                    ],
+                                });
+                            }
+                            break;
+                        }
+                        case "cron": {
+                            const classInfo = classes.find((c) => c.name === className);
+                            if (classInfo) {
+                                classInfo.methods.push({
+                                    name: methodName,
+                                    decorators: [
+                                        {
+                                            name: "GenezioMethod",
+                                            arguments: {
+                                                type: "cron",
+                                                cronString: genezioMethodArguments
+                                                    .slice(1)
+                                                    .join(" "),
+                                            },
+                                        },
+                                    ],
+                                });
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        return classes;
+    }
+
+    fileFilter(cwd: string): (file: FileDetails) => boolean {
+        return (file: FileDetails) => {
+            const folderPath = path.join(cwd, file.path);
+            return (
+                file.extension === ".go" &&
+                !file.path.includes("node_modules") &&
+                !file.path.includes(".git") &&
+                !fs.lstatSync(folderPath).isDirectory()
+            );
+        };
+    }
+}

--- a/src/utils/decorators/jsTsDecorators.ts
+++ b/src/utils/decorators/jsTsDecorators.ts
@@ -1,0 +1,179 @@
+import path from "path";
+import FileDetails from "../../models/fileDetails.js";
+import { DecoratorExtractor } from "./decoratorFactory.js";
+import fs from "fs";
+import { ClassInfo, MethodInfo } from "./decoratorTypes.js";
+import { NodePath } from "@babel/traverse";
+import {
+    ClassDeclaration,
+    ClassMethod,
+    isCallExpression,
+    isIdentifier,
+    isClassDeclaration,
+    CallExpression,
+    isObjectExpression,
+    isObjectProperty,
+    isStringLiteral,
+} from "@babel/types";
+import babel from "@babel/core";
+import { createRequire } from "module";
+
+export class JsTsDecoratorExtractor implements DecoratorExtractor {
+    fileFilter(cwd: string): (file: FileDetails) => boolean {
+        return (file: FileDetails) => {
+            const folderPath = path.join(cwd, file.path);
+            return (
+                (file.extension === ".js" || file.extension === ".ts") &&
+                !file.path.includes("node_modules") &&
+                !file.path.includes(".git") &&
+                !fs.lstatSync(folderPath).isDirectory()
+            );
+        };
+    }
+
+    async getDecoratorsFromFile(file: string): Promise<ClassInfo[]> {
+        const inputCode = fs.readFileSync(file, "utf8");
+        const classes: ClassInfo[] = [];
+        const extractorFunction = function extract() {
+            return {
+                name: "extract-decorators",
+                visitor: {
+                    ClassDeclaration(path: NodePath<ClassDeclaration>) {
+                        if (path.node.decorators) {
+                            const info: ClassInfo = {
+                                path: file,
+                                name: path.node.id?.name ?? "default",
+                                decorators: [],
+                                methods: [],
+                            };
+                            for (const decorator of path.node.decorators) {
+                                if (isIdentifier(decorator.expression)) {
+                                    info.decorators = [
+                                        ...(info.decorators ?? []),
+                                        { name: decorator.expression.name },
+                                    ];
+                                } else if (
+                                    isCallExpression(decorator.expression) &&
+                                    isIdentifier(decorator.expression.callee)
+                                ) {
+                                    info.decorators = [
+                                        ...(info.decorators ?? []),
+                                        {
+                                            name: decorator.expression.callee.name,
+                                            arguments: JsTsDecoratorExtractor.parseArguments(
+                                                decorator.expression.arguments,
+                                            ),
+                                        },
+                                    ];
+                                }
+                            }
+                            classes.push(info);
+                        }
+                    },
+                    ClassMethod(path: NodePath<ClassMethod>) {
+                        if (path.node.decorators) {
+                            const classDeclarationNode = path.context.parentPath.parentPath?.node;
+                            const className = isClassDeclaration(classDeclarationNode)
+                                ? classDeclarationNode.id?.name ?? "defaultClass"
+                                : "defaultClass";
+
+                            const methodIdentifierNode = path.node.key;
+                            const methodName = isIdentifier(methodIdentifierNode)
+                                ? methodIdentifierNode.name
+                                : "defaultMethod";
+
+                            for (const decorator of path.node.decorators) {
+                                const info: MethodInfo = {
+                                    name: methodName,
+                                    decorators: [],
+                                };
+                                let existingClass = classes.find((c) => c.name === className);
+                                if (!existingClass) {
+                                    existingClass = {
+                                        path: file,
+                                        name: className,
+                                        decorators: [],
+                                        methods: [],
+                                    };
+                                    classes.push(existingClass);
+                                }
+
+                                if (isIdentifier(decorator.expression)) {
+                                    info.decorators = [
+                                        ...(info.decorators ?? []),
+                                        { name: decorator.expression.name },
+                                    ];
+                                } else if (
+                                    isCallExpression(decorator.expression) &&
+                                    isIdentifier(decorator.expression.callee)
+                                ) {
+                                    info.decorators = [
+                                        ...(info.decorators ?? []),
+                                        {
+                                            name: decorator.expression.callee.name,
+                                            arguments: JsTsDecoratorExtractor.parseArguments(
+                                                decorator.expression.arguments,
+                                            ),
+                                        },
+                                    ];
+                                }
+
+                                existingClass.methods.push(info);
+                            }
+                        }
+                    },
+                },
+            };
+        };
+
+        const require = createRequire(import.meta.url);
+        const packagePath = path.dirname(require.resolve("@babel/plugin-syntax-decorators"));
+        // const presetTypescript = path.dirname(require.resolve("@babel/preset-typescript"));
+        await babel.transformAsync(inputCode, {
+            presets: [require.resolve("@babel/preset-typescript")],
+            plugins: [
+                [packagePath, { version: "2023-05", decoratorsBeforeExport: false }],
+                extractorFunction,
+            ],
+            filename: file,
+            configFile: false,
+        });
+
+        return classes;
+    }
+
+    static parseArguments(args: CallExpression["arguments"]): { [key: string]: string } {
+        if (!args) {
+            return {};
+        }
+
+        return args
+            .map((arg) => {
+                if (isObjectExpression(arg)) {
+                    return arg.properties.reduce(
+                        (acc: Array<{ key: string; value: string }>, curr) => {
+                            if (
+                                isObjectProperty(curr) &&
+                                (isIdentifier(curr.key) || isStringLiteral(curr.key)) &&
+                                isStringLiteral(curr.value)
+                            ) {
+                                const key = isIdentifier(curr.key) ? curr.key.name : curr.key.value;
+                                return [...acc, { key, value: curr.value.value }];
+                            }
+
+                            return [...acc];
+                        },
+                        [],
+                    );
+                } else {
+                    return undefined;
+                }
+            })
+            .filter((a) => a !== undefined)
+            .flat()
+            .reduce((acc: { [key: string]: string }, curr) => {
+                acc[curr!.key] = curr!.value;
+                return acc;
+            }, {});
+    }
+}

--- a/src/yamlProjectConfiguration/migration.ts
+++ b/src/yamlProjectConfiguration/migration.ts
@@ -7,6 +7,7 @@ import { scanClassesForDecorators } from "../utils/configuration.js";
 import _ from "lodash";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
 import { UserError } from "../errors.js";
+import { PackageManagerType } from "../packageManagers/packageManager.js";
 
 function compressArray<T>(array: T[] | undefined): T[] | T | undefined {
     if (!array) return undefined;
@@ -56,6 +57,12 @@ export async function tryV2Migration(config: unknown): Promise<v2 | undefined> {
         } else {
             const scannedClasses = await scanClassesForDecorators({
                 path: v1Config.workspace?.backend || ".",
+                language: {
+                    name: Language.ts,
+                    runtime: "nodejs20.x",
+                    packageManager: PackageManagerType.npm,
+                },
+                classes: [],
             });
             backendLanguage =
                 scannedClasses.length > 0


### PR DESCRIPTION
## Type of change

-   [x] 🍕 New feature

## Description

Use tresitter to enable users to specify deployable go services with comment annotation like `// genezio: deploy`, instead of relying on the yaml configuration file.

Current available annotations:
- genezio: deploy (above a struct with methods)
- genezio: http (above a method)
- genezio: cron <cron-string> (above a method)

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
