### PR TITLE
remove the need for configuration file on local sdk generation

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -309,8 +309,8 @@ export async function deployClasses(
 
             // .jar files cannot be parsed by AWS Lambda, skip this step for AWS Lambda
             if (element.language === "kt") {
-                console.debug("Skipping ZIP due to .jar file");
-                console.debug(path.join(output.path, "app-standalone.jar"));
+                debugLogger.debug("Skipping ZIP due to .jar file");
+                debugLogger.debug(path.join(output.path, "app-standalone.jar"));
                 return {
                     name: element.name,
                     archivePath: path.join(output.path, "app-standalone.jar"),

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -7,7 +7,9 @@ import { UserError } from "../errors.js";
 import { DecoratorExtractorFactory } from "./decorators/decoratorFactory.js";
 
 async function tryToReadClassInformationFromDecorators(
-    yamlBackend: Pick<YAMLBackend, "path" | "classes" | "language">,
+    yamlBackend: Pick<YAMLBackend, "path" | "classes"> & {
+        language: Pick<YAMLBackend["language"], "name">;
+    },
 ) {
     const cwd = yamlBackend.path || process.cwd();
 
@@ -26,7 +28,9 @@ async function tryToReadClassInformationFromDecorators(
 }
 
 export async function scanClassesForDecorators(
-    yamlBackend: Pick<YAMLBackend, "path" | "classes" | "language">,
+    yamlBackend: Pick<YAMLBackend, "path" | "classes"> & {
+        language: Pick<YAMLBackend["language"], "name">;
+    },
 ): Promise<YamlClass[]> {
     const result = await tryToReadClassInformationFromDecorators(yamlBackend).catch((error) => {
         if (error instanceof UserError && error.message.includes("Language not supported")) {

--- a/src/yamlProjectConfiguration/migration.ts
+++ b/src/yamlProjectConfiguration/migration.ts
@@ -7,7 +7,6 @@ import { scanClassesForDecorators } from "../utils/configuration.js";
 import _ from "lodash";
 import { CloudProviderIdentifier } from "../models/cloudProviderIdentifier.js";
 import { UserError } from "../errors.js";
-import { PackageManagerType } from "../packageManagers/packageManager.js";
 
 function compressArray<T>(array: T[] | undefined): T[] | T | undefined {
     if (!array) return undefined;
@@ -59,8 +58,6 @@ export async function tryV2Migration(config: unknown): Promise<v2 | undefined> {
                 path: v1Config.workspace?.backend || ".",
                 language: {
                     name: Language.ts,
-                    runtime: "nodejs20.x",
-                    packageManager: PackageManagerType.npm,
                 },
             });
             backendLanguage =

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -153,10 +153,7 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
 
     return defaultConfig as DeepRequired<
         typeof defaultConfig,
-        | "region"
-        | "backend.language.packageManager"
-        | "backend.language.runtime"
-        | "backend.cloudProvider"
+        "region" | "backend.cloudProvider"
     > & {
         frontend: typeof defaultConfig.frontend;
     };

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -153,7 +153,10 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
 
     return defaultConfig as DeepRequired<
         typeof defaultConfig,
-        "region" | "backend.cloudProvider"
+        | "region"
+        | "backend.language.packageManager"
+        | "backend.language.runtime"
+        | "backend.cloudProvider"
     > & {
         frontend: typeof defaultConfig.frontend;
     };


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

This removes the need for a `genezio.yaml` configuration file for local SDK generation, a feature needed for custom third-party integrations.

I made a change in the type declaration of the configuration file, so that `language.runtime` and `language.packageManager` are not required. I am not sure that this change won't have any repercussions, so I would like someone who worked here to give their opinion (maybe @costinsin).

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
