### PR TITLE
Optimise ts sdk generator process

### DIFF
--- a/src/generateSdk/astGenerator/TsAstGenerator.ts
+++ b/src/generateSdk/astGenerator/TsAstGenerator.ts
@@ -39,8 +39,38 @@ import { GENEZIO_CLASS_STATIC_METHOD_NOT_SUPPORTED, UserError } from "../../erro
 
 type Declaration = StructLiteral | TypeAlias | Enum;
 
+// This properties should be populated only once and then reused
+let _files: readonly typescript.SourceFile[] | undefined;
+let _typeChecker: typescript.TypeChecker | undefined;
+
 export class AstGenerator implements AstGeneratorInterface {
     rootNode?: typescript.SourceFile;
+
+    get files(): readonly typescript.SourceFile[] {
+        // Lazy initialization: execute logic only once
+        if (!_files) {
+            const typescriptFiles: string[] = [];
+            this.getAllFiles(typescriptFiles, ".");
+
+            const program = typescript.createProgram(typescriptFiles, {});
+            _typeChecker = program.getTypeChecker();
+            _files = program.getSourceFiles();
+        }
+        return _files;
+    }
+
+    get typeChecker(): typescript.TypeChecker {
+        // Lazy initialization: execute logic only once
+        if (!_typeChecker) {
+            const typescriptFiles: string[] = [];
+            this.getAllFiles(typescriptFiles, ".");
+
+            const program = typescript.createProgram(typescriptFiles, {});
+            _typeChecker = program.getTypeChecker();
+            _files = program.getSourceFiles();
+        }
+        return _typeChecker;
+    }
 
     mapTypesToParamType(
         type: typescript.Node,
@@ -506,9 +536,26 @@ export class AstGenerator implements AstGeneratorInterface {
     }
 
     getAllFiles(files: string[], dirPath: string) {
-        if (dirPath.endsWith("node_modules")) {
+        const ignoreFolders = [
+            "node_modules",
+            ".git",
+            ".svn",
+            ".vscode",
+            ".idea",
+            ".cache",
+            "tmp",
+            ".temp",
+            ".history",
+            ".nyc_output",
+            ".terraform",
+            ".serverless",
+        ];
+
+        // Check if the current directory is in the ignore list
+        if (ignoreFolders.some((folder) => dirPath.indexOf(folder) !== -1)) {
             return;
         }
+
         readdirSync(dirPath).forEach((file) => {
             const absolute = path.join(dirPath, file);
             if (statSync(absolute).isDirectory()) {
@@ -520,14 +567,7 @@ export class AstGenerator implements AstGeneratorInterface {
     }
 
     async generateAst(input: AstGeneratorInput): Promise<AstGeneratorOutput> {
-        const typescriptFiles: string[] = [];
-        this.getAllFiles(typescriptFiles, ".");
-
-        const program = typescript.createProgram(typescriptFiles, {});
-        const typeChecker = program.getTypeChecker();
-
-        const files = program.getSourceFiles();
-        files.forEach((file) => {
+        this.files.forEach((file) => {
             if (path.resolve(file.fileName) === path.resolve(input.class.path)) {
                 this.rootNode = file;
             }
@@ -542,7 +582,7 @@ export class AstGenerator implements AstGeneratorInterface {
             if (typescript.isClassDeclaration(child)) {
                 const classDeclaration = this.parseClassDeclaration(
                     child,
-                    typeChecker,
+                    this.typeChecker,
                     declarations,
                 );
                 if (classDeclaration && !classDefinition) {


### PR DESCRIPTION
# Pull Request Template


## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

I've fixed two problems in this PR:

- We were doing the `this.getAllFiles(typescriptFiles, ".");` and `const program = typescript.createProgram(typescriptFiles, {});` operations multiple times, each time for every genezio class.
- `getAllFiles` was retrieving also the contents of the `.git` folder.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
