### PR TITLE
Fix connection error fallback mechanism

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -1018,6 +1018,7 @@ async function communicateWithProcess(
                 processForClasses,
                 localProcess.envVars,
             );
+            throw new UserError("There was an error connecting to the server");
         }
         throw error;
     }

--- a/src/requests/axios.ts
+++ b/src/requests/axios.ts
@@ -2,7 +2,6 @@ import axios, { AxiosError } from "axios";
 import { debugLogger } from "../utils/logging.js";
 import { StatusError } from "./models.js";
 import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
-import Sentry from "@sentry/node";
 
 enum GenezioErrorCode {
     UnknownError = 0,
@@ -24,8 +23,7 @@ axios.interceptors.response.use(
     function (error: AxiosError<StatusError>) {
         const response = error.response;
         if (!response) {
-            Sentry.captureException(error);
-            throw new UserError("There was an error connecting to the server.");
+            throw error;
         }
 
         if (response.status === 402) {


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

We were receiving sentry errors regarding connection to the local server for users' applications. This is an expected error that used to have a fallback mechanism that would attempt to restart the process. That mechanism was lost because we stopped returning AxiosErrors from the Axios interceptor.

This PR returns the unmodified AxiosError from the interceptor in case of a missing response (indicating a problem reaching the server), which will allow the fallback to take place, as well as sending a custom UserError which should no longer be captured by Sentry.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
