### PR TITLE
Move deploy auto login before backend/frontend deployment

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -105,6 +105,12 @@ export async function deployCommand(options: GenezioDeployOptions) {
         checkExperimentalDecorators(backendCwd);
     }
 
+    // check if user is logged in
+    if (!(await isLoggedIn())) {
+        debugLogger.debug("No auth token found. Starting automatic authentication...");
+        await loginCommand("", false);
+    }
+
     let deployClassesResult;
     backend: if (configuration.backend && !options.frontend) {
         if (configuration.backend.classes?.length === 0) {
@@ -418,14 +424,6 @@ export async function deployClasses(
             path: path.relative(process.cwd(), c.path).replace(/\.[^/.]+$/, ""),
         };
     });
-
-    // check if user is logged in
-    if (projectConfiguration.cloudProvider !== CloudProviderIdentifier.SELF_HOSTED_AWS) {
-        if (!(await isLoggedIn())) {
-            debugLogger.debug("No auth token found. Starting automatic authentication...");
-            await loginCommand("", false);
-        }
-    }
 
     // TODO: Enable cloud adapter setting for every class
     const cloudAdapter = getCloudAdapter(cloudProvider);


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Before this change, auto login would only be called for projects that have backend deployment. If the project was only deploying frontend, the auto login code would not be called.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
