### PR TITLE
added try catch on delete folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
                 "@babel/preset-typescript": "^7.23.3",
                 "@babel/traverse": "^7.24.1",
                 "@genezio/test-interface-component": "^1.0.1",
-                "@rollup/rollup-darwin-arm64": "4.14.1",
                 "@sentry/node": "^7.109.0",
                 "@sentry/profiling-node": "~7.108.0",
                 "archiver": "^7.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import program from "./genezio.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "./telemetry/telemetry.js";
 import { deleteFolder } from "./utils/file.js";
 import { SENTRY_DSN } from "./constants.js";
-import { debugLogger, logError } from "./utils/logging.js";
+import { debugLogger } from "./utils/logging.js";
 import path from "path";
 import os from "os";
 
@@ -40,7 +40,7 @@ process.on("SIGINT", async () => {
     try {
         await deleteFolder(temporaryFolder);
     } catch (error) {
-        logError(error as Error);
+        debugLogger.error("Error deleting temporary folder", error);
     }
     process.exit();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import program from "./genezio.js";
 import { GenezioTelemetry, TelemetryEventTypes } from "./telemetry/telemetry.js";
 import { deleteFolder } from "./utils/file.js";
 import { SENTRY_DSN } from "./constants.js";
-import { debugLogger } from "./utils/logging.js";
+import { debugLogger, logError } from "./utils/logging.js";
 import path from "path";
 import os from "os";
 
@@ -37,7 +37,11 @@ process.on("SIGINT", async () => {
         commandOptions: "",
     });
 
-    await deleteFolder(temporaryFolder);
+    try {
+        await deleteFolder(temporaryFolder);
+    } catch (error) {
+        logError(error as Error);
+    }
     process.exit();
 });
 process.on("exit", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,10 @@ process.on("SIGINT", async () => {
         commandOptions: "",
     });
 
-    try {
-        await deleteFolder(temporaryFolder);
-    } catch (error) {
-        debugLogger.error("Error deleting temporary folder", error);
-    }
+    await deleteFolder(temporaryFolder).catch((error) => {
+        debugLogger.error(`Error deleting temporary folder ${temporaryFolder}`, error);
+    });
+
     process.exit();
 });
 process.on("exit", async () => {


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix
## Description
If you would terminate the proccess in the middle of a deploy, there was a chance that you enter a state where the program can't delete the temporary folder because most likely it is being written in at the same time. This would lead to a state where the proccess would not stop no matter how many times you try to terminate it. To fix this, i added a try catch on delete folder that logs the error, behaivour which is normal for mid execution interupts for any other platform.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
