### PR TITLE
Support custom path for SSR frameworks

### DIFF
--- a/src/commands/deploy/command.ts
+++ b/src/commands/deploy/command.ts
@@ -73,6 +73,15 @@ async function decideDeployType(options: GenezioDeployOptions): Promise<DeployTy
         if (config.container) {
             return DeployType.Docker;
         }
+        if (config.nextjs) {
+            return DeployType.NextJS;
+        }
+        if (config.nuxt) {
+            return DeployType.Nuxt;
+        }
+        if (config.nitro) {
+            return DeployType.Nitro;
+        }
     }
 
     // Check if next.config.js exists

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -317,7 +317,7 @@ export async function genezioDeploy(options: GenezioDeployOptions) {
         );
     }
 
-    await uploadUserCode(configuration.name, configuration.region, options.stage);
+    await uploadUserCode(configuration.name, configuration.region, options.stage, process.cwd());
 
     const settings = configuration.services?.authentication?.settings;
     if (settings) {

--- a/src/commands/deploy/nextjs/edge.ts
+++ b/src/commands/deploy/nextjs/edge.ts
@@ -152,13 +152,13 @@ function walkDirectoryForEdgeFunctions(dir: string): Promise<EdgeFunction[]> {
     });
 }
 
-export async function getEdgeFunctions(cwd?: string): Promise<EdgeFunction[]> {
+export async function getEdgeFunctions(cwd: string): Promise<EdgeFunction[]> {
     const edgeFunctions: EdgeFunction[] = [];
-    const pathForAppAbsolute = path.join(cwd || process.cwd(), "app");
-    const pathForSrcAbsolute = path.join(cwd || process.cwd(), "src", "app");
+    const pathForAppAbsolute = path.join(cwd, "app");
+    const pathForSrcAbsolute = path.join(cwd, "src", "app");
 
-    const pathForApp = path.relative(cwd || process.cwd(), pathForAppAbsolute);
-    const pathForSrc = path.relative(cwd || process.cwd(), pathForSrcAbsolute);
+    const pathForApp = path.relative(cwd, pathForAppAbsolute);
+    const pathForSrc = path.relative(cwd, pathForSrcAbsolute);
 
     const appFolderFunctions = await walkDirectoryForEdgeFunctions(pathForApp);
     const srcAppFolderFunctions = await walkDirectoryForEdgeFunctions(pathForSrc);

--- a/src/commands/deploy/nextjs/edge.ts
+++ b/src/commands/deploy/nextjs/edge.ts
@@ -152,13 +152,13 @@ function walkDirectoryForEdgeFunctions(dir: string): Promise<EdgeFunction[]> {
     });
 }
 
-export async function getEdgeFunctions(): Promise<EdgeFunction[]> {
+export async function getEdgeFunctions(cwd?: string): Promise<EdgeFunction[]> {
     const edgeFunctions: EdgeFunction[] = [];
-    const pathForAppAbsolute = path.join(process.cwd(), "app");
-    const pathForSrcAbsolute = path.join(process.cwd(), "src", "app");
+    const pathForAppAbsolute = path.join(cwd || process.cwd(), "app");
+    const pathForSrcAbsolute = path.join(cwd || process.cwd(), "src", "app");
 
-    const pathForApp = path.relative(process.cwd(), pathForAppAbsolute);
-    const pathForSrc = path.relative(process.cwd(), pathForSrcAbsolute);
+    const pathForApp = path.relative(cwd || process.cwd(), pathForAppAbsolute);
+    const pathForSrc = path.relative(cwd || process.cwd(), pathForSrcAbsolute);
 
     const appFolderFunctions = await walkDirectoryForEdgeFunctions(pathForApp);
     const srcAppFolderFunctions = await walkDirectoryForEdgeFunctions(pathForSrc);

--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -893,25 +893,20 @@ export async function uploadUserCode(
     name: string,
     region: string,
     stage: string,
-    cwd?: string,
+    cwd: string,
 ): Promise<void> {
     const tmpFolderProject = await createTemporaryFolder();
     debugLogger.debug(`Creating archive of the project in ${tmpFolderProject}`);
-    const promiseZip = zipDirectory(
-        cwd || process.cwd(),
-        path.join(tmpFolderProject, "projectCode.zip"),
-        false,
-        [
-            "**/node_modules/*",
-            "./node_modules/*",
-            "node_modules/*",
-            "**/node_modules",
-            "./node_modules",
-            "node_modules",
-            "node_modules/**",
-            "**/node_modules/**",
-        ],
-    );
+    const promiseZip = zipDirectory(cwd, path.join(tmpFolderProject, "projectCode.zip"), false, [
+        "**/node_modules/*",
+        "./node_modules/*",
+        "node_modules/*",
+        "**/node_modules",
+        "./node_modules",
+        "node_modules",
+        "node_modules/**",
+        "**/node_modules/**",
+    ]);
 
     await promiseZip;
     const presignedUrlForProjectCode = await getPresignedURLForProjectCodePush(region, name, stage);

--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -889,11 +889,16 @@ export async function uploadEnvVarsFromFile(
 }
 
 // Upload the project code to S3 for in-browser editing
-export async function uploadUserCode(name: string, region: string, stage: string): Promise<void> {
+export async function uploadUserCode(
+    name: string,
+    region: string,
+    stage: string,
+    cwd?: string,
+): Promise<void> {
     const tmpFolderProject = await createTemporaryFolder();
     debugLogger.debug(`Creating archive of the project in ${tmpFolderProject}`);
     const promiseZip = zipDirectory(
-        process.cwd(),
+        cwd || process.cwd(),
         path.join(tmpFolderProject, "projectCode.zip"),
         false,
         [


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Support custom path for SSR frameworks.

As a fallback/backwards compatibility reasons (old genezio.yaml files) - everywhere where `cwd` is not set, we will use `process.cwd()` which is the root directory of the project.

The path is set in the `genezio.yaml` in each ssr component sections:
```yaml
nextjs
  path:
nitro:
  path:
nuxt:
  path:
```

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
