### PR TITLE
add empty space before cmd

### DIFF
--- a/src/commands/deploy/docker/deploy.ts
+++ b/src/commands/deploy/docker/deploy.ts
@@ -86,7 +86,7 @@ export async function dockerDeploy(options: GenezioDeployOptions) {
     if (entrypoint) {
         cmdEntryFile += entrypoint.join(" ");
     } else {
-        cmdEntryFile += "/bin/sh -c";
+        cmdEntryFile += "/bin/sh -c ";
     }
 
     if (cmd) {


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Add a space after `/bin/sh -c`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
