### PR TITLE
Fix cloud provider AB testing

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -147,6 +147,7 @@ export async function deployCommand(options: GenezioDeployOptions) {
             );
             // Write the new configuration in the config file
             await configIOController.write(yamlConfig);
+            configuration.backend.cloudProvider = yamlConfig.backend.cloudProvider;
         }
 
         await GenezioTelemetry.sendEvent({


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR correctly propagates the cloud provider if the fairy of ab testing decides to change it.

Before this PR, if the cloudProvider was changed to `capybara`, it wouldn't be updated in the `configuration` object.
Hence, the cloud provider was updated in the `genezio.yaml` to `capybara`, but the project itself was deployed on `genezio`, causing later issues.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
