### PR TITLE
Make bundle function work without genezio yaml

### DIFF
--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -1,4 +1,4 @@
-import { debugLogger, log } from "../utils/logging.js";
+import { log } from "../utils/logging.js";
 import {
     mapYamlClassToSdkClassConfiguration,
     sdkGeneratorApiHandler,
@@ -123,8 +123,6 @@ export async function bundleCommand(options: GenezioBundleOptions | GenezioBundl
         if (!element) {
             throw new UserError(`Function ${options.functionName} not found.`);
         }
-        debugLogger.debug("Function found", JSON.stringify(element, null, 2));
-        debugLogger.debug("Backend path", backendConfiguration.path);
 
         await functionToCloudInput(element, backendConfiguration.path, options.output);
     }

--- a/src/genezio.ts
+++ b/src/genezio.ts
@@ -668,6 +668,10 @@ program
 program
     .command("bundleFunction", { hidden: true })
     .option("--functionName <functionName>", "The name of the function that needs to be bundled.")
+    .option("--handler <handler>", "The name of handler of the function.")
+    .option("--entry <entry>", "The entry file of the function.")
+    .option("--functionPath <functionPath>", "The path of the folder containing the function.")
+    .option("--backendPath <backendPath>", "The path of the backend folder.", ".")
     .option(
         "--cloudAdapter <cloudAdapter>",
         "The cloud adapter that will be used.",

--- a/src/models/commandOptions.ts
+++ b/src/models/commandOptions.ts
@@ -16,6 +16,10 @@ export interface GenezioBundleFunctionOptions extends BaseOptions {
     functionName: string;
     output: string;
     cloudAdapter?: CloudAdapterIdentifier;
+    handler?: string;
+    entry?: string;
+    functionPath?: string;
+    backendPath?: string;
 }
 
 export interface GenezioLocalOptions extends BaseOptions {


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

We want to be able to bundle a function without the need of a genezio.yaml file
This PR allows you to do that if all your command options are properly set

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
