### PR TITLE
ignore reinclusion rules in .gitignore

### DIFF
--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -976,7 +976,9 @@ const excludedFiles = [
 function getGitIgnorePatterns(cwd: string): string[] {
     const gitIgnorePath = path.join(cwd, ".gitignore");
     if (existsSync(gitIgnorePath)) {
-        return gitignore.parse(readFileSync(gitIgnorePath)).patterns;
+        return gitignore
+            .parse(readFileSync(gitIgnorePath))
+            .patterns.filter((pattern) => !pattern.startsWith("!"));
     }
 
     return [];

--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -973,28 +973,46 @@ const excludedFiles = [
     ".env.local",
 ];
 
-function getGitIgnorePatterns(cwd: string): string[] {
+type Patterns = {
+    exclude: string[];
+    reinclude: string[];
+};
+
+function getGitIgnorePatterns(cwd: string): Patterns {
     const gitIgnorePath = path.join(cwd, ".gitignore");
     if (existsSync(gitIgnorePath)) {
-        return gitignore
-            .parse(readFileSync(gitIgnorePath))
-            .patterns.filter((pattern) => !pattern.startsWith("!"));
+        return {
+            exclude: gitignore
+                .parse(readFileSync(gitIgnorePath))
+                .patterns.filter((pattern) => !pattern.startsWith("!")),
+            reinclude: gitignore
+                .parse(readFileSync(gitIgnorePath))
+                .patterns.filter((pattern) => pattern.startsWith("!"))
+                .map((pattern) => pattern.slice(1)),
+        };
     }
 
-    return [];
+    return { exclude: [], reinclude: [] };
 }
 
-function getAllGitIgnorePatterns(cwd: string): string[] {
-    let patterns: string[] = getGitIgnorePatterns(cwd);
+function getAllGitIgnorePatterns(cwd: string): Patterns {
+    const patterns: Patterns = getGitIgnorePatterns(cwd);
     readdirSync(cwd, { withFileTypes: true }).forEach((file) => {
         if (
             file.isDirectory() &&
             !file.name.startsWith(".") &&
             !file.name.startsWith("node_modules")
         ) {
-            patterns = [
-                ...patterns,
-                ...getAllGitIgnorePatterns(path.join(cwd, file.name)).map((pattern) =>
+            const newPatterns = getAllGitIgnorePatterns(path.join(cwd, file.name));
+            patterns.exclude = [
+                ...patterns.exclude,
+                ...newPatterns.exclude.map((pattern) =>
+                    path.join(path.relative(cwd, path.join(cwd, file.name)), pattern),
+                ),
+            ];
+            patterns.reinclude = [
+                ...patterns.reinclude,
+                ...newPatterns.reinclude.map((pattern) =>
                     path.join(path.relative(cwd, path.join(cwd, file.name)), pattern),
                 ),
             ];
@@ -1012,11 +1030,13 @@ export async function uploadUserCode(
 ): Promise<void> {
     const tmpFolderProject = await createTemporaryFolder();
     debugLogger.debug(`Creating archive of the project in ${tmpFolderProject}`);
+    const { exclude, reinclude } = getAllGitIgnorePatterns(cwd);
     const promiseZip = zipDirectory(
         cwd,
         path.join(tmpFolderProject, "projectCode.zip"),
         true,
-        excludedFiles.concat(getAllGitIgnorePatterns(cwd)),
+        excludedFiles.concat(exclude),
+        reinclude,
     );
 
     await promiseZip;

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -106,7 +106,8 @@ export async function zipDirectory(
     sourceDir: string,
     outPath: string,
     includeHiddenFiles: boolean = false,
-    exclusion?: string[],
+    exclusion: string[] = [],
+    reinclusion: string[] = [],
 ): Promise<void> {
     const archive = archiver("zip", { zlib: { level: 9 } });
     const stream = fs.createWriteStream(outPath);
@@ -116,17 +117,25 @@ export async function zipDirectory(
     }
 
     return new Promise((resolve, reject) => {
-        archive
-            .glob("**/*", {
+        archive.on("error", (err) => reject(err));
+        archive.pipe(stream);
+
+        archive.glob("**/*", {
+            cwd: sourceDir,
+            dot: includeHiddenFiles,
+            // skip deals with directories, it doesn't allow any children to be returned
+            skip: exclusion,
+            // ignore deals with files, it doesn't prevent files from folder content to be returned
+            ignore: exclusion,
+        });
+
+        if (reinclusion.length > 0) {
+            archive.glob("**/*", {
                 cwd: sourceDir,
                 dot: includeHiddenFiles,
-                // skip deals with directories, it doesn't allow any children to be returned
-                skip: exclusion,
-                // ignore deals with files, it doesn't prevent files from folder content to be returned
-                ignore: exclusion,
-            })
-            .on("error", (err) => reject(err))
-            .pipe(stream);
+                pattern: reinclusion,
+            });
+        }
 
         stream.on("close", () => resolve());
         archive.finalize();


### PR DESCRIPTION
## Type of change

-   [x] 🐛 Bug Fix

## Description

Rules starting with `!` in `.gitignore` files trigger a bug that would result in an empty archive being uploaded for user's code. Simply ignoring these rules solves this issue.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
