### PR TITLE
Bug fix: we could override incorrectly a index.mjs handler

### DIFF
--- a/src/bundlers/node/nodeJsBundler.ts
+++ b/src/bundlers/node/nodeJsBundler.ts
@@ -69,6 +69,8 @@ export class NodeJsBundler implements BundlerInterface {
             return (
                 file.extension !== ".ts" &&
                 file.extension !== ".js" &&
+                file.extension !== ".mjs" &&
+                file.extension !== ".cjs" &&
                 file.extension !== ".tsx" &&
                 file.extension !== ".jsx" &&
                 !file.path.includes("node_modules") &&


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

If the user already has a `index.mjs` file for a function and he also uses genezio classes, we might override the handler for the classes when we copy incorrectly the `index.mjs` file. We must handle `*.mjs` and *.cjs` files as js files.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
