### PR TITLE
remove console log with port on local function wrapper code

### DIFF
--- a/src/bundlers/node/nodeJsLocalBundler.ts
+++ b/src/bundlers/node/nodeJsLocalBundler.ts
@@ -62,8 +62,6 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(port, () => {
-  console.log('Server running on port ' + port);
-
 });
 `;
 }


### PR DESCRIPTION
## Type of change

-   [x] 🧑‍💻 Improvement

## Description

The local wrapper logged the port where the application was running. That log could be misleading for the user, as that port is not exposed directly to the user, but to our express "proxy" serving all the functions from the same port.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
