### PR TITLE
Reconfigure deployment order to deploy backend, deploy frontend, set …

### DIFF
--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -305,6 +305,22 @@ export async function genezioDeploy(options: GenezioDeployOptions) {
         }
     }
 
+    // Add backend environment variables for backend deployments
+    // At this point the project and environment should be available in deployClassesResult
+    if (configuration.backend && !options.frontend && deployClassesResult) {
+        const cwd = configuration.backend.path
+            ? path.resolve(configuration.backend.path)
+            : process.cwd();
+        await uploadEnvVarsFromFile(
+            options.env,
+            deployClassesResult.projectId,
+            deployClassesResult.projectEnvId,
+            cwd,
+            options.stage || "prod",
+            configuration,
+        );
+    }
+
     await uploadUserCode(configuration.name, configuration.region, options.stage);
 
     const settings = configuration.services?.authentication?.settings;
@@ -562,19 +578,6 @@ export async function deployClasses(
     const projectId = result.projectId;
     const projectEnvId = result.projectEnvId;
     if (projectId) {
-        // Deploy environment variables if --env is true
-        const cwd = projectConfiguration.workspace?.backend
-            ? path.resolve(projectConfiguration.workspace.backend)
-            : process.cwd();
-        await uploadEnvVarsFromFile(
-            options.env,
-            projectId,
-            projectEnvId,
-            cwd,
-            options.stage || "prod",
-            configuration,
-        );
-
         return {
             projectId: projectId,
             projectEnvId: projectEnvId,


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR reconfigures the order of deployment/setting the infrastructure in the following order:
* deploy backend
* deploy frontend
* set environment variables

This will allows us to inject auto-generated `subdomain` into `backend.environment` :
```yaml
backend:
  path: ./server
  language:
    name: js
  environment:
    FRONTEND_URL: ${{frontend.<frontend-name>.subdomain}}
```

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
