### PR TITLE
When a frontend is deployed for the first time, attempt to set a redi…

### DIFF
--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -72,6 +72,7 @@ import {
     uploadEnvVarsFromFile,
     processYamlEnvironmentVariables,
     enableAuthentication,
+    setDefaultPasswordRedirectUrl,
 } from "./utils.js";
 import { enableEmailIntegration } from "../../requests/integration.js";
 import { findAnEnvFile } from "../../utils/environmentVariables.js";
@@ -750,6 +751,11 @@ export async function deployFrontend(
     }
 
     frontend.subdomain = options.subdomain || frontend.subdomain;
+
+    // If authentication is enabled in the project - attempt to set a default password reset URL
+    if (configuration.services?.authentication) {
+        await setDefaultPasswordRedirectUrl(name, stage, frontend.subdomain || "");
+    }
 
     const cloudAdapter = getCloudAdapter(CloudProviderIdentifier.GENEZIO_CLOUD);
     const url = await cloudAdapter.deployFrontend(name, region, frontend, stage);

--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -159,10 +159,10 @@ export type SetEmailTemplatesRequest = {
             redirectUrl: string;
         };
         variables: string[];
-    };
+    }[];
 };
 
-export type setEmailTemplatesResponse = {
+export type EmailTemplatesResponse = {
     templates: {
         type: string;
         template: {
@@ -173,5 +173,5 @@ export type setEmailTemplatesResponse = {
             redirectUrl: string;
         };
         variables: string[];
-    };
+    }[];
 };

--- a/src/projectConfiguration/yaml/models.ts
+++ b/src/projectConfiguration/yaml/models.ts
@@ -22,6 +22,10 @@ export enum TriggerType {
     cron = "cron",
     http = "http",
 }
+export enum AuthenticationEmailTemplateType {
+    passwordReset = "PASS_RESET",
+    verification = "VERIFICATION",
+}
 
 export enum FunctionType {
     aws = "aws",

--- a/src/requests/authentication.ts
+++ b/src/requests/authentication.ts
@@ -1,10 +1,12 @@
 import {
+    EmailTemplatesResponse,
     GetAuthenticationResponse,
     GetAuthProvidersResponse,
     SetAuthenticationRequest,
     SetAuthenticationResponse,
     SetAuthProvidersRequest,
     SetAuthProvidersResponse,
+    SetEmailTemplatesRequest,
 } from "../models/requests.js";
 import sendRequest from "../utils/requests.js";
 
@@ -54,6 +56,28 @@ export async function setAuthProviders(
         `core/auth/providers/${envId}`,
         data,
     )) as SetAuthProvidersResponse;
+
+    return response;
+}
+
+export async function getEmailTemplates(envId: string) {
+    const response = (await sendRequest(
+        "GET",
+        `core/auth/email-templates/${envId}`,
+        "",
+    )) as EmailTemplatesResponse;
+
+    return response;
+}
+
+export async function setEmailTemplates(envId: string, request: SetEmailTemplatesRequest) {
+    const data: string = JSON.stringify(request);
+
+    const response = (await sendRequest(
+        "PUT",
+        `core/auth/email-templates/${envId}`,
+        data,
+    )) as EmailTemplatesResponse;
 
     return response;
 }


### PR DESCRIPTION
…rect URL for the password

# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

I reverted in #1338 because the feature was not usable - for now I believe we should not add `settings.templates` to the yaml file because it will clutter the file unnecessary and it's not the best DX.

To support one-click deployment for templates that use `authentication/resetPassword/redirectUrl`, we are going to support a best effort approach where when deploying a frontend for the first time, we also set the `resetPassword/redirectUrl`.

The `redirectUrl` will not be updated if:
- a second subdomain is deployed
- a custom domain is set
- the authentication is enabled from UI
If any of these occur, the user should update/set the `redirecUrl` manually.


## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
