### PR TITLE
Throw error if frontend publish folder is missing

### DIFF
--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -696,8 +696,9 @@ export async function deployFrontend(
         log.info(
             `Skipping frontend deployment for \`${frontend.path}\` because it has no publish folder in the YAML configuration. Check https://genezio.com/docs/project-structure/genezio-configuration-file for more details.`,
         );
-
-        return;
+        throw new UserError(
+            `Frontend named ${name} has no publish folder in the YAML configuration.`,
+        );
     }
 
     await doAdaptiveLogAction(`Building frontend ${index + 1}`, async () => {

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -692,12 +692,19 @@ export async function deployFrontend(
 ): Promise<string | undefined> {
     const stage: string = options.stage || "";
 
-    if (!frontend.publish) {
+    if (frontend.publish === null || frontend.publish === undefined) {
         log.info(
             `Skipping frontend deployment for \`${frontend.path}\` because it has no publish folder in the YAML configuration. Check https://genezio.com/docs/project-structure/genezio-configuration-file for more details.`,
         );
+        return;
+    }
+
+    // check if the frontend path exists
+    if (!(await fileExists(frontend.publish))) {
         throw new UserError(
-            `Frontend named ${name} has no publish folder in the YAML configuration.`,
+            `The frontend path ${colors.cyan(
+                `${frontend.publish}`,
+            )} does not exist. Please make sure the path is correct.`,
         );
     }
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Throw error if frontend `publish` folder is missing instead of just returning a warning.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
