### PR TITLE
Change genezio link internal structure to contain SDK language

### DIFF
--- a/src/commands/create/create.ts
+++ b/src/commands/create/create.ts
@@ -4,7 +4,6 @@ import git from "isomorphic-git";
 import http from "isomorphic-git/http/node/index.js";
 import path from "path";
 import nativeFs from "fs";
-import { setLinkPathForProject } from "../../utils/linkDatabase.js";
 import { log } from "../../utils/logging.js";
 import { platform } from "os";
 import { GenezioCreateOptions } from "../../models/commandOptions.js";
@@ -15,6 +14,8 @@ import { YamlConfigurationIOController } from "../../yamlProjectConfiguration/v2
 import { YAMLContext, mergeContexts } from "yaml-transmute";
 import _ from "lodash";
 import { UserError } from "../../errors.js";
+import { Language } from "../../yamlProjectConfiguration/models.js";
+import { linkFrontendsToProject } from "../../utils/linkDatabase.js";
 
 type ProjectInfo = {
     name: string;
@@ -77,7 +78,10 @@ export async function createCommand(options: GenezioCreateOptions) {
                     break;
                 case true:
                     // Genezio link inside the client project
-                    await setLinkPathForProject(options.name, path.join(projectPath, "client"));
+                    await linkFrontendsToProject(options.name, [
+                        // TODO: Use the actual template language instead of always TypeScript
+                        { path: path.join(projectPath, "client"), language: Language.ts },
+                    ]);
                     log.info(SUCCESSFULL_CREATE_MULTIREPO(projectPath, options.name));
                     break;
             }

--- a/src/generateSdk/sdkMonitor.ts
+++ b/src/generateSdk/sdkMonitor.ts
@@ -4,10 +4,10 @@ import { default as fsExtra } from "fs-extra";
 import fsPromises from "fs/promises";
 import fs from "fs";
 import path from "path";
-import { getLinkPathsForProject } from "../utils/linkDatabase.js";
 import { debugLogger } from "../utils/logging.js";
 import { Options, Result, compareSync } from "dir-compare";
 import { deleteFolder } from "../utils/file.js";
+import { getLinkedFrontendsForProject } from "../utils/linkDatabase.js";
 
 const POLLING_INTERVAL = 2000;
 
@@ -46,10 +46,10 @@ async function watchNodeModules(
         }
     }
 
-    const linkPaths = await getLinkPathsForProject(projectName);
-    for (const linkPath of linkPaths) {
-        watchPaths.push(path.join(linkPath, nodeModulesSdkDirectoryPath));
-        watchPaths.push(path.join(linkPath, "node_modules", ".package-lock.json"));
+    const linkedFrontends = await getLinkedFrontendsForProject(projectName);
+    for (const link of linkedFrontends) {
+        watchPaths.push(path.join(link.path, nodeModulesSdkDirectoryPath));
+        watchPaths.push(path.join(link.path, "node_modules", ".package-lock.json"));
     }
 
     return setInterval(async () => {
@@ -107,7 +107,7 @@ async function writeSdkToNodeModules(
     // A frontend can be explicitly declared in the genezio.yaml file or it can be linked to the project
     const frontendPaths = (frontends || [])
         .map((f) => f.path)
-        .concat(await getLinkPathsForProject(projectName));
+        .concat((await getLinkedFrontendsForProject(projectName)).map((f) => f.path));
     for (const frontendPath of frontendPaths) {
         const to = path.join(frontendPath, "node_modules", "@genezio-sdk", `${projectName}`);
 

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -362,13 +362,14 @@ program
 program
     .command("link")
     .argument("[projectName]", "The name of the project that you want to communicate with.")
+    .argument("[language]", "The language of the SDK that will be generated.")
     .summary("Links the genezio generated SDK in the current working directory")
     .description(
         "Linking a client with a deployed project will enable `genezio local` to figure out where to generate the SDK to call the backend methods.\n\
 This command is useful when the project has dedicated repositories for the backend and the frontend.",
     )
-    .action(async (projectName: string) => {
-        await linkCommand(projectName).catch((error) => {
+    .action(async (projectName?: string, projectLanguage?: string) => {
+        await linkCommand(projectName, projectLanguage).catch((error) => {
             logError(error);
             exit(1);
         });

--- a/src/utils/linkDatabase.ts
+++ b/src/utils/linkDatabase.ts
@@ -1,59 +1,94 @@
 import { promises as fs } from "fs";
 import os from "os";
 import path from "path";
+import { Language } from "../yamlProjectConfiguration/models.js";
+import zod from "zod";
 
-async function getLinkContent(): Promise<Map<string, string[]>> {
+export type LinkedFrontend = {
+    path: string;
+    language: Language;
+};
+
+async function getLinkContent(): Promise<Map<string, LinkedFrontend[]>> {
     const directoryPath = path.join(os.homedir(), ".genezio");
     const filePath = path.join(directoryPath, "geneziolinks");
     try {
         // Try to read the file
         const data = await fs.readFile(filePath, "utf8");
-        // Parse the content as JSON and return as a Map
-        return new Map(Object.entries(JSON.parse(data)));
+        // Parse the content as JSON and convert it as a Map
+        const projectMap: Map<string, LinkedFrontend[]> = new Map(Object.entries(JSON.parse(data)));
+
+        const linkedFrontendSchema = zod.object({
+            path: zod.string(),
+            language: zod.nativeEnum(Language),
+        });
+        for (const [projectName, linkedFrontends] of projectMap.entries()) {
+            // Ignore values that do not match the `LinkedFrontend` schema, because they are most likely using an old version format
+            projectMap.set(
+                projectName,
+                linkedFrontends.filter((f) => linkedFrontendSchema.safeParse(f).success),
+            );
+        }
+
+        return projectMap;
     } catch (error) {
         const err = error as NodeJS.ErrnoException;
         if (err.code === "ENOENT" || err.code === "ENOTDIR") {
             await fs.mkdir(directoryPath, { recursive: true });
             // If the file doesn't exist, create it with an empty object
             await fs.writeFile(filePath, JSON.stringify({}), "utf8");
-            return new Map<string, string[]>();
+            return new Map<string, LinkedFrontend[]>();
         }
+
         // Rethrow the error if it's not because the file doesn't exist
         throw error;
     }
 }
 
-export async function getLinkPathsForProject(projectName: string): Promise<string[]> {
-    const content = await getLinkContent();
-    const key = `${projectName}`;
-    return content.get(key) || [];
+async function saveLinkContent(content: Map<string, LinkedFrontend[]>): Promise<void> {
+    const directoryPath = path.join(os.homedir(), ".genezio");
+    const filePath = path.join(directoryPath, "geneziolinks");
+
+    await fs.writeFile(filePath, JSON.stringify(Object.fromEntries(content)), "utf8");
 }
 
-export async function setLinkPathForProject(projectName: string, linkPath: string): Promise<void> {
+export async function getLinkedFrontendsForProject(projectName: string): Promise<LinkedFrontend[]> {
     const content = await getLinkContent();
-    const key = `${projectName}`;
-    const paths = content.get(key) || [];
-    if (paths.includes(linkPath)) {
-        return;
+
+    return content.get(projectName) || [];
+}
+
+export async function linkFrontendsToProject(
+    projectName: string,
+    frontends: LinkedFrontend[],
+): Promise<void> {
+    const content = await getLinkContent();
+    const linkedFrontends = content.get(projectName) || [];
+
+    for (const frontend of frontends) {
+        // If the frontend is already linked don't add it twice
+        if (
+            linkedFrontends.find(
+                (linked) => linked.path === frontend.path && linked.language === frontend.language,
+            )
+        ) {
+            continue;
+        }
+
+        linkedFrontends.push(frontend);
     }
-    paths.push(linkPath);
-    content.set(key, paths);
+
+    content.set(projectName, linkedFrontends);
     await saveLinkContent(content);
 }
 
 export async function deleteAllLinkPaths(): Promise<void> {
-    await saveLinkContent(new Map<string, string[]>());
+    await saveLinkContent(new Map<string, LinkedFrontend[]>());
 }
 
 export async function deleteLinkPathForProject(projectName: string): Promise<void> {
     const content = await getLinkContent();
-    const key = `${projectName}`;
-    content.delete(key);
-    await saveLinkContent(content);
-}
 
-async function saveLinkContent(content: Map<string, string[]>): Promise<void> {
-    const directoryPath = path.join(os.homedir(), ".genezio");
-    const filePath = path.join(directoryPath, "geneziolinks");
-    await fs.writeFile(filePath, JSON.stringify(Object.fromEntries(content)), "utf8");
+    content.delete(projectName);
+    await saveLinkContent(content);
 }

--- a/tests/commands/create/create.test.ts
+++ b/tests/commands/create/create.test.ts
@@ -4,7 +4,7 @@ import { describe, test, vi, beforeEach, expect } from "vitest";
 import { regions } from "../../../src/utils/configs";
 import { createCommand } from "../../../src/commands/create/create";
 import { GenezioCreateOptions } from "../../../src/models/commandOptions";
-import { setLinkPathForProject } from "../../../src/utils/linkDatabase";
+import { linkFrontendsToProject } from "../../../src/utils/linkDatabase";
 
 vi.mock("fs", () => {
     return { default: memfsFs };
@@ -200,7 +200,7 @@ describe("create", () => {
 
         await createCommand(options);
 
-        expect(setLinkPathForProject).toHaveBeenCalled();
+        expect(linkFrontendsToProject).toHaveBeenCalled();
 
         // Project folder should be created
         expect(vol.existsSync(path.join(process.cwd(), "genezio-project"))).toBe(true);


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [x] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

We would like to know the SDK language of a linked frontend when writing it. Until now, we would always write the JS/TS SDK, but now a frontend in any supported language can be linked.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [x] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
