### PR TITLE
Enabled default creation on nextjs w/o wizzard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "genezio",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "genezio",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "license": "GPL-3",
             "dependencies": {
                 "@amplitude/analytics-node": "^1.3.5",
@@ -20,7 +20,6 @@
                 "@babel/preset-typescript": "^7.24.6",
                 "@babel/traverse": "^7.24.1",
                 "@genezio/test-interface-component": "^1.2.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.19.1",
                 "@sentry/node": "^7.116.0",
                 "@sentry/profiling-node": "~7.118.0",
                 "@webcontainer/env": "^1.1.1",

--- a/src/commands/create/create.ts
+++ b/src/commands/create/create.ts
@@ -124,8 +124,9 @@ export async function createCommand(options: GenezioCreateOptions) {
         }
         case "nextjs": {
             log.info("Running npx create-next-app...");
+
             const defaultConfiguration =
-                "--typescript --eslint --tailwind --src-dir --app --no-import-alias";
+                "--typescript --eslint --tailwind --no-src-dir --app --no-import-alias";
             await $({ stdio: "inherit" })(
                 `npx --yes create-next-app ${projectPath}` +
                     (options.default ? ` ${defaultConfiguration}` : ""),

--- a/src/commands/create/create.ts
+++ b/src/commands/create/create.ts
@@ -124,8 +124,12 @@ export async function createCommand(options: GenezioCreateOptions) {
         }
         case "nextjs": {
             log.info("Running npx create-next-app...");
-
-            await $({ stdio: "inherit" })`npx --yes create-next-app ${projectPath}`.catch(() => {
+            const defaultConfiguration =
+                "--typescript --eslint --tailwind --src-dir --app --no-import-alias";
+            await $({ stdio: "inherit" })(
+                `npx --yes create-next-app ${projectPath}` +
+                    (options.default ? ` ${defaultConfiguration}` : ""),
+            ).catch(() => {
                 throw new UserError("Failed to create a Next.js project using create-next-app.");
             });
 

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -327,7 +327,11 @@ create
         ),
     )
     .option("--path <path>", "Path where to create the project.", undefined)
-    .option("--default", "Skip the interactive questions.", false)
+    .option(
+        "--default",
+        "Skip the Next.js wizard interactive questions and apply default configuration.",
+        false,
+    )
     .summary("Create a new Next.js project.")
     .action(async (options: GenezioCreateNextJsOptions, { parent }: { parent: Command }) => {
         const createOptions = await askCreateOptions({

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -327,6 +327,7 @@ create
         ),
     )
     .option("--path <path>", "Path where to create the project.", undefined)
+    .option("--default", "Skip the interactive questions.", false)
     .summary("Create a new Next.js project.")
     .action(async (options: GenezioCreateNextJsOptions, { parent }: { parent: Command }) => {
         const createOptions = await askCreateOptions({

--- a/src/models/commandOptions.ts
+++ b/src/models/commandOptions.ts
@@ -100,6 +100,7 @@ export interface GenezioCreateNextJsOptions extends BaseOptions {
     name?: string;
     region?: string;
     path?: string;
+    default: boolean;
 }
 
 export interface GenezioCreateServerlessFunctionOptions extends BaseOptions {


### PR DESCRIPTION
# Pull Request Template
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

You can now create a default nextjs app by adding --default, this way you do not need to utilize the nextjs wizard.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
