### PR TITLE
fix block comment decorators

### DIFF
--- a/src/utils/decorators/baseDecoratorExtractor.ts
+++ b/src/utils/decorators/baseDecoratorExtractor.ts
@@ -1,0 +1,81 @@
+import FileDetails from "../../models/fileDetails.js";
+import { ClassInfo, MethodInfo } from "./decoratorTypes.js";
+
+export abstract class DecoratorExtractor {
+    abstract getDecoratorsFromFile(file: string): Promise<ClassInfo[]>;
+    abstract fileFilter(cwd: string): (file: FileDetails) => boolean;
+
+    createGenezioMethodInfo(methodName: string, commentText: string): MethodInfo | undefined {
+        const genezioMethodArguments = commentText
+            .split("genezio:")[1]
+            .split(" ")
+            .filter((arg) => arg !== "");
+        if (genezioMethodArguments.length < 1) {
+            return;
+        }
+        let decoratorArguments = {};
+        switch (genezioMethodArguments[0]) {
+            case "http": {
+                decoratorArguments = {
+                    type: "http",
+                };
+                break;
+            }
+            case "cron": {
+                decoratorArguments = {
+                    type: "cron",
+                    cronString: genezioMethodArguments.slice(1).join(" "),
+                };
+                break;
+            }
+            default: {
+                decoratorArguments = {
+                    type: "jsonrpc",
+                };
+                break;
+            }
+        }
+        const methodInfo: MethodInfo = {
+            name: methodName,
+            decorators: [
+                {
+                    name: "GenezioMethod",
+                    arguments: decoratorArguments,
+                },
+            ],
+        };
+        return methodInfo;
+    }
+
+    createGenezioClassInfo(className: string, file: string, commentText: string): ClassInfo {
+        const genezioDeployArguments = commentText
+            .split("genezio: deploy")[1]
+            .split(" ")
+            .filter((arg) => arg !== "");
+        let classType: string = "jsonrpc";
+        switch (genezioDeployArguments[0]) {
+            case "http": {
+                classType = "http";
+                break;
+            }
+            case "cron": {
+                classType = "cron";
+                break;
+            }
+        }
+        const classInfo: ClassInfo = {
+            path: file,
+            name: className,
+            decorators: [
+                {
+                    name: "GenezioDeploy",
+                    arguments: {
+                        type: classType,
+                    },
+                },
+            ],
+            methods: [],
+        };
+        return classInfo;
+    }
+}

--- a/src/utils/decorators/decoratorFactory.ts
+++ b/src/utils/decorators/decoratorFactory.ts
@@ -1,14 +1,8 @@
 import { UserError } from "../../errors.js";
-import FileDetails from "../../models/fileDetails.js";
 import { Language } from "../../yamlProjectConfiguration/models.js";
-import { ClassInfo } from "./decoratorTypes.js";
+import { DecoratorExtractor } from "./baseDecoratorExtractor.js";
 import { GoDecoratorExtractor } from "./goDecorators.js";
 import { JsTsDecoratorExtractor } from "./jsTsDecorators.js";
-
-export interface DecoratorExtractor {
-    getDecoratorsFromFile: (file: string) => Promise<ClassInfo[]>;
-    fileFilter: (cwd: string) => (file: FileDetails) => boolean;
-}
 
 export class DecoratorExtractorFactory {
     static createExtractor = (language: Language): DecoratorExtractor => {

--- a/src/utils/decorators/jsTsDecorators.ts
+++ b/src/utils/decorators/jsTsDecorators.ts
@@ -192,6 +192,17 @@ export class JsTsDecoratorExtractor implements DecoratorExtractor {
                         .split("genezio: deploy")[1]
                         .split(" ")
                         .filter((arg) => arg !== "");
+                    let classType: string = "jsonrpc";
+                    switch (genezioDeployArguments[0]) {
+                        case "http": {
+                            classType = "http";
+                            break;
+                        }
+                        case "cron": {
+                            classType = "cron";
+                            break;
+                        }
+                    }
                     const classInfo: ClassInfo = {
                         path: file,
                         name: className,
@@ -199,7 +210,7 @@ export class JsTsDecoratorExtractor implements DecoratorExtractor {
                             {
                                 name: "GenezioDeploy",
                                 arguments: {
-                                    type: genezioDeployArguments[0] || "jsonrpc",
+                                    type: classType,
                                 },
                             },
                         ],

--- a/src/utils/decorators/jsTsDecorators.ts
+++ b/src/utils/decorators/jsTsDecorators.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import FileDetails from "../../models/fileDetails.js";
-import { DecoratorExtractor } from "./decoratorFactory.js";
 import fs from "fs";
 import { ClassInfo, MethodInfo } from "./decoratorTypes.js";
 import { NodePath } from "@babel/traverse";
@@ -19,8 +18,9 @@ import babel from "@babel/core";
 import { createRequire } from "module";
 import { default as Parser } from "tree-sitter";
 import { debugLogger } from "../logging.js";
+import { DecoratorExtractor } from "./baseDecoratorExtractor.js";
 
-export class JsTsDecoratorExtractor implements DecoratorExtractor {
+export class JsTsDecoratorExtractor extends DecoratorExtractor {
     fileFilter(cwd: string): (file: FileDetails) => boolean {
         return (file: FileDetails) => {
             const folderPath = path.join(cwd, file.path);
@@ -179,6 +179,9 @@ export class JsTsDecoratorExtractor implements DecoratorExtractor {
                         break;
                     }
                     const classStmt = child.child(1);
+                    if (!classStmt) {
+                        break;
+                    }
                     const className = classStmt?.child(1)?.text || "";
                     const comment = child.previousSibling;
                     if (!comment) {
@@ -188,99 +191,34 @@ export class JsTsDecoratorExtractor implements DecoratorExtractor {
                     if (!commentText.includes("genezio: deploy")) {
                         break;
                     }
-                    const genezioDeployArguments = commentText
-                        .split("genezio: deploy")[1]
-                        .split(" ")
-                        .filter((arg) => arg !== "");
-                    let classType: string = "jsonrpc";
-                    switch (genezioDeployArguments[0]) {
-                        case "http": {
-                            classType = "http";
-                            break;
-                        }
-                        case "cron": {
-                            classType = "cron";
-                            break;
-                        }
-                    }
-                    const classInfo: ClassInfo = {
-                        path: file,
-                        name: className,
-                        decorators: [
-                            {
-                                name: "GenezioDeploy",
-                                arguments: {
-                                    type: classType,
-                                },
-                            },
-                        ],
-                        methods: [],
-                    };
-                    classStmt?.namedChildren.forEach((child) => {
-                        switch (child.type) {
-                            case "class_body": {
-                                child.namedChildren.forEach((child) => {
-                                    if (child.type !== "method_definition") {
-                                        return;
-                                    }
-                                    let methodName = child.child(0)?.text || "";
-                                    if (methodName === "async") {
-                                        methodName = child.child(1)?.text || "";
-                                    }
-                                    const comment = child.previousSibling;
-                                    if (comment?.type !== "comment") {
-                                        return;
-                                    }
-                                    const commentText = comment?.text || "";
-                                    if (!commentText.includes("genezio:")) {
-                                        return;
-                                    }
-                                    const genezioMethodArguments = commentText
-                                        .split("genezio:")[1]
-                                        .split(" ")
-                                        .filter((arg) => arg !== "");
-                                    if (genezioMethodArguments.length < 1) {
-                                        return;
-                                    }
-                                    let decoratorArguments = {};
-                                    switch (genezioMethodArguments[0]) {
-                                        case "http": {
-                                            decoratorArguments = {
-                                                type: "http",
-                                            };
-                                            break;
-                                        }
-                                        case "cron": {
-                                            decoratorArguments = {
-                                                type: "cron",
-                                                cronString: genezioMethodArguments
-                                                    .slice(1)
-                                                    .join(" "),
-                                            };
-                                            break;
-                                        }
-                                        default: {
-                                            decoratorArguments = {
-                                                type: "jsonrpc",
-                                            };
-                                            break;
-                                        }
-                                    }
-                                    classInfo.methods.push({
-                                        name: methodName,
-                                        decorators: [
-                                            {
-                                                name: "GenezioMethod",
-                                                arguments: decoratorArguments,
-                                            },
-                                        ],
-                                    });
-                                });
-                                break;
-                            }
-                            default: {
-                                break;
-                            }
+                    const classInfo = this.createGenezioClassInfo(className, file, commentText);
+                    classStmt.namedChildren.forEach((child) => {
+                        if (child.type === "class_body") {
+                            child.namedChildren.forEach((child) => {
+                                if (child.type !== "method_definition") {
+                                    return;
+                                }
+                                let methodName = child.child(0)?.text || "";
+                                if (methodName === "async") {
+                                    methodName = child.child(1)?.text || "";
+                                }
+                                const comment = child.previousSibling;
+                                if (comment?.type !== "comment") {
+                                    return;
+                                }
+                                const commentText = comment?.text || "";
+                                if (!commentText.includes("genezio:")) {
+                                    return;
+                                }
+                                const methodInfo = this.createGenezioMethodInfo(
+                                    methodName,
+                                    commentText,
+                                );
+                                if (!methodInfo) {
+                                    return;
+                                }
+                                classInfo.methods.push(methodInfo);
+                            });
                         }
                     });
                     classes.push(classInfo);


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

Allow decorators in jsdoc and block comments for JS and TS services, instead of just single-line comments.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
