### PR TITLE
remove old node runtimes

### DIFF
--- a/src/bundlers/node/containerManifest.ts
+++ b/src/bundlers/node/containerManifest.ts
@@ -1,6 +1,4 @@
 import {
-    CONTAINER_IMAGE_NODE16,
-    CONTAINER_IMAGE_NODE18,
     CONTAINER_IMAGE_NODE20,
     DEFAULT_NODE_RUNTIME_IMAGE,
     supportedNodeRuntimes,
@@ -10,12 +8,6 @@ export function generateNodeContainerManifest(nodeVersion: string) {
     let nodeVersionImage = DEFAULT_NODE_RUNTIME_IMAGE;
     switch (nodeVersion) {
         case supportedNodeRuntimes[0]:
-            nodeVersionImage = CONTAINER_IMAGE_NODE16;
-            break;
-        case supportedNodeRuntimes[1]:
-            nodeVersionImage = CONTAINER_IMAGE_NODE18;
-            break;
-        case supportedNodeRuntimes[2]:
             nodeVersionImage = CONTAINER_IMAGE_NODE20;
             break;
     }

--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -1,10 +1,8 @@
-export type NodeRuntime = "nodejs16.x" | "nodejs18.x" | "nodejs20.x";
+export type NodeRuntime = "nodejs20.x";
 export type Architecture = "arm64" | "x86_64";
 export const DEFAULT_NODE_RUNTIME: NodeRuntime = "nodejs20.x";
 export const DEFAULT_ARCHITECTURE: Architecture = "arm64";
 
-export const CONTAINER_IMAGE_NODE16 = "node:16.20.2-alpine3.18";
-export const CONTAINER_IMAGE_NODE18 = "node:18.19.0-alpine";
 export const CONTAINER_IMAGE_NODE20 = "node:20.11.1-alpine3.19";
 
 export const DEFAULT_NODE_RUNTIME_IMAGE = CONTAINER_IMAGE_NODE20;
@@ -14,5 +12,5 @@ export type NodeOptions = {
     architecture: Architecture;
 };
 
-export const supportedNodeRuntimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x"] as const;
+export const supportedNodeRuntimes = ["nodejs20.x"] as const;
 export const supportedArchitectures = ["arm64", "x86_64"] as const;


### PR DESCRIPTION
## Type of change

-   [x] 🧑‍💻 Improvement

## Description

Remove old node runtime versions (node16 and node18). Until future stable node versions, the only supported runtime will be node20.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
