### PR TITLE
Fixed space in path for go bug

### DIFF
--- a/src/bundlers/go/localGoMain.ts
+++ b/src/bundlers/go/localGoMain.ts
@@ -287,6 +287,6 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 func main() {
 	port := os.Args[1]
 	http.HandleFunc("/", handleRequest)
-	http.ListenAndServe(":"+port, nil)
+	http.ListenAndServe("localhost:"+port, nil)
 }
 `;

--- a/src/generateSdk/astGenerator/GoAstGenerator.ts
+++ b/src/generateSdk/astGenerator/GoAstGenerator.ts
@@ -14,10 +14,11 @@ import {
     SourceType,
     StructLiteral,
 } from "../../models/genezioModels.js";
-import { runNewProcess, runNewProcessWithResultAndReturnCode } from "../../utils/process.js";
+import { runNewProcess } from "../../utils/process.js";
 import { checkIfGoIsInstalled } from "../../utils/go.js";
 import { createTemporaryFolder } from "../../utils/file.js";
 import { UserError } from "../../errors.js";
+import { $, ExecaError } from "execa";
 
 const releaseTag = "v0.1.1";
 const binaryName = `golang_ast_generator_${releaseTag}`;
@@ -73,14 +74,12 @@ export class AstGenerator implements AstGeneratorInterface {
             await this.#compileGenezioGoAstExtractor();
         }
         const classAbsolutePath = path.resolve(input.class.path);
-        const result = await runNewProcessWithResultAndReturnCode(
-            `${goAstGeneratorPath} ${classAbsolutePath}`,
-            input.root,
-        );
-        if (result.code !== 0) {
-            log.error(result.stderr);
+        const result = await $({
+            cwd: input.root,
+        })`${goAstGeneratorPath} ${classAbsolutePath}`.catch((error: ExecaError) => {
+            log.error(error.stderr);
             throw new UserError("Error: Failed to generate AST for class " + input.class.path);
-        }
+        });
 
         const ast = JSON.parse(result.stdout);
         const error = ast.error;

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -43,18 +43,3 @@ export function runNewProcessWithResult(command: string, cwd?: string): Promise<
         });
     });
 }
-
-export function runNewProcessWithResultAndReturnCode(
-    command: string,
-    cwd?: string,
-): Promise<{ stdout: string; stderr: string; code: number }> {
-    return new Promise(function (resolve) {
-        exec(command, { cwd }, (err, stdout, stderr) => {
-            if (err) {
-                resolve({ stdout, stderr, code: err.code || -1 });
-            } else {
-                resolve({ stdout, stderr, code: 0 });
-            }
-        });
-    });
-}


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

On windows the AST generation for GO was not working for paths that had a space in them. To fix this i used `$` provided by execa which is platform agnostic and handles spaces in paths automatically. Moreover, on Windows we had a permisions problem on local in that everytime the go code was compiled into a .exe file, it needed user permision to acces the internet, fixed this by specifying that the executable only runs on localhost.
<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
