### PR TITLE
Fix overlapping warning

### DIFF
--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -95,7 +95,7 @@ export async function scanClassesForDecorators(
                     type: type,
                     methods: methods,
                 });
-            } else {
+            } else if (r && deployDecoratorFound) {
                 overlappingYamlClasses.push(r?.name || "");
             }
         }


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Currently, the overlapping classes error appears when the user declares a file that contains a class that is marked for deployment in Genezio.

This is happening because `deployDecoratorFound` is false, hence it will execute the `else` branch adding an `""` string.

The warning should appear if `r` is defined and contains classes and if `deployDecoratorFound` is true.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
