### PR TITLE
use stage id instead of name when push/pull code in s3

### DIFF
--- a/src/cloudAdapter/cloudAdapter.ts
+++ b/src/cloudAdapter/cloudAdapter.ts
@@ -53,6 +53,11 @@ export type GenezioCloudOutput = {
     functions: DeployCodeFunctionResponse[];
 };
 
+export type GenezioCloudFrontendOutput = {
+    domain: string;
+    envId: string;
+};
+
 export type CloudAdapterOptions = {
     stage?: string;
 };
@@ -70,5 +75,5 @@ export interface CloudAdapter {
         projectRegion: string,
         frontend: YamlFrontend,
         stage: string,
-    ): Promise<string>;
+    ): Promise<GenezioCloudFrontendOutput>;
 }

--- a/src/cloudAdapter/cluster/clusterAdapter.ts
+++ b/src/cloudAdapter/cluster/clusterAdapter.ts
@@ -3,6 +3,7 @@ import { YamlFrontend } from "../../projectConfiguration/yaml/v2.js";
 import {
     CloudAdapter,
     CloudAdapterOptions,
+    GenezioCloudFrontendOutput,
     GenezioCloudInput,
     GenezioCloudOutput,
 } from "../cloudAdapter.js";
@@ -129,7 +130,7 @@ export class ClusterCloudAdapter implements CloudAdapter {
         projectRegion: string,
         frontend: YamlFrontend,
         stage: string,
-    ): Promise<string> {
+    ): Promise<GenezioCloudFrontendOutput> {
         const finalStageName = stage != "" && stage != "prod" ? `-${stage}` : "";
         const finalSubdomain = frontend.subdomain + finalStageName;
         const archivePath = path.join(await createTemporaryFolder(), `${finalSubdomain}.zip`);
@@ -156,7 +157,7 @@ export class ClusterCloudAdapter implements CloudAdapter {
         debugLogger.debug("Content of the folder zipped. Uploading to S3.");
         await uploadContentToS3(result.presignedURL, archivePath, undefined, result.userId);
         debugLogger.debug("Uploaded to S3.");
-        const finalDomain = await createFrontendProject(
+        const createFrontendResult = await createFrontendProject(
             finalSubdomain,
             projectName,
             projectRegion,
@@ -166,7 +167,7 @@ export class ClusterCloudAdapter implements CloudAdapter {
         // clean up temporary folder
         await deleteFolder(path.dirname(archivePath));
 
-        return finalDomain;
+        return createFrontendResult;
     }
 }
 

--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -9,6 +9,7 @@ import { deployRequest } from "../../requests/deployCode.js";
 import {
     CloudAdapter,
     CloudAdapterOptions,
+    GenezioCloudFrontendOutput,
     GenezioCloudInput,
     GenezioCloudInputType,
     GenezioCloudOutput,
@@ -202,7 +203,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
         projectRegion: string,
         frontend: YamlFrontend,
         stage: string,
-    ): Promise<string> {
+    ): Promise<GenezioCloudFrontendOutput> {
         const finalStageName = stage != "" && stage != "prod" ? `-${stage}` : "";
         const finalSubdomain = frontend.subdomain + finalStageName;
         const archivePath = path.join(await createTemporaryFolder(), `${finalSubdomain}.zip`);
@@ -231,7 +232,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
         debugLogger.debug("Content of the folder zipped. Uploading to S3.");
         await uploadContentToS3(result.presignedURL, archivePath, undefined, result.userId);
         debugLogger.debug("Uploaded to S3.");
-        const finalDomain = await createFrontendProject(
+        const createFrontendResult = await createFrontendProject(
             finalSubdomain,
             projectName,
             projectRegion,
@@ -241,7 +242,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
         // clean up temporary folder
         await deleteFolder(path.dirname(archivePath));
 
-        return finalDomain;
+        return createFrontendResult;
     }
 }
 

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -3,7 +3,7 @@ import { interruptLocalProcesses } from "../utils/localInterrupt.js";
 import { doAdaptiveLogAction, log } from "../utils/logging.js";
 import { YamlConfigurationIOController } from "../projectConfiguration/yaml/v2.js";
 import { exit } from "process";
-import { cloneCommand } from "./clone.js";
+import { askCloneOptions, cloneCommand } from "./clone.js";
 
 export async function pullCommand(stage: string) {
     await interruptLocalProcesses();
@@ -27,7 +27,13 @@ export async function pullCommand(stage: string) {
         exit(0);
     }
 
+    const options = await askCloneOptions({
+        name: configuration.name,
+        region: configuration.region,
+        stage: stage,
+    });
+
     await doAdaptiveLogAction("Pulling the latest changes from the cloud...", async () =>
-        cloneCommand(configuration.name, configuration.region, stage, "."),
+        cloneCommand(options.name, options.region, options.stage, "."),
     );
 }

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -657,7 +657,10 @@ program
     .option("--stage <stage>", "Stage of the project.")
     .summary("Clone a project to your local machine.")
     .action(async (path: string, options: GenezioCloneOptions) => {
-        options = await askCloneOptions(options);
+        options = await askCloneOptions(options).catch((error) => {
+            logError(error);
+            exit(1);
+        });
         if (!path) {
             path = `./${options.name}`;
         }

--- a/src/requests/createFrontendProject.ts
+++ b/src/requests/createFrontendProject.ts
@@ -6,13 +6,14 @@ import version from "../utils/version.js";
 import { AxiosResponse } from "axios";
 import { StatusOk } from "./models.js";
 import { debugLogger } from "../utils/logging.js";
+import { GenezioCloudFrontendOutput } from "../cloudAdapter/cloudAdapter.js";
 
 export async function createFrontendProject(
     genezioDomain: string,
     projectName: string,
     region: string,
     stage: string,
-): Promise<string> {
+): Promise<GenezioCloudFrontendOutput> {
     // Check if user is authenticated
     const authToken = await getAuthToken();
     if (!authToken) {
@@ -26,7 +27,7 @@ export async function createFrontendProject(
         stage,
     });
 
-    const response: AxiosResponse<StatusOk<{ domain: string }>> = await axios({
+    const response: AxiosResponse<StatusOk<{ domain: string; envId: string }>> = await axios({
         method: "PUT",
         url: `${BACKEND_ENDPOINT}/frontend`,
         data: json,
@@ -38,11 +39,11 @@ export async function createFrontendProject(
         maxBodyLength: Infinity,
     });
 
-    if (!response.data.domain) {
+    if (!response.data.domain || !response.data.envId) {
         throw new UserError("Could not create frontend project");
     }
 
-    return response.data.domain;
+    return { domain: response.data.domain, envId: response.data.envId };
 }
 
 export interface CreateFrontendV2Request {


### PR DESCRIPTION
## Type of change

-   [x] 🧑‍💻 Improvement

## Description

The Github integration requires a more relaxed naming convention for genezio stages (environments). Because S3 doesn't allow slashes in prefix names (which wee need), we have to change the way we name those prefixes to use the env id instead of the env name.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
