### PR TITLE
Add an empty next.config.js file if missing.

### DIFF
--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -383,10 +383,10 @@ async function deployFunctions(config: YamlProjectConfiguration, stage?: string)
 
 function writeNextConfig() {
     const cwd = process.cwd();
-    const extension = ["js", "cjs", "mjs", "ts"].find((ext) =>
+    const configExists = ["js", "cjs", "mjs", "ts"].find((ext) =>
         fs.existsSync(path.join(cwd, `next.config.${ext}`)),
     );
-    if (!extension) {
+    if (!configExists) {
         fs.writeFileSync("next.config.js", ``);
     }
 }

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -57,6 +57,7 @@ export async function nextJsDeploy(options: GenezioDeployOptions) {
 
     const genezioConfig = await readOrAskConfig(options.config);
 
+    writeNextConfig();
     await writeOpenNextConfig(genezioConfig.region);
     // Build the Next.js project
     await $({ stdio: "inherit" })`npx --yes @genezio/open-next@latest build`.catch(() => {
@@ -378,6 +379,16 @@ async function deployFunctions(config: YamlProjectConfiguration, stage?: string)
     debugLogger.debug(`Deployed functions: ${JSON.stringify(result.functions)}`);
 
     return result;
+}
+
+function writeNextConfig() {
+    const cwd = process.cwd();
+    const extension = ["js", "cjs", "mjs", "ts"].find((ext) =>
+        fs.existsSync(path.join(cwd, `next.config.${ext}`)),
+    );
+    if (!extension) {
+        fs.writeFileSync("next.config.js", ``);
+    }
 }
 
 async function writeOpenNextConfig(region: string) {


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

If `next.config.js` is missing, open-next will throw an error. We add an empty config file to make it work automatically. 

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
