### PR TITLE
temporarily redirect go functions to aws lambda

### DIFF
--- a/src/bundlers/go/genezioRuntimeGoBundler.ts
+++ b/src/bundlers/go/genezioRuntimeGoBundler.ts
@@ -10,7 +10,7 @@ export class GenezioRuntimeGoBundler extends GoBundler {
 
     generateErrorReturn(): string {
         return `
-            sendError(w, err, JsonRpcMethod)
+            sendError(ctx, w, err, JsonRpcMethod)
             return
         `;
     }

--- a/src/bundlers/go/localGoBundler.ts
+++ b/src/bundlers/go/localGoBundler.ts
@@ -11,7 +11,7 @@ export class LocalGoBundler extends GoBundler {
 
     generateErrorReturn(): string {
         return `
-            sendError(w, err, JsonRpcMethod)
+            sendError(ctx, w, err, JsonRpcMethod)
             return
         `;
     }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -252,7 +252,11 @@ export async function deployClasses(
 
         throw error;
     });
-    const cloudProvider = await getCloudProvider(configuration.name);
+    const cloudProvider =
+        // TODO: Remove this as soon as Genezio Cloud supports Go
+        backend.language.name === Language.go
+            ? CloudProviderIdentifier.GENEZIO_AWS
+            : await getCloudProvider(configuration.name);
     const projectConfiguration = new ProjectConfiguration(
         configuration,
         cloudProvider,


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

Genezio Cloud currently has a few bugs when deploying GO, especially from platforms other than Linux. While we search for a solution regarding this, this PR aims to redirect all GO deployments to the AWS Lambda cloud provider.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
