### PR TITLE
catch internal server errors and display appropiate message

### DIFF
--- a/src/requests/axios.ts
+++ b/src/requests/axios.ts
@@ -31,6 +31,11 @@ axios.interceptors.response.use(
                 "You've hit the maximum number of projects. To continue, please upgrade your subscription.",
             );
         }
+        if (!response.data.error) {
+            throw new UserError(
+                "There was an error on our end. Please try again! If the problem persists, please report it to our issues page on GitHub: https://github.com/Genez-io/genezio/issues",
+            );
+        }
         if (response.data.error.code === GenezioErrorCode.UpdateRequired) {
             throw new UserError("Please update your genezio CLI. Run 'npm update -g genezio'.");
         }


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

This addresses the popular `error reading property code of undefined`, which occurs whenever the server crashes for various reasons and the HTTP response doesn't have a structure that can be understood by the CLI. 

This change catches such errors and encourages the users to open a GitHub issue regarding their problem.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
