### PR TITLE
Migrate to new cloud provider naming

### DIFF
--- a/src/bundlers/go/goBundler.ts
+++ b/src/bundlers/go/goBundler.ts
@@ -6,8 +6,8 @@ import { BundlerInterface } from "../bundler.interface.js";
 
 export function NewGoBundler(projectConfiguration: ProjectConfiguration): BundlerInterface {
     if (
-        projectConfiguration.cloudProvider == CloudProviderIdentifier.CAPYBARA ||
-        projectConfiguration.cloudProvider == CloudProviderIdentifier.CAPYBARA_LINUX
+        projectConfiguration.cloudProvider == CloudProviderIdentifier.GENEZIO_UNIKERNEL ||
+        projectConfiguration.cloudProvider == CloudProviderIdentifier.GENEZIO_CLOUD
     ) {
         return new GenezioRuntimeGoBundler();
     }

--- a/src/bundlers/node/nodeJsBinaryDependenciesBundler.ts
+++ b/src/bundlers/node/nodeJsBinaryDependenciesBundler.ts
@@ -99,7 +99,7 @@ export class NodeJsBinaryDependenciesBundler implements BundlerInterface {
             `[NodeJSBinaryDependenciesBundler] Redownload binary dependencies if necessary for file ${input.path}...`,
         );
         const architecture =
-            input.projectConfiguration.cloudProvider == CloudProviderIdentifier.GENEZIO
+            input.projectConfiguration.cloudProvider == CloudProviderIdentifier.GENEZIO_AWS
                 ? Architecture.ARM64
                 : Architecture.X64;
         // 4. Redownload binary dependencies if necessary

--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -386,12 +386,12 @@ export class NodeJsBundler implements BundlerInterface {
         provider: CloudProviderIdentifier,
     ): ((className: string) => string) | null {
         switch (provider) {
-            case CloudProviderIdentifier.CLUSTER:
+            case CloudProviderIdentifier.GENEZIO_CLUSTER:
                 return clusterHandlerGenerator;
-            case CloudProviderIdentifier.GENEZIO:
+            case CloudProviderIdentifier.GENEZIO_AWS:
                 return lambdaHandlerGenerator;
-            case CloudProviderIdentifier.CAPYBARA:
-            case CloudProviderIdentifier.CAPYBARA_LINUX:
+            case CloudProviderIdentifier.GENEZIO_UNIKERNEL:
+            case CloudProviderIdentifier.GENEZIO_CLOUD:
                 return genezioRuntimeHandlerGenerator;
             default:
                 return null;
@@ -406,7 +406,7 @@ export class NodeJsBundler implements BundlerInterface {
 
         // TODO: Remove this check after cluster is fully supported in other regions
         if (
-            cloudProvider === CloudProviderIdentifier.CLUSTER &&
+            cloudProvider === CloudProviderIdentifier.GENEZIO_CLUSTER &&
             input.projectConfiguration.region !== "us-east-1"
         ) {
             throw new UserError(

--- a/src/bundlers/node/nodeJsLocalBundler.ts
+++ b/src/bundlers/node/nodeJsLocalBundler.ts
@@ -50,7 +50,7 @@ export class NodeJsLocalBundler implements BundlerInterface {
         }
 
         const isClusterDeployment =
-            input.projectConfiguration.cloudProvider === CloudProviderIdentifier.CLUSTER;
+            input.projectConfiguration.cloudProvider === CloudProviderIdentifier.GENEZIO_CLUSTER;
         await writeToFile(
             input.path,
             "local.mjs",

--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -239,8 +239,8 @@ function getClassFunctionUrl(
     className: string,
 ): string {
     if (
-        cloudProvider === CloudProviderIdentifier.CAPYBARA ||
-        cloudProvider === CloudProviderIdentifier.CAPYBARA_LINUX
+        cloudProvider === CloudProviderIdentifier.GENEZIO_UNIKERNEL ||
+        cloudProvider === CloudProviderIdentifier.GENEZIO_CLOUD
     ) {
         return baseUrl;
     } else {

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -29,13 +29,13 @@ export async function bundleCommand(options: GenezioBundleOptions) {
     // Override cloud provider if it's set using command line args
     switch (options.cloudAdapter) {
         case CloudAdapterIdentifier.AWS:
-            backendConfiguration.cloudProvider = CloudProviderIdentifier.GENEZIO;
+            backendConfiguration.cloudProvider = CloudProviderIdentifier.GENEZIO_AWS;
             break;
         case CloudAdapterIdentifier.RUNTIME:
-            backendConfiguration.cloudProvider = CloudProviderIdentifier.CAPYBARA_LINUX;
+            backendConfiguration.cloudProvider = CloudProviderIdentifier.GENEZIO_CLOUD;
             break;
         case CloudAdapterIdentifier.CLUSTER:
-            backendConfiguration.cloudProvider = CloudProviderIdentifier.CLUSTER;
+            backendConfiguration.cloudProvider = CloudProviderIdentifier.GENEZIO_CLUSTER;
             break;
     }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -376,7 +376,7 @@ export async function deployClasses(
 
     // TODO: Enable cloud adapter setting for every class
     const cloudAdapter = getCloudAdapter(
-        configuration.backend?.cloudProvider || CloudProviderIdentifier.GENEZIO,
+        configuration.backend?.cloudProvider || CloudProviderIdentifier.GENEZIO_AWS,
     );
     const result = await cloudAdapter.deploy(bundlerResultArray, projectConfiguration, {
         stage: options.stage,
@@ -589,7 +589,7 @@ export async function deployFrontend(
 
     frontend.subdomain = options.subdomain || frontend.subdomain;
 
-    const cloudAdapter = getCloudAdapter(CloudProviderIdentifier.GENEZIO);
+    const cloudAdapter = getCloudAdapter(CloudProviderIdentifier.GENEZIO_AWS);
     const url = await cloudAdapter.deployFrontend(name, region, frontend, stage);
     return url;
 }
@@ -639,12 +639,12 @@ async function handleSdk(
 
 function getCloudAdapter(provider: string): CloudAdapter {
     switch (provider) {
-        case CloudProviderIdentifier.GENEZIO:
-        case CloudProviderIdentifier.CAPYBARA:
+        case CloudProviderIdentifier.GENEZIO_AWS:
+        case CloudProviderIdentifier.GENEZIO_UNIKERNEL:
             return new GenezioCloudAdapter();
-        case CloudProviderIdentifier.CAPYBARA_LINUX:
+        case CloudProviderIdentifier.GENEZIO_CLOUD:
             return new GenezioCloudAdapter();
-        case CloudProviderIdentifier.CLUSTER:
+        case CloudProviderIdentifier.GENEZIO_CLUSTER:
             return new ClusterCloudAdapter();
         case CloudProviderIdentifier.SELF_HOSTED_AWS:
             return new SelfHostedAwsAdapter();
@@ -664,10 +664,10 @@ export async function performCloudProviderABTesting(
     const isAlreadyDeployed = await isProjectDeployed(projectName, projectRegion);
 
     // We won't perform AB testing if the cloud provider is set for runtime, self-hosted or cluster.
-    if (!isAlreadyDeployed && projectCloudProvider === CloudProviderIdentifier.GENEZIO) {
+    if (!isAlreadyDeployed && projectCloudProvider === CloudProviderIdentifier.GENEZIO_AWS) {
         const randomCloudProvider = getRandomCloudProvider();
 
-        if (randomCloudProvider !== CloudProviderIdentifier.GENEZIO) {
+        if (randomCloudProvider !== CloudProviderIdentifier.GENEZIO_AWS) {
             debugLogger.debug(
                 "You've been visited by the AB testing fairy! 🧚‍♂️ Your cloud provider is now set to",
                 randomCloudProvider,

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -136,9 +136,9 @@ export async function prepareLocalBackendEnvironment(
         });
         const projectConfiguration = new ProjectConfiguration(yamlProjectConfiguration, sdk);
 
-        // Local deployments always use the genezio cloud provider unless the user uses the cluster deployment
-        if (projectConfiguration.cloudProvider !== CloudProviderIdentifier.CLUSTER) {
-            projectConfiguration.cloudProvider = CloudProviderIdentifier.GENEZIO;
+        // Local deployments always use the genezio-aws cloud provider unless the user uses the genezio-cluster deployment
+        if (projectConfiguration.cloudProvider !== CloudProviderIdentifier.GENEZIO_CLUSTER) {
+            projectConfiguration.cloudProvider = CloudProviderIdentifier.GENEZIO_AWS;
         }
 
         const processForClasses = await startProcesses(projectConfiguration, sdk, options);

--- a/src/models/cloudProviderIdentifier.ts
+++ b/src/models/cloudProviderIdentifier.ts
@@ -13,12 +13,25 @@ export enum CloudAdapterIdentifier {
 }
 
 export enum CloudProviderIdentifier {
-    GENEZIO = "genezio",
+    CAPYBARA_LINUX = "genezioCloud",
+    CAPYBARA = "genezioCloudUnikernel",
+    CLUSTER = "genezioCluster",
+    GENEZIO = "genezioAws",
+
     SELF_HOSTED_AWS = "selfHostedAws",
-    CAPYBARA = "capybara",
-    CAPYBARA_LINUX = "capybaraLinux",
-    CLUSTER = "cluster",
+
+    GENEZIO_LEGACY = "genezio",
+    CAPYBARA_LEGACY = "capybara",
+    CAPYBARA_LINUX_LEGACY = "capybaraLinux",
+    CLUSTER_LEGACY = "cluster",
 }
+
+export const CloudProviderMapping: Partial<Record<CloudProviderIdentifier, CloudProviderIdentifier>> = {
+    [CloudProviderIdentifier.CAPYBARA_LEGACY]: CloudProviderIdentifier.CAPYBARA,
+    [CloudProviderIdentifier.CAPYBARA_LINUX_LEGACY]: CloudProviderIdentifier.CAPYBARA_LINUX,
+    [CloudProviderIdentifier.GENEZIO_LEGACY]: CloudProviderIdentifier.GENEZIO,
+    [CloudProviderIdentifier.CLUSTER_LEGACY]: CloudProviderIdentifier.CLUSTER,
+};
 
 export interface LambdaResponse {
     statusDescription: string;

--- a/src/models/cloudProviderIdentifier.ts
+++ b/src/models/cloudProviderIdentifier.ts
@@ -13,10 +13,10 @@ export enum CloudAdapterIdentifier {
 }
 
 export enum CloudProviderIdentifier {
-    CAPYBARA_LINUX = "genezioCloud",
-    CAPYBARA = "genezioCloudUnikernel",
-    CLUSTER = "genezioCluster",
-    GENEZIO = "genezioAws",
+    CAPYBARA_LINUX = "genezio-cloud",
+    CAPYBARA = "genezio-unikernel",
+    CLUSTER = "genezio-cluster",
+    GENEZIO = "genezio-aws",
 
     SELF_HOSTED_AWS = "selfHostedAws",
 

--- a/src/models/cloudProviderIdentifier.ts
+++ b/src/models/cloudProviderIdentifier.ts
@@ -13,24 +13,27 @@ export enum CloudAdapterIdentifier {
 }
 
 export enum CloudProviderIdentifier {
-    CAPYBARA_LINUX = "genezio-cloud",
-    CAPYBARA = "genezio-unikernel",
-    CLUSTER = "genezio-cluster",
-    GENEZIO = "genezio-aws",
-
-    SELF_HOSTED_AWS = "selfHostedAws",
+    GENEZIO_CLOUD = "genezio-cloud",
+    GENEZIO_UNIKERNEL = "genezio-unikernel",
+    GENEZIO_CLUSTER = "genezio-cluster",
+    GENEZIO_AWS = "genezio-aws",
+    SELF_HOSTED_AWS = "self-hosted-aws",
 
     GENEZIO_LEGACY = "genezio",
     CAPYBARA_LEGACY = "capybara",
     CAPYBARA_LINUX_LEGACY = "capybaraLinux",
     CLUSTER_LEGACY = "cluster",
+    SELF_HOSTED_AWS_LEGACY = "selfHostedAws",
 }
 
-export const CloudProviderMapping: Partial<Record<CloudProviderIdentifier, CloudProviderIdentifier>> = {
-    [CloudProviderIdentifier.CAPYBARA_LEGACY]: CloudProviderIdentifier.CAPYBARA,
-    [CloudProviderIdentifier.CAPYBARA_LINUX_LEGACY]: CloudProviderIdentifier.CAPYBARA_LINUX,
-    [CloudProviderIdentifier.GENEZIO_LEGACY]: CloudProviderIdentifier.GENEZIO,
-    [CloudProviderIdentifier.CLUSTER_LEGACY]: CloudProviderIdentifier.CLUSTER,
+export const CloudProviderMapping: Partial<
+    Record<CloudProviderIdentifier, CloudProviderIdentifier>
+> = {
+    [CloudProviderIdentifier.CAPYBARA_LEGACY]: CloudProviderIdentifier.GENEZIO_UNIKERNEL,
+    [CloudProviderIdentifier.CAPYBARA_LINUX_LEGACY]: CloudProviderIdentifier.GENEZIO_CLOUD,
+    [CloudProviderIdentifier.GENEZIO_LEGACY]: CloudProviderIdentifier.GENEZIO_AWS,
+    [CloudProviderIdentifier.CLUSTER_LEGACY]: CloudProviderIdentifier.GENEZIO_CLUSTER,
+    [CloudProviderIdentifier.SELF_HOSTED_AWS_LEGACY]: CloudProviderIdentifier.SELF_HOSTED_AWS,
 };
 
 export interface LambdaResponse {

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -115,7 +115,7 @@ export class ProjectConfiguration {
             architecture: yamlConfiguration.backend?.language.architecture || DEFAULT_ARCHITECTURE,
         };
         this.cloudProvider =
-            yamlConfiguration.backend?.cloudProvider || CloudProviderIdentifier.GENEZIO;
+            yamlConfiguration.backend?.cloudProvider || CloudProviderIdentifier.CAPYBARA_LINUX;
         this.workspace = new Workspace(yamlConfiguration.backend?.path || process.cwd());
         // Generate AST Summary
         this.astSummary = {

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -115,7 +115,7 @@ export class ProjectConfiguration {
             architecture: yamlConfiguration.backend?.language.architecture || DEFAULT_ARCHITECTURE,
         };
         this.cloudProvider =
-            yamlConfiguration.backend?.cloudProvider || CloudProviderIdentifier.CAPYBARA_LINUX;
+            yamlConfiguration.backend?.cloudProvider || CloudProviderIdentifier.GENEZIO_CLOUD;
         this.workspace = new Workspace(yamlConfiguration.backend?.path || process.cwd());
         // Generate AST Summary
         this.astSummary = {

--- a/src/requests/getAuthStatus.ts
+++ b/src/requests/getAuthStatus.ts
@@ -31,11 +31,11 @@ export default async function getAuthStatus(envId: string): Promise<AuthStatus> 
         const [cloud, id] = authStatus.token.split("-");
         switch (cloud) {
             case "0":
-                authStatus.cloudProvider = CloudProviderIdentifier.GENEZIO;
+                authStatus.cloudProvider = CloudProviderIdentifier.GENEZIO_AWS;
                 authStatus.token = id;
                 break;
             case "1":
-                authStatus.cloudProvider = CloudProviderIdentifier.CAPYBARA;
+                authStatus.cloudProvider = CloudProviderIdentifier.GENEZIO_UNIKERNEL;
                 authStatus.token = id;
                 break;
             default:

--- a/src/utils/abTesting.ts
+++ b/src/utils/abTesting.ts
@@ -42,6 +42,6 @@ export async function isProjectDeployed(name: string, region: string): Promise<b
 // This function is used to randomly select a cloud provider for AB testing.
 export function getRandomCloudProvider(): CloudProviderIdentifier {
     return Math.random() < 0.5
-        ? CloudProviderIdentifier.GENEZIO
-        : CloudProviderIdentifier.CAPYBARA_LINUX;
+        ? CloudProviderIdentifier.GENEZIO_AWS
+        : CloudProviderIdentifier.GENEZIO_CLOUD;
 }

--- a/src/utils/servicesEnvVariables.ts
+++ b/src/utils/servicesEnvVariables.ts
@@ -34,7 +34,7 @@ async function getAuthFunctionUrl(
     }
 
     switch (authStatus.cloudProvider) {
-        case CloudProviderIdentifier.GENEZIO:
+        case CloudProviderIdentifier.GENEZIO_AWS:
             return `https://${authStatus.token}.lambda-url.${region}.on.aws/AuthService`;
         default:
             debugLogger.error(`Cloud provider ${authStatus.cloudProvider} is not supported yet`);

--- a/src/yamlProjectConfiguration/migration.ts
+++ b/src/yamlProjectConfiguration/migration.ts
@@ -68,7 +68,7 @@ export async function tryV2Migration(config: unknown): Promise<v2 | undefined> {
 
         if (
             (v1Config.cloudProvider as unknown as CloudProviderIdentifier) ===
-            CloudProviderIdentifier.CLUSTER
+            CloudProviderIdentifier.GENEZIO_CLUSTER
         ) {
             throw new UserError(
                 "genezio >= 1.0.0 is required for the migration of the cloud provider to cluster",
@@ -90,7 +90,7 @@ export async function tryV2Migration(config: unknown): Promise<v2 | undefined> {
                       cloudProvider:
                           // AWS was deprecated in Genezio YAML v2
                           v1Config.cloudProvider === "aws"
-                              ? CloudProviderIdentifier.GENEZIO
+                              ? CloudProviderIdentifier.GENEZIO_AWS
                               : (v1Config.cloudProvider as unknown as CloudProviderIdentifier),
                       classes: v1Config.classes.map((c) => ({
                           name: c.name,

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -131,7 +131,7 @@ function parseGenezioConfig(config: unknown) {
         frontend: zod.array(frontendSchema).or(frontendSchema).optional(),
     });
 
-    const parsedv2Schema = v2Schema.parse(config);
+    const parsedConfig = v2Schema.parse(config);
 
     // Update cloudProvider using the mapping if the current provider is a legacy version
     if (parsedv2Schema.backend?.cloudProvider && CloudProviderMapping[parsedv2Schema.backend.cloudProvider as CloudProviderIdentifier]) {

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -134,11 +134,11 @@ function parseGenezioConfig(config: unknown) {
     const parsedConfig = v2Schema.parse(config);
 
     // Update cloudProvider using the mapping if the current provider is a legacy version
-    if (parsedv2Schema.backend?.cloudProvider && CloudProviderMapping[parsedv2Schema.backend.cloudProvider as CloudProviderIdentifier]) {
-        parsedv2Schema.backend.cloudProvider = CloudProviderMapping[parsedv2Schema.backend.cloudProvider as CloudProviderIdentifier];
+    if (parsedConfig.backend?.cloudProvider && CloudProviderMapping[parsedConfig.backend.cloudProvider as CloudProviderIdentifier]) {
+        parsedConfig.backend.cloudProvider = CloudProviderMapping[parsedConfig.backend.cloudProvider as CloudProviderIdentifier];
     }
 
-    return parsedv2Schema;
+    return parsedConfig;
 }
 
 function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
@@ -154,7 +154,7 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
                 defaultConfig.backend.language.architecture ??= DEFAULT_ARCHITECTURE;
         }
 
-        defaultConfig.backend.cloudProvider ??= CloudProviderIdentifier.CAPYBARA_LINUX;
+        defaultConfig.backend.cloudProvider ??= CloudProviderIdentifier.GENEZIO_CLOUD;
     }
 
     if (defaultConfig.frontend && !Array.isArray(defaultConfig.frontend)) {

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -2,11 +2,20 @@ import { YAMLContext, parse as parseYaml, stringify as stringifyYaml } from "yam
 import zod from "zod";
 import nativeFs from "fs";
 import { IFs } from "memfs";
+import { log } from "../utils/logging.js";
 import { regions } from "../utils/configs.js";
 import { GENEZIO_CONFIGURATION_FILE_NOT_FOUND, UserError, zodFormatError } from "../errors.js";
 import { Language } from "./models.js";
-import { DEFAULT_ARCHITECTURE, DEFAULT_NODE_RUNTIME, supportedArchitectures, supportedNodeRuntimes } from "../models/projectOptions.js";
-import { CloudProviderIdentifier, CloudProviderMapping } from "../models/cloudProviderIdentifier.js";
+import {
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_NODE_RUNTIME,
+    supportedArchitectures,
+    supportedNodeRuntimes,
+} from "../models/projectOptions.js";
+import {
+    CloudProviderIdentifier,
+    CloudProviderMapping,
+} from "../models/cloudProviderIdentifier.js";
 import { PackageManagerType } from "../packageManagers/packageManager.js";
 import { TriggerType } from "./models.js";
 import { isValidCron } from "cron-validator";
@@ -134,8 +143,15 @@ function parseGenezioConfig(config: unknown) {
     const parsedConfig = v2Schema.parse(config);
 
     // Update cloudProvider using the mapping if the current provider is a legacy version
-    if (parsedConfig.backend?.cloudProvider && CloudProviderMapping[parsedConfig.backend.cloudProvider as CloudProviderIdentifier]) {
-        parsedConfig.backend.cloudProvider = CloudProviderMapping[parsedConfig.backend.cloudProvider as CloudProviderIdentifier];
+    if (
+        parsedConfig.backend?.cloudProvider &&
+        CloudProviderMapping[parsedConfig.backend.cloudProvider as CloudProviderIdentifier]
+    ) {
+        log.warn(
+            `Legacy cloud provider used: '${parsedConfig.backend.cloudProvider}'. Use '${CloudProviderMapping[parsedConfig.backend.cloudProvider as CloudProviderIdentifier]}' instead.`,
+        );
+        parsedConfig.backend.cloudProvider =
+            CloudProviderMapping[parsedConfig.backend.cloudProvider as CloudProviderIdentifier];
     }
 
     return parsedConfig;

--- a/tests/performAbTesting.test.ts
+++ b/tests/performAbTesting.test.ts
@@ -18,10 +18,10 @@ describe("test changing cloud providers for AB testing", () => {
 
         const name = "test";
         const region = "us-east-1";
-        const cloudProvider = CloudProviderIdentifier.GENEZIO;
+        const cloudProvider = CloudProviderIdentifier.GENEZIO_AWS;
 
         await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
-            CloudProviderIdentifier.GENEZIO,
+            CloudProviderIdentifier.GENEZIO_AWS,
         );
         expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
     });
@@ -32,10 +32,10 @@ describe("test changing cloud providers for AB testing", () => {
 
         const name = "test";
         const region = "us-east-1";
-        const cloudProvider = CloudProviderIdentifier.CAPYBARA_LINUX;
+        const cloudProvider = CloudProviderIdentifier.GENEZIO_CLOUD;
 
         await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
-            CloudProviderIdentifier.CAPYBARA_LINUX,
+            CloudProviderIdentifier.GENEZIO_CLOUD,
         );
         expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
     });
@@ -44,14 +44,14 @@ describe("test changing cloud providers for AB testing", () => {
         const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
         isProjectDeployedSpy.mockResolvedValue(false);
         const getRandomCloudProviderSpy = vi.spyOn(abTestingModule, "getRandomCloudProvider");
-        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.CAPYBARA_LINUX);
+        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.GENEZIO_CLOUD);
 
         const name = "test";
         const region = "us-east-1";
-        const cloudProvider = CloudProviderIdentifier.GENEZIO;
+        const cloudProvider = CloudProviderIdentifier.GENEZIO_AWS;
 
         await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
-            CloudProviderIdentifier.CAPYBARA_LINUX,
+            CloudProviderIdentifier.GENEZIO_CLOUD,
         );
         expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
         expect(getRandomCloudProviderSpy).toHaveBeenCalledOnce();
@@ -61,14 +61,14 @@ describe("test changing cloud providers for AB testing", () => {
         const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
         isProjectDeployedSpy.mockResolvedValue(false);
         const getRandomCloudProviderSpy = vi.spyOn(abTestingModule, "getRandomCloudProvider");
-        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.GENEZIO);
+        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.GENEZIO_AWS);
 
         const name = "test";
         const region = "us-east-1";
-        const cloudProvider = CloudProviderIdentifier.GENEZIO;
+        const cloudProvider = CloudProviderIdentifier.GENEZIO_AWS;
 
         await expect(performCloudProviderABTesting(name, region, cloudProvider)).resolves.toEqual(
-            CloudProviderIdentifier.GENEZIO,
+            CloudProviderIdentifier.GENEZIO_AWS,
         );
         expect(isProjectDeployedSpy).toHaveBeenCalledOnce();
         expect(getRandomCloudProviderSpy).toHaveBeenCalledOnce();
@@ -78,7 +78,7 @@ describe("test changing cloud providers for AB testing", () => {
         const isProjectDeployedSpy = vi.spyOn(abTestingModule, "isProjectDeployed");
         isProjectDeployedSpy.mockResolvedValue(false);
         const getRandomCloudProviderSpy = vi.spyOn(abTestingModule, "getRandomCloudProvider");
-        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.CAPYBARA_LINUX);
+        getRandomCloudProviderSpy.mockReturnValue(CloudProviderIdentifier.GENEZIO_CLOUD);
 
         const name = "test";
         const region = "us-east-1";

--- a/tests/requests/deployCode.test.ts
+++ b/tests/requests/deployCode.test.ts
@@ -21,7 +21,7 @@ test("should throw error if server returns error", async () => {
         const projectConfiguration: ProjectConfiguration = {
             name: "test",
             region: "us-east-1",
-            cloudProvider: CloudProviderIdentifier.GENEZIO,
+            cloudProvider: CloudProviderIdentifier.GENEZIO_AWS,
             astSummary: {
                 classes: [],
                 version: "1.0.0",
@@ -42,7 +42,7 @@ test("should throw error if server returns data.error object", async () => {
         const projectConfiguration: ProjectConfiguration = {
             name: "test",
             region: "us-east-1",
-            cloudProvider: CloudProviderIdentifier.GENEZIO,
+            cloudProvider: CloudProviderIdentifier.GENEZIO_AWS,
             astSummary: {
                 classes: [],
                 version: "1.0.0",
@@ -62,7 +62,7 @@ test("should return response.data if everything is ok", async () => {
     const projectConfiguration: ProjectConfiguration = {
         name: "test",
         region: "us-east-1",
-        cloudProvider: CloudProviderIdentifier.GENEZIO,
+        cloudProvider: CloudProviderIdentifier.GENEZIO_AWS,
         astSummary: {
             classes: [],
             version: "1.0.0",
@@ -88,7 +88,7 @@ test("should read token and pass it to headers", async () => {
     const projectConfiguration: ProjectConfiguration = {
         name: "test",
         region: "us-east-1",
-        cloudProvider: CloudProviderIdentifier.GENEZIO,
+        cloudProvider: CloudProviderIdentifier.GENEZIO_AWS,
         astSummary: {
             classes: [],
             version: "1.0.0",


### PR DESCRIPTION
-   [X] 🔥 Breaking change


## Description
Update cloud provider names and maintain backwards compatibility with the old ones.
Changed the default provider to CAPYBARA_LINUX.

New cloud provider names:
genezioCloud
genezioCloudUnikernel
genezioAws
genezioCluster

This change does not affect self hosted AWS.
