### PR TITLE
Add streaming support to Lambda faas handler

### DIFF
--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -626,7 +626,8 @@ export async function functionToCloudInput(
         );
         entryFile = `index-${Math.random().toString(36).substring(7)}.mjs`;
     }
-    await writeToFile(path.join(tmpFolderPath), entryFile, handlerContent);
+    await writeToFile(tmpFolderPath, entryFile, handlerContent);
+    await handlerProvider.writeAdditionalFiles(tmpFolderPath);
 
     debugLogger.debug(`Zip the directory ${tmpFolderPath}.`);
 

--- a/src/functionHandlerProvider/functionHandlerProvider.ts
+++ b/src/functionHandlerProvider/functionHandlerProvider.ts
@@ -2,4 +2,5 @@ import { FunctionConfiguration } from "../models/projectConfiguration.js";
 
 export interface FunctionHandlerProvider {
     getHandler(functionConfiguration: FunctionConfiguration): Promise<string>;
+    writeAdditionalFiles(path: string): Promise<void>;
 }

--- a/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
+++ b/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
@@ -1,10 +1,12 @@
+import { writeToFile } from "../../utils/file.js";
 import { FunctionConfiguration } from "../../models/projectConfiguration.js";
 import { FunctionHandlerProvider } from "../functionHandlerProvider.js";
 
 export class AwsFunctionHandlerProvider implements FunctionHandlerProvider {
     async getHandler(functionConfiguration: FunctionConfiguration): Promise<string> {
         return (
-            `import { ${functionConfiguration.handler} as genezioDeploy } from "./${functionConfiguration.entry}";
+            `import './setupLambdaGlobals.mjs';
+import { ${functionConfiguration.handler} as genezioDeploy } from "./${functionConfiguration.entry}";
 
 function formatTimestamp(timestamp) {
   const date = new Date(timestamp);
@@ -71,7 +73,8 @@ const handler = async function(event) {
     body: event.isBase64Encoded
       ? Buffer.from(event.body, "base64")
       : event.body.toString(),
-    isBase64Encoded: event.isBase64Encoded
+    isBase64Encoded: event.isBase64Encoded,
+    responseStream: event.responseStream,
   };
 
   const result = await genezioDeploy(req).catch(error => {
@@ -87,5 +90,17 @@ const handler = async function(event) {
 
 export { handler };`
         );
+    }
+
+    async writeAdditionalFiles(outPath: string): Promise<void> {
+        const content = `global.awslambda = {
+        streamifyResponse: function (handler) {
+                return async (event, context) => {
+                        await handler(event, event.responseStream, context);
+                }
+        },
+};`;
+
+        await writeToFile(outPath, "setupLambdaGlobals.mjs", content);
     }
 }


### PR DESCRIPTION
## Type of change

-   [x] 🍕 New feature

## Description

Extend the Lambda handler to support response streaming.
Mock the `awslambda.streamifyResponse` function to use the stream created by the Genezio function runtime.