### PR TITLE
Use / instead of platform dependent path separator.

### DIFF
--- a/src/commands/deploy/nuxt/deploy.ts
+++ b/src/commands/deploy/nuxt/deploy.ts
@@ -68,7 +68,7 @@ async function deployFunction(config: YamlProjectConfiguration, options: Genezio
         {
             path: ".output",
             name: "nuxt-server",
-            entry: path.join("server", "index.mjs"),
+            entry: "server/index.mjs",
             handler: "handler",
             type: FunctionType.aws,
         },


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

We should use `/` as separator in entryFile field, not a platform specific separator.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
