### PR TITLE
Use real path of temp folder instead of symlink on MacOS

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -300,7 +300,7 @@ export async function createLocalTempFolder(
             name = Math.random().toString(36).substring(2, 8);
         }
 
-        const tempFolder = path.join(os.tmpdir(), folderName, name);
+        const tempFolder = path.join(fs.realpathSync(os.tmpdir()), folderName, name);
         if (fs.existsSync(tempFolder)) {
             if (shouldDeleteContents) {
                 fsExtra.emptyDirSync(tempFolder);


### PR DESCRIPTION
# Pull Request Template

## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

When os.tmpdir() is invoked on MacOS, it returns the path /var/folders/… instead of /private/var/folders/…. Notably, on MacOS, /var/folders/… is a symlink to /private/var/folders/….

This behavior is documented in NodeJS's issue tracker (see NodeJS issue [#11422](https://github.com/nodejs/node/issues/11422)). The significance of this lies in its interaction with an NPM bug. Specifically, when running NPM commands from a directory that is a symlink (in this case, caused by os.tmpdir()'s behavior), it leads to incorrect packaging of NPM packages.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
