### PR TITLE
allow upper case for subdomain

### DIFF
--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -725,7 +725,7 @@ export async function deployFrontend(
     }
 
     // check if subdomain contains only numbers, letters and hyphens
-    if (frontend.subdomain && !frontend.subdomain.match(/^[a-z0-9-]+$/)) {
+    if (frontend.subdomain && !frontend.subdomain.match(/^[a-zA-z][a-zA-Z0-9-]{0,62}$/)) {
         throw new UserError(`The subdomain can only contain letters, numbers and hyphens.`);
     }
 


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

Allow users to specify subdomains that include uppercase characters in their genezio.yaml.
The server side logic will now perform another validation and cast the string to lowercase before creating the frontend. The CLI will still however return errors if forbidden characters are used or maximum length is surpassed.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
