### PR TITLE
[bugfix] Allow logLevel option to be used anywhere in command

### DIFF
--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -205,9 +205,7 @@ program
     });
 
 const create = program
-    .enablePositionalOptions()
     .command("create")
-    .passThroughOptions()
     .option("--path <path>", "Path where to create the project.", undefined)
     .summary("Create a new project from a template.")
     .action(async (options: GenezioCreateInteractiveOptions) => {
@@ -253,10 +251,13 @@ create
         "Create a project with a backend and a frontend in separate repositories.",
         false,
     )
-    .option("--path <path>", "Path where to create the project.", undefined)
     .summary("Create a new project from a backend and a frontend template.")
-    .action(async (options: GenezioCreateFullstackOptions) => {
-        const createOptions = await askCreateOptions({ ...options, type: "fullstack" });
+    .action(async (options: GenezioCreateFullstackOptions, { parent }: { parent: Command }) => {
+        const createOptions = await askCreateOptions({
+            ...parent.opts(),
+            ...options,
+            type: "fullstack",
+        });
 
         const telemetryEvent = GenezioTelemetry.sendEvent({
             eventType: TelemetryEventTypes.GENEZIO_CREATE,
@@ -288,10 +289,13 @@ create
             Object.keys(backendTemplates),
         ),
     )
-    .option("--path <path>", "Path where to create the project.", undefined)
     .summary("Create a new project from a backend template.")
-    .action(async (options: GenezioCreateBackendOptions) => {
-        const createOptions = await askCreateOptions({ ...options, type: "backend" });
+    .action(async (options: GenezioCreateBackendOptions, { parent }: { parent: Command }) => {
+        const createOptions = await askCreateOptions({
+            ...parent.opts(),
+            ...options,
+            type: "backend",
+        });
 
         const telemetryEvent = GenezioTelemetry.sendEvent({
             eventType: TelemetryEventTypes.GENEZIO_CREATE,
@@ -318,10 +322,13 @@ create
             regions.map((region) => region.value),
         ),
     )
-    .option("--path <path>", "Path where to create the project.", undefined)
     .summary("Create a new Next.js project.")
-    .action(async (options: GenezioCreateNextJsOptions) => {
-        const createOptions = await askCreateOptions({ ...options, type: "nextjs" });
+    .action(async (options: GenezioCreateNextJsOptions, { parent }: { parent: Command }) => {
+        const createOptions = await askCreateOptions({
+            ...parent.opts(),
+            ...options,
+            type: "nextjs",
+        });
 
         const telemetryEvent = GenezioTelemetry.sendEvent({
             eventType: TelemetryEventTypes.GENEZIO_CREATE,
@@ -350,8 +357,12 @@ create
     )
     .option("--path <path>", "Path where to create the project.", undefined)
     .summary("Create a new Express.js project.")
-    .action(async (options: GenezioCreateExpressJsOptions) => {
-        const createOptions = await askCreateOptions({ ...options, type: "expressjs" });
+    .action(async (options: GenezioCreateExpressJsOptions, { parent }: { parent: Command }) => {
+        const createOptions = await askCreateOptions({
+            ...parent.opts(),
+            ...options,
+            type: "expressjs",
+        });
 
         const telemetryEvent = GenezioTelemetry.sendEvent({
             eventType: TelemetryEventTypes.GENEZIO_CREATE,
@@ -380,8 +391,12 @@ create
     )
     .option("--path <path>", "Path where to create the project.", undefined)
     .summary("Create a new Serverless Function project.")
-    .action(async (options: GenezioCreateExpressJsOptions) => {
-        const createOptions = await askCreateOptions({ ...options, type: "serverless" });
+    .action(async (options: GenezioCreateExpressJsOptions, { parent }: { parent: Command }) => {
+        const createOptions = await askCreateOptions({
+            ...parent.opts(),
+            ...options,
+            type: "serverless",
+        });
 
         const telemetryEvent = GenezioTelemetry.sendEvent({
             eventType: TelemetryEventTypes.GENEZIO_CREATE,


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

A previous PR fixed `--path` not working in the `genezio create nextjs/expressjs/serverless` command by adding option passtrough. This broke the `--logLevel` global option. This PR fixes the problem, while still making the `genezio create --path`  option work.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
