### PR TITLE
Search ${{env.KEY}} in process.env 

### DIFF
--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -69,7 +69,7 @@ import {
 } from "../../requests/authentication.js";
 import { getPresignedURLForProjectCodePush } from "../../requests/getPresignedURLForProjectCodePush.js";
 import { uploadContentToS3 } from "../../requests/uploadContentToS3.js";
-import { displayHint } from "../../utils/strings.js";
+import { displayHint, replaceExpression } from "../../utils/strings.js";
 
 export async function getOrCreateEmptyProject(
     projectName: string,
@@ -600,19 +600,14 @@ export async function evaluateResource(
             options,
         );
 
-        // If `resource` contains other clear text, keep it and replace just ${{<variable>}}
-        const resourceString = resource.replace(/\${{[\w\s/.-]+}}/, resourceValue);
-
-        return resourceString;
+        return replaceExpression(resource, resourceValue);
     }
 
     if ("key" in resourceRaw) {
-        // search resourceRaw.key in process.env
+        // search for the environment variable in process.env
         const resourceFromProcessValue = process.env[resourceRaw.key];
         if (resourceFromProcessValue) {
-            // If `resource` contains other clear text, keep it and replace just ${{<variable>}}
-            const resourceString = resource.replace(/\${{[\w\s/.-]+}}/, resourceFromProcessValue);
-            return resourceString;
+            return replaceExpression(resource, resourceFromProcessValue);
         }
 
         if (!envFile) {
@@ -630,9 +625,7 @@ export async function evaluateResource(
             );
         }
 
-        // If `resource` contains other clear text, keep it and replace just ${{<variable>}}
-        const resourceString = resource.replace(/\${{[\w\s/.-]+}}/, resourceValue);
-        return resourceString;
+        return replaceExpression(resource, resourceValue);
     }
 
     return resourceRaw.value;

--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -607,6 +607,14 @@ export async function evaluateResource(
     }
 
     if ("key" in resourceRaw) {
+        // search resourceRaw.key in process.env
+        const resourceFromProcessValue = process.env[resourceRaw.key];
+        if (resourceFromProcessValue) {
+            // If `resource` contains other clear text, keep it and replace just ${{<variable>}}
+            const resourceString = resource.replace(/\${{[\w\s/.-]+}}/, resourceFromProcessValue);
+            return resourceString;
+        }
+
         if (!envFile) {
             throw new UserError(
                 `Environment variable file ${envFile} is missing. Please provide the correct path with genezio deploy --env <envFile>.`,

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -35,3 +35,20 @@ export const cyan = "\x1b[36m" + reset;
 export const displayHint = function (message: string) {
     return `${colors.green(`Hint:`)} ${message}`;
 };
+
+/**
+ * Replace an expression of format <prefix>${{<variable>}}<suffix>
+ * to <prefix><value><suffix>
+ *
+ * ${{<variable>}} can be any alphanumeric string with special characters
+ * like /, -, ., _ and whitespace
+ *
+ * @param {string} resource - The original resource string
+ * @param {string} value - The value to replace the placeholder with.
+ * @returns {string} - The updated string with the placeholder replaced.
+ */
+export function replaceExpression(expression: string, value: string) {
+    // ${{<variable>}} can be any alphanumeric string with special characters
+    const placeholderPattern = /\${{[\w\s/.-_]+}}/;
+    return expression.replace(placeholderPattern, value);
+}


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR adds support for searching environment variables in `process.env` also.

This is available only for env vars declared in the `genezio.yaml` file with `${{env.MY_ENV}}`.

This is useful for testing commands or CI commands where the user runs:
```
MY_ENV=test genezio deploy
```
In our case is useful for running integration tests for the `services.authentication` feature.

Note: This pr contains a small refactoring for supporting a string prefix/suffix for genezio.yaml expressions (e.g. `https://${{<expression>}}/endpoint`)

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] I have updated the documentation;
-   [x] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
