### PR TITLE
fix @types/node install bug

### DIFF
--- a/src/bundlers/node/typescriptRequiredDepsBundler.ts
+++ b/src/bundlers/node/typescriptRequiredDepsBundler.ts
@@ -1,12 +1,13 @@
 import { BundlerInput, BundlerInterface, BundlerOutput } from "../bundler.interface.js";
 import { fileExists } from "../../utils/file.js";
 import { DependencyInstaller } from "./dependencyInstaller.js";
+import path from "path";
 
 // Ensures that all dependencies required by the Typescript compiler are installed.
 export class TsRequiredDepsBundler implements BundlerInterface {
     async bundle(input: BundlerInput): Promise<BundlerOutput> {
         const cwd = input.projectConfiguration.workspace?.backend || process.cwd();
-        const exists = await fileExists(`${cwd}/node_modules/@types/node`);
+        const exists = await fileExists(path.join(cwd, "node_modules", "@types", "node"));
 
         // Install @types/node for typescript if it is not already installed
         if (!exists) {

--- a/src/bundlers/node/typescriptRequiredDepsBundler.ts
+++ b/src/bundlers/node/typescriptRequiredDepsBundler.ts
@@ -5,8 +5,8 @@ import { DependencyInstaller } from "./dependencyInstaller.js";
 // Ensures that all dependencies required by the Typescript compiler are installed.
 export class TsRequiredDepsBundler implements BundlerInterface {
     async bundle(input: BundlerInput): Promise<BundlerOutput> {
-        const exists = await fileExists("node_modules/@types/node");
         const cwd = input.projectConfiguration.workspace?.backend || process.cwd();
+        const exists = await fileExists(`${cwd}/node_modules/@types/node`);
 
         // Install @types/node for typescript if it is not already installed
         if (!exists) {


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

The CLI checks for the package @types/node to be installed on every typescript project, but on monorepo projects, it searches in the root folder, leading to installing the package every time.
This solves the annoying issue of the server reloading at the start of `genezio local`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
