### PR TITLE
add bigint suuport for typesafe genezio TS

### DIFF
--- a/sdk-external-modules/remote-ts/src/remote.ts
+++ b/sdk-external-modules/remote-ts/src/remote.ts
@@ -3,16 +3,29 @@
  * if new genezio commands are executed.
  */
 
+const replacer = (_: string, value: any) =>
+    typeof value === "bigint" ? { $bigint: value.toString() } : value;
+
+const reviver = (_: string, value: any) =>
+    value !== null &&
+    typeof value === "object" &&
+    "$bigint" in value &&
+    typeof value.$bigint === "string"
+        ? BigInt(value.$bigint)
+        : value;
+
 async function makeRequestBrowser(request: any, url: any) {
     const response = await fetch(url, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
         },
-        body: JSON.stringify(request),
+        body: JSON.stringify(request, replacer),
     });
 
-    return response.json();
+    const textBody = await response.text();
+
+    return JSON.parse(textBody, reviver);
 }
 
 /**

--- a/src/bundlers/node/lambdaHandlerGenerator.ts
+++ b/src/bundlers/node/lambdaHandlerGenerator.ts
@@ -10,6 +10,17 @@ import {  ${className.replace(/["]/g, "")} as genezioClass } from "./module.mjs"
 
 var handler = undefined;
 
+const replacer = (key, value) =>
+  typeof value === "bigint" ? { $bigint: value.toString() } : value;
+
+const reviver = (key, value) =>
+  value !== null &&
+  typeof value === "object" &&
+  "$bigint" in value &&
+  typeof value.$bigint === "string"
+    ? BigInt(value.$bigint)
+    : value;
+
 function prepareForSerialization(e) {
     if (e instanceof Error) {
         const object = { message: e.message, stack: e.stack, info: e.info, code: e.code } 
@@ -106,7 +117,7 @@ if (!genezioClass) {
         let body = event.body;
 
         try {
-            body = JSON.parse(event.body);
+            body = JSON.parse(event.body, reviver);
         } catch (error) { }
 
         const components = event.requestContext.http.path.substring(1).split("/");
@@ -151,7 +162,7 @@ if (!genezioClass) {
                     };
                 } else if (response.body instanceof Object) {
                     try {
-                        response.body = JSON.stringify(response.body);
+                        response.body = JSON.stringify(response.body, replacer);
                     } catch (error) { }
                 }
 
@@ -167,7 +178,7 @@ if (!genezioClass) {
         } else {
             let body = null;
             try {
-                body = JSON.parse(event.body);
+                body = JSON.parse(event.body, reviver);
             } catch (error) {
                 return {
                     statusCode: 400,
@@ -251,7 +262,7 @@ if (!genezioClass) {
                                 result: result,
                                 error: null,
                                 id: requestId,
-                            }),
+                            }, replacer),
                             headers: { 'Content-Type': 'application/json', 'X-Powered-By': 'genezio' }
                         };
                     })

--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -28,6 +28,7 @@ import {
     EnumType,
     DateType,
     MapType,
+    BigIntType,
 } from "../../models/genezioModels.js";
 
 import typescript from "typescript";
@@ -49,6 +50,7 @@ export class AstGenerator implements AstGeneratorInterface {
         | DoubleType
         | IntegerType
         | StringType
+        | BigIntType
         | BooleanType
         | FloatType
         | AnyType
@@ -70,6 +72,8 @@ export class AstGenerator implements AstGeneratorInterface {
                     rawValue: literalType.literal.getText(),
                 };
             }
+            case typescript.SyntaxKind.BigIntKeyword:
+                return { type: AstNodeType.BigIntLiteral };
             case typescript.SyntaxKind.StringKeyword:
                 return { type: AstNodeType.StringLiteral };
             case typescript.SyntaxKind.NumberKeyword:

--- a/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
+++ b/src/generateSdk/sdkGenerator/TsSdkGenerator.ts
@@ -501,6 +501,8 @@ class SdkGenerator implements SdkGeneratorInterface {
                 return (elem as CustomAstNodeType).rawValue;
             case AstNodeType.StringLiteral:
                 return "string";
+            case AstNodeType.BigIntLiteral:
+                return "bigint";
             case AstNodeType.IntegerLiteral:
             case AstNodeType.FloatLiteral:
             case AstNodeType.DoubleLiteral:

--- a/src/models/genezioModels.ts
+++ b/src/models/genezioModels.ts
@@ -63,6 +63,7 @@ export enum AstNodeType {
     FloatLiteral = "FloatLiteral",
     NullLiteral = "NullLiteral",
     DoubleLiteral = "DoubleLiteral",
+    BigIntLiteral = "BigIntLiteral",
     VoidLiteral = "VoidLiteral",
     AnyLiteral = "AnyLiteral",
     ArrayType = "ArrayType",
@@ -136,6 +137,10 @@ export interface IntegerType extends Node {
     type: AstNodeType.IntegerLiteral;
 }
 
+export interface BigIntType extends Node {
+    type: AstNodeType.BigIntLiteral;
+}
+
 export interface BooleanType extends Node {
     type: AstNodeType.BooleanLiteral;
 }
@@ -203,6 +208,7 @@ export interface PropertyDefinition {
     type:
         | DoubleType
         | IntegerType
+        | BigIntType
         | StringType
         | BooleanType
         | FloatType
@@ -235,6 +241,7 @@ export interface TypeAlias extends Node {
     aliasType:
         | DoubleType
         | IntegerType
+        | BigIntType
         | StringType
         | BooleanType
         | FloatType
@@ -262,6 +269,7 @@ export interface ParameterDefinition extends Node {
     paramType:
         | DoubleType
         | IntegerType
+        | BigIntType
         | StringType
         | BooleanType
         | FloatType
@@ -293,6 +301,7 @@ export interface MethodDefinition extends Node {
     returnType:
         | DoubleType
         | IntegerType
+        | BigIntType
         | StringType
         | BooleanType
         | FloatType


### PR DESCRIPTION
## Type of change

-   [x] 🧑‍💻 Improvement

## Description

Added support for the javascript primitive [`bigint`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt), which enables the use of 64-bit integers. The problem with this primitive is that it is not serializable by default. We needed to do a little hack to send this over the wire when used as a parameter or return type of a genezio typsafe function.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
