### PR TITLE
Reorder frameworks to detect vue/svelte instead of vite

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -237,34 +237,6 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             continue;
         }
 
-        if (await isViteComponent(contents)) {
-            await addFrontendComponentToConfig(configPath, {
-                path: componentPath,
-                publish: "dist",
-                scripts: {
-                    deploy: [`${getPackageManager().command} install`],
-                    build: [`${getPackageManager().command} run build`],
-                },
-            });
-            frameworksDetected.frontend = frameworksDetected.frontend || [];
-            frameworksDetected.frontend.push("vite");
-            continue;
-        }
-
-        if (await isReactComponent(contents)) {
-            await addFrontendComponentToConfig(configPath, {
-                path: componentPath,
-                publish: "build",
-                scripts: {
-                    deploy: [`${getPackageManager().command} install`],
-                    build: [`${getPackageManager().command} run build`],
-                },
-            });
-            frameworksDetected.frontend = frameworksDetected.frontend || [];
-            frameworksDetected.frontend.push("react");
-            continue;
-        }
-
         if (await isVueComponent(contents)) {
             await addFrontendComponentToConfig(configPath, {
                 path: componentPath,
@@ -304,6 +276,34 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             });
             frameworksDetected.frontend = frameworksDetected.frontend || [];
             frameworksDetected.frontend.push("svelte");
+            continue;
+        }
+
+        if (await isViteComponent(contents)) {
+            await addFrontendComponentToConfig(configPath, {
+                path: componentPath,
+                publish: "dist",
+                scripts: {
+                    deploy: [`${getPackageManager().command} install`],
+                    build: [`${getPackageManager().command} run build`],
+                },
+            });
+            frameworksDetected.frontend = frameworksDetected.frontend || [];
+            frameworksDetected.frontend.push("vite");
+            continue;
+        }
+
+        if (await isReactComponent(contents)) {
+            await addFrontendComponentToConfig(configPath, {
+                path: componentPath,
+                publish: "build",
+                scripts: {
+                    deploy: [`${getPackageManager().command} install`],
+                    build: [`${getPackageManager().command} run build`],
+                },
+            });
+            frameworksDetected.frontend = frameworksDetected.frontend || [];
+            frameworksDetected.frontend.push("react");
             continue;
         }
 


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR changes the order of the frontend frameworks so Vue, Svelte have priority over Vite.

TL;DR; We want to expose to the user the actual frontend framework used (Vue, Svelte), not the local dev tool a.k.a Vite.

Generally, Vite is used to create templates and build frontends - it's not a frontend framework per se.
Modern frameworks such as Vue or Svelte are using vite by default under the hood, so it's redundant to give this information to the user. It's better to confirm with him the actual framework used.

A bit more complex is React that can be build with CRA or Vite - in this case it make sense to tell the user which build/local dev tool is used under the hood.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [x] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
