### PR TITLE
use aws handler for genezio local

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -152,7 +152,7 @@ export async function prepareLocalBackendEnvironment(
         });
         const projectConfiguration = new ProjectConfiguration(
             yamlProjectConfiguration,
-            CloudProviderIdentifier.GENEZIO_CLOUD,
+            CloudProviderIdentifier.GENEZIO_AWS,
             sdkResponse,
         );
 


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

Genezio local should still use the aws handler, as the request still use the aws interface.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
