### PR TITLE
Remove a/b testing for runtime

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -3,7 +3,6 @@ import { log } from "../utils/logging.js";
 import path from "path";
 import { exit } from "process";
 import {
-    ENVIRONMENT,
     DASHBOARD_URL,
     RECOMMENTDED_GENEZIO_TYPES_VERSION_RANGE,
     REQUIRED_GENEZIO_TYPES_VERSION_RANGE,
@@ -118,27 +117,6 @@ export async function deployCommand(options: GenezioDeployOptions) {
             });
             throw error;
         });
-
-        // Enable cloud provider AB Testing
-        // This is ONLY done in the dev environment and if DISABLE_AB_TESTING is not set.
-        if (
-            ENVIRONMENT === "dev" &&
-            configuration.backend &&
-            process.env["DISABLE_AB_TESTING"] !== "true"
-        ) {
-            const yamlConfig = await configIOController.read(/* fillDefaults= */ false);
-            if (!yamlConfig.backend) {
-                throw new UserError("No backend entry in genezio configuration file.");
-            }
-            yamlConfig.backend.cloudProvider = await performCloudProviderABTesting(
-                configuration.name,
-                configuration.region,
-                configuration.backend.cloudProvider,
-            );
-            // Write the new configuration in the config file
-            await configIOController.write(yamlConfig);
-            configuration.backend.cloudProvider = yamlConfig.backend.cloudProvider;
-        }
 
         await GenezioTelemetry.sendEvent({
             eventType: TelemetryEventTypes.GENEZIO_BACKEND_DEPLOY_START,


### PR DESCRIPTION
Remove a/b testing from deployments. I've decided to leave the a/b testing logic there in case we will need it on a future cloud provider (genezio-unikernel is the first one to come to mind).
