### PR TITLE
Autodetect and prompt the user to set env vars

### DIFF
--- a/src/utils/environmentVariables.ts
+++ b/src/utils/environmentVariables.ts
@@ -1,0 +1,52 @@
+import inquirer from "inquirer";
+import { fileExists } from "./file.js";
+import { getEnvironmentVariables } from "../requests/getEnvironmentVariables.js";
+import path from "path";
+
+export async function detectEnvironmentVariablesFile(path: string) {
+    return await fileExists(path);
+}
+
+export async function promptToConfirmSettingEnvironmentVariables(envVars: string[]) {
+    const { confirmSetEnvVars }: { confirmSetEnvVars: boolean } = await inquirer.prompt([
+        {
+            type: "confirm",
+            name: "confirmSetEnvVars",
+            message: `We detected that ${envVars.join(", ")} are not set remotely. Do you want us to set them for you?`,
+            default: false,
+        },
+    ]);
+
+    if (!confirmSetEnvVars) {
+        return false;
+    }
+
+    return true;
+}
+
+export async function getUnsetEnvironmentVariables(
+    local: string[],
+    projectId: string,
+    projectEnvId: string,
+) {
+    const remoteEnvVars = await getEnvironmentVariables(projectId, projectEnvId);
+
+    const missingEnvVars = local.filter(
+        (envVar) => !remoteEnvVars.find((remoteEnvVar) => remoteEnvVar.name === envVar),
+    );
+
+    return missingEnvVars;
+}
+
+export async function findAnEnvFile(cwd: string): Promise<string | undefined> {
+    const possibleEnvFilePath = ["server/.env", ".env"];
+
+    for (const envFilePath of possibleEnvFilePath) {
+        const fullPath = path.join(cwd, envFilePath);
+        if (await fileExists(fullPath)) {
+            return fullPath;
+        }
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR auto-detects missing environment variables and prompts the user to confirm if genezio should also set them.
E.G.:

```
? We detected that TEST, OPEN_API_KEY are not set remotely. Do you want us to set them for you? [yes/no] no
Skipping environment variables upload.
```

This interactive behaviour is not triggered when `CI = true`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
