### PR TITLE
Force pip to install x86 packages

### DIFF
--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -85,7 +85,7 @@ import { getProjectEnvFromProjectByName } from "../../requests/getProjectInfoByN
 import { getFunctionHandlerProvider } from "../../utils/getFunctionHandlerProvider.js";
 import { getFunctionEntryFilename } from "../../utils/getFunctionEntryFilename.js";
 import { getPackageManager } from "../../packageManagers/packageManager.js";
-import { supportedPythonDepsInstallVersions } from "../../models/projectOptions.js";
+import { supportedPythonDepsInstallVersion } from "../../models/projectOptions.js";
 
 export async function genezioDeploy(options: GenezioDeployOptions) {
     const configIOController = new YamlConfigurationIOController(options.config, {
@@ -640,7 +640,7 @@ export async function functionToCloudInput(
                 let installCommand;
 
                 if (packageManager.command === "pip" || packageManager.command === "pip3") {
-                    installCommand = `${packageManager.command} install -r ${requirementsOutputPath} --platform manylinux2014_x86_64 --only-binary=:all: --python-version ${supportedPythonDepsInstallVersions} -t ${pathForDependencies}`;
+                    installCommand = `${packageManager.command} install -r ${requirementsOutputPath} --platform manylinux2014_x86_64 --only-binary=:all: --python-version ${supportedPythonDepsInstallVersion} -t ${pathForDependencies}`;
                 } else if (packageManager.command === "poetry") {
                     installCommand = `${packageManager.command} install --no-root --directory ${pathForDependencies}`;
                 } else {

--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -33,3 +33,4 @@ export const supportedNodeRuntimes = ["nodejs20.x"] as const;
 export const supportedPythonRuntimes = ["python3.9.x"] as const;
 export const supportedArchitectures = ["arm64", "x86_64"] as const;
 export const supportedSSRFrameworks = ["nextjs", "nitro", "nuxt"] as const;
+export const supportedPythonDepsInstallVersions = ["3.11"] as const;

--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -33,4 +33,4 @@ export const supportedNodeRuntimes = ["nodejs20.x"] as const;
 export const supportedPythonRuntimes = ["python3.9.x"] as const;
 export const supportedArchitectures = ["arm64", "x86_64"] as const;
 export const supportedSSRFrameworks = ["nextjs", "nitro", "nuxt"] as const;
-export const supportedPythonDepsInstallVersions = ["3.11"] as const;
+export const supportedPythonDepsInstallVersion = "3.11" as const;


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Force pip to install x86 packages, because runtime architecture is x86.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
