### PR TITLE
[Analyze] Set scripts as an array always

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -192,8 +192,8 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 path: componentPath,
                 publish: path.join(componentPath, "dist"),
                 scripts: {
-                    deploy: `${getPackageManager().command} install`,
-                    build: `${getPackageManager().command} run build`,
+                    deploy: [`${getPackageManager().command} install`],
+                    build: [`${getPackageManager().command} run build`],
                 },
             });
             break component;
@@ -204,8 +204,8 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 path: componentPath,
                 publish: path.join(componentPath, "build"),
                 scripts: {
-                    deploy: `${getPackageManager().command} install`,
-                    build: `${getPackageManager().command} run build`,
+                    deploy: [`${getPackageManager().command} install`],
+                    build: [`${getPackageManager().command} run build`],
                 },
             });
             break component;

--- a/src/commands/analyze/utils.ts
+++ b/src/commands/analyze/utils.ts
@@ -15,10 +15,26 @@ export async function addFrontendComponentToConfig(
 ) {
     const configIOController = new YamlConfigurationIOController(configPath);
 
+    // Ensure each script field is an array
+    // It's easier to use arrays consistently instead of
+    // having to check if it's a string or an array
+    const scripts = component.scripts;
+    if (scripts) {
+        if (scripts.deploy && typeof scripts.deploy === "string") {
+            scripts.deploy = [scripts.deploy];
+        }
+        if (scripts.build && typeof scripts.build === "string") {
+            scripts.build = [scripts.build];
+        }
+        if (scripts.start && typeof scripts.start === "string") {
+            scripts.start = [scripts.start];
+        }
+    }
+
     config["frontend"] = {
         path: component.path,
         publish: component.publish,
-        scripts: component.scripts,
+        scripts: scripts,
     };
 
     await configIOController.write(config);
@@ -30,6 +46,19 @@ export async function addBackendComponentToConfig(
     component: YAMLBackend,
 ) {
     const configIOController = new YamlConfigurationIOController(configPath);
+
+    // Ensure each script field is an array
+    // It's easier to use arrays consistently instead of
+    // having to check if it's a string or an array
+    const scripts = component.scripts;
+    if (scripts) {
+        if (scripts.deploy && typeof scripts.deploy === "string") {
+            scripts.deploy = [scripts.deploy];
+        }
+        if (scripts.local && typeof scripts.local === "string") {
+            scripts.local = [scripts.local];
+        }
+    }
 
     config["backend"] = {
         path: component.path,


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Save the `scripts` field as an array always - there are 2 reasons:
- It makes the code easier on the dashboard side because it will treat this field as an array of strings
- It's an indication for the user that he can add a list of commands in the`scripts`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
