### PR TITLE
Make Source Maps smaller by avoiding to include original file content

### DIFF
--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -213,6 +213,7 @@ export class NodeJsBundler implements BundlerInterface {
             outfile: outputFilePath,
             plugins: [nodeExternalPlugin, supportRequireInESM],
             sourcemap: "inline",
+            sourcesContent: false,
         });
 
         if (output.errors.length > 0) {


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

We only use sourcemaps for error stack traces, which does not require having the original file content. This change will slightly lower the bundled code size in case there is a lot of code, because it won't store the original code in the source map anymore.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
