### PR TITLE
Fix for issue when isGnzContext is called on 'null' value.

### DIFF
--- a/src/bundlers/node/genezioRuntimeHandlerGenerator.ts
+++ b/src/bundlers/node/genezioRuntimeHandlerGenerator.ts
@@ -201,7 +201,7 @@ if (!genezioClass) {
                 });
             });
 
-            if(body.params && body.params.length > 0 && body.params[0].isGnzContext === true ) {
+            if(body.params && body.params.length > 0 && body.params[0] && body.params[0].isGnzContext === true ) {
                 body.params[0].requestContext = {
                     http: event.http,
                     url: event.url, 

--- a/src/bundlers/node/lambdaHandlerGenerator.ts
+++ b/src/bundlers/node/lambdaHandlerGenerator.ts
@@ -238,7 +238,7 @@ if (!genezioClass) {
                 });
             });
 
-            if(body.params && body.params.length > 0 && body.params[0].isGnzContext === true ) {
+            if(body.params && body.params.length > 0 && body.params[0] && body.params[0].isGnzContext === true ) {
                body.params[0].requestContext = event.requestContext;
                body.params[0].headers = event.headers;
             }


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

If the first parameter is `null`, calling `isGnzContext` on that value will result in a crash.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
