### PR TITLE
Revert default provider change back to aws

### DIFF
--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -115,7 +115,7 @@ export class ProjectConfiguration {
             architecture: yamlConfiguration.backend?.language.architecture || DEFAULT_ARCHITECTURE,
         };
         this.cloudProvider =
-            yamlConfiguration.backend?.cloudProvider || CloudProviderIdentifier.GENEZIO_CLOUD;
+            yamlConfiguration.backend?.cloudProvider || CloudProviderIdentifier.GENEZIO_AWS;
         this.workspace = new Workspace(yamlConfiguration.backend?.path || process.cwd());
         // Generate AST Summary
         this.astSummary = {

--- a/src/yamlProjectConfiguration/v2.ts
+++ b/src/yamlProjectConfiguration/v2.ts
@@ -170,7 +170,7 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
                 defaultConfig.backend.language.architecture ??= DEFAULT_ARCHITECTURE;
         }
 
-        defaultConfig.backend.cloudProvider ??= CloudProviderIdentifier.GENEZIO_CLOUD;
+        defaultConfig.backend.cloudProvider ??= CloudProviderIdentifier.GENEZIO_AWS;
     }
 
     if (defaultConfig.frontend && !Array.isArray(defaultConfig.frontend)) {


### PR DESCRIPTION
Revert back the default provider change from `genezio-cloud` to `genezio-aws`.