### PR TITLE
Prevent browser redirect at login if CI is set to true

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -15,6 +15,14 @@ export async function loginCommand(accessToken: string, logSuccesMessage = true)
         eventType: TelemetryEventTypes.GENEZIO_LOGIN,
     });
 
+    // If we are in a CI environment, we don't open the browser because it will hang indefinitely
+    if (process.env["CI"]) {
+        log.error(
+            "CI environment detected. Cannot open browser for authentication. Use `genezio login <token>` instead.",
+        );
+        return;
+    }
+
     const promiseHttpServer = new Promise((resolve) => {
         if (accessToken !== "") {
             saveAuthToken(accessToken);


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

If `CI` is set to true it means the genezio process runs in a continuous integration environment.
Trying to open the browser will make the process hang indefinitely.

This eats away GitHub actions minutes for failed logins because it will hang until the action timeouts or is cancelled.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
