### PR TITLE
Fix condition to correctly form the distribution URL

### DIFF
--- a/src/commands/deploy/nextjs.ts
+++ b/src/commands/deploy/nextjs.ts
@@ -214,8 +214,7 @@ async function deployCDN(
             origin: serverOrigin,
         },
     );
-
-    if (!distributionUrl.startsWith("https://") || !distributionUrl.startsWith("http://")) {
+    if (!distributionUrl.startsWith("https://") && !distributionUrl.startsWith("http://")) {
         return `https://${distributionUrl}`;
     }
 


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

The if condition was not okay before. For a `distributionUrl` that is starting with `https://`, the condition `!distributionUrl.startsWith("http://")` is true - making the whole if condition true.

Hence, we ended up displaying `https://https://domain`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] I have updated the documentation;
-   [x] New and existing unit tests pass locally with my changes;
