### PR TITLE
allow object body and query params in genezio local functions

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -664,9 +664,10 @@ async function startServerHttp(
     });
 
     async function handlerFunctionCall(req: Request<{ functionName: string }>, res: Response) {
-        // remove /.functions/:functionName from the url in order to get expected path for the function
-        req.url = "/" + req.url.split("/").slice(3).join("/");
         const reqToFunction = getEventObjectFromRequest(req);
+        // remove /.functions/:functionName from the url in order to get expected path for the function
+        reqToFunction.rawPath = "/" + reqToFunction.rawPath?.split("/").slice(3).join("/");
+        reqToFunction.requestContext.http.path = reqToFunction.rawPath;
 
         const localProcess = processForUnits.get(req.params.functionName);
 
@@ -923,8 +924,10 @@ function sendResponse(res: Response, httpResponse: LambdaResponse) {
     } else {
         if (Buffer.isBuffer(httpResponse.body)) {
             res.end(JSON.stringify(httpResponse.body.toJSON()));
+        } else if (typeof httpResponse.body === "object") {
+            res.end(JSON.stringify(httpResponse.body));
         } else {
-            res.end(httpResponse.body ? httpResponse.body : "");
+            res.end(httpResponse.body ? httpResponse.body.toString() : "");
         }
     }
 }


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🐛 Bug Fix

## Description

Fixed a bug that broke genezio local if trying to return a body of type object from a function. Also, fixed query params which broke since we trimmed the URL for local functions.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
