### PR TITLE
Prompt user to select project name if the package.json name project exists

### DIFF
--- a/src/commands/create/create.ts
+++ b/src/commands/create/create.ts
@@ -132,6 +132,8 @@ export function checkProjectName(projectName: string) {
             "Project name must start with a letter and contain only letters, numbers and dashes",
         );
     }
+
+    return true;
 }
 
 export function checkPathIsEmpty(projectPath: string) {

--- a/src/requests/getProjectInfoByName.ts
+++ b/src/requests/getProjectInfoByName.ts
@@ -6,10 +6,7 @@ import { ProjectDetails, StatusOk } from "./models.js";
 import { AxiosResponse } from "axios";
 import { UserError } from "../errors.js";
 
-export default async function getProjectInfoByName(
-    projectName: string,
-    region: string,
-): Promise<ProjectDetails> {
+export default async function getProjectInfoByName(projectName: string): Promise<ProjectDetails> {
     const authToken = await getAuthToken();
 
     if (!authToken) {
@@ -21,9 +18,6 @@ export default async function getProjectInfoByName(
     const response: AxiosResponse<StatusOk<{ project: ProjectDetails }>> = await axios({
         method: "GET",
         url: `${BACKEND_ENDPOINT}/projects/name/${projectName}`,
-        params: {
-            region: region,
-        },
         headers: {
             Authorization: `Bearer ${authToken}`,
             "Accept-Version": `genezio-cli/${version}`,
@@ -32,15 +26,13 @@ export default async function getProjectInfoByName(
     return response.data.project;
 }
 
-export async function getProjectEnvFromProjectByName(
-    projectName: string,
-    region: string,
-    stageName: string,
-) {
+export async function getProjectEnvFromProjectByName(projectName: string, stageName: string) {
     let completeProjectInfo;
     try {
-        completeProjectInfo = await getProjectInfoByName(projectName, region);
-    } catch (e) {}
+        completeProjectInfo = await getProjectInfoByName(projectName);
+    } catch (e) {
+        /* empty */
+    }
 
     if (completeProjectInfo != undefined) {
         const projectEnv = completeProjectInfo.projectEnvs.find(

--- a/src/utils/servicesEnvVariables.ts
+++ b/src/utils/servicesEnvVariables.ts
@@ -14,14 +14,12 @@ async function getAuthFunctionUrl(
     region: string,
     stage: string,
 ): Promise<string | undefined> {
-    const projectEnv = await getProjectEnvFromProjectByName(projectName, region, stage).catch(
-        (error) => {
-            if (error instanceof UserError) {
-                throw error;
-            }
-            return undefined;
-        },
-    );
+    const projectEnv = await getProjectEnvFromProjectByName(projectName, stage).catch((error) => {
+        if (error instanceof UserError) {
+            throw error;
+        }
+        return undefined;
+    });
     if (!projectEnv) {
         return undefined;
     }


### PR DESCRIPTION


<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

We don't want to automatically use the package.json name if the project exists, because it could overwrite the existing project by accident.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
