### PR TITLE
Add --disable-optimization flag to disable dependencies optimization …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
                 "@babel/preset-typescript": "^7.23.3",
                 "@babel/traverse": "^7.24.1",
                 "@genezio/test-interface-component": "^1.0.1",
-                "@rollup/rollup-linux-arm64-musl": "4.14.3",
                 "@sentry/node": "^7.110.1",
                 "@sentry/profiling-node": "~7.108.0",
                 "archiver": "^7.0.1",

--- a/src/bundlers/bundler.interface.ts
+++ b/src/bundlers/bundler.interface.ts
@@ -21,6 +21,7 @@ export type BundlerInput = {
         commandParameters?: string[];
         installDeps?: boolean;
         allNonJsFilesPaths?: FileDetails[];
+        isOptimizationDisabled?: boolean;
     };
 };
 

--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -430,6 +430,7 @@ export class NodeJsBundler implements BundlerInterface {
         debugLogger.debug(
             `[NodeJSBundler] Get the list of node modules and bundling the javascript code for file ${input.path}.`,
         );
+
         await Promise.all([
             this.#bundleNodeJSCode(
                 input.configuration.path,
@@ -439,7 +440,10 @@ export class NodeJsBundler implements BundlerInterface {
             mode === "development"
                 ? this.#copyDependencies(undefined, temporaryFolder, mode, cwd)
                 : Promise.resolve(),
-            mode === "production"
+            mode === "production" && input.extra.isOptimizationDisabled
+                ? this.#copyDependencies(undefined, temporaryFolder, mode, cwd)
+                : Promise.resolve(),
+            mode === "production" && !input.extra.isOptimizationDisabled
                 ? this.#getDependenciesInfo(input.configuration.path, input, cwd)
                 : Promise.resolve(),
         ]);

--- a/src/bundlers/utils.ts
+++ b/src/bundlers/utils.ts
@@ -21,6 +21,7 @@ export async function bundle(
     ast: Program,
     element: ClassConfiguration,
     installDeps: boolean = true,
+    isOptimizationDisabled: boolean = false,
 ): Promise<BundlerOutput> {
     if (!(await fileExists(element.path))) {
         printAdaptiveLog("Bundling your code\n", "error");
@@ -80,6 +81,7 @@ export async function bundle(
             mode: "production",
             tmpFolder: tmpFolder,
             installDeps,
+            isOptimizationDisabled,
         },
     });
     debugLogger.debug(`The bundling process finished successfully for file ${element.path}.`);

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -73,7 +73,7 @@ export async function bundleCommand(options: GenezioBundleOptions) {
         (classInfo) => classInfo.classConfiguration.path === element.path,
     )!.program;
 
-    const result = await bundle(projectConfiguration, ast, element);
+    const result = await bundle(projectConfiguration, ast, element, options.disableOptimization);
     mkdirSync(options.output, { recursive: true });
     await zipDirectory(result.path, path.join(options.output, "bundle.zip"));
     writeToFile(options.output, "bundle.ast", JSON.stringify(result.configuration));

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -301,7 +301,13 @@ export async function deployClasses(
             const ast = sdkResponse.sdkGeneratorInput.classesInfo.find(
                 (classInfo) => classInfo.classConfiguration.path === element.path,
             )!.program;
-            const output = await bundle(projectConfiguration, ast, element, options.installDeps);
+            const output = await bundle(
+                projectConfiguration,
+                ast,
+                element,
+                options.installDeps,
+                options.disableOptimization,
+            );
 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             // check if the unzipped folder is smaller than 250MB

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -125,6 +125,11 @@ program
     .option("--backend", "Deploy only the backend application.", false)
     .option("--frontend", "Deploy only the frontend application.", false)
     .option("--install-deps", "Automatically install missing dependencies", false)
+    .option(
+        "--disable-optimization",
+        "Set this flag to true to disable dependency optimization.",
+        false,
+    )
     .option("--env <envFile>", "Load environment variables from a given file", undefined)
     .option("--stage <stage>", "Set the environment name to deploy to", "prod")
     .option(
@@ -447,6 +452,11 @@ program
     .option("--className <className>", "The name of the class that needs to be bundled.")
     .option("--cloudAdapter <cloudAdapter>", "The cloud adapter that will be used.")
     .option("--output <output>", "The output path of the bundled class.")
+    .option(
+        "--disable-optimization",
+        "Set this flag to true to disable dependency optimization.",
+        false,
+    )
     .action(async (options: GenezioBundleOptions) => {
         await bundleCommand(options).catch(async (error) => {
             logError(error);

--- a/src/models/commandOptions.ts
+++ b/src/models/commandOptions.ts
@@ -8,6 +8,7 @@ export interface BaseOptions {
 export interface GenezioBundleOptions extends BaseOptions {
     className: string;
     output: string;
+    disableOptimization: boolean;
     cloudAdapter?: CloudAdapterIdentifier;
 }
 
@@ -25,6 +26,7 @@ export interface GenezioDeployOptions extends BaseOptions {
     backend: boolean;
     frontend: boolean;
     installDeps: boolean;
+    disableOptimization: boolean;
     env?: string;
     stage: string;
     subdomain?: string;


### PR DESCRIPTION
…for nodejs

# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR add the flag ` --disable-optimization` to `genezio deploy` and `genezio bundleClass` to disable dependencies optimization for nodejs backends.

In specific cases is handy to bundle all installed dependencies for a project, instead of letting `esbuild` minimizing them.


## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
