### PR TITLE
Fix Runtime handler URL composition

### DIFF
--- a/src/bundlers/node/genezioRuntimeHandlerGenerator.ts
+++ b/src/bundlers/node/genezioRuntimeHandlerGenerator.ts
@@ -75,7 +75,7 @@ if (!genezioClass) {
         if (!body || (body && body["jsonrpc"] !== "2.0")) {
             // For raw http calls, paths should match \`/funcId/className/methodName\`
             const components = event.http.path.substring(1).split("/");
-            if (!components[2]) {
+            if (!components[1]) {
                 return {
                     statusCode: 404,
                     headers: { 'Content-Type': 'application/json', 'X-Powered-By': 'genezio' },
@@ -83,7 +83,7 @@ if (!genezioClass) {
                 };
             }
 
-            const method = components[2];
+            const method = components[1];
 
             const http2CompliantHeaders = {};
             for (const header in event.headers) {


### PR DESCRIPTION
-   [ ] 🐛 Bug Fix

The url returned by the runtime now has the functionId as part of the subdomain. Previously, it was the first element of the path. As a result, in order to take the method name, we need to take the first part of the path.