### PR TITLE
Temporarily revert detecting containers

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -14,7 +14,6 @@ import {
     isVueComponent,
     isAngularComponent,
     isSvelteComponent,
-    isContainerComponent,
     isFlaskComponent,
     isDjangoComponent,
     isFastAPIComponent,
@@ -35,7 +34,6 @@ import {
 } from "../../projectConfiguration/yaml/v2.js";
 import {
     addBackendComponentToConfig,
-    addContainerComponentToConfig,
     addFrontendComponentToConfig,
     addServicesToConfig,
     addSSRComponentToConfig,
@@ -93,7 +91,7 @@ export enum SUPPORTED_FORMATS {
 export const DEFAULT_FORMAT = SUPPORTED_FORMATS.TEXT;
 export const DEFAULT_CI_FORMAT = SUPPORTED_FORMATS.JSON;
 
-export const KEY_FILES = ["package.json", "Dockerfile", "requirements.txt"];
+export const KEY_FILES = ["package.json", "requirements.txt"];
 export const KEY_DEPENDENCY_FILES = ["package.json", "requirements.txt"];
 export const ENVIRONMENT_EXAMPLE_FILES = [".env.template", ".env.example", ".env.local.example"];
 export const EXCLUDED_DIRECTORIES = ["node_modules", ".git", "dist", "build"];
@@ -397,16 +395,6 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             });
             frameworksDetected.frontend = frameworksDetected.frontend || [];
             frameworksDetected.frontend.push("react");
-            continue;
-        }
-
-        if (await isContainerComponent(contents)) {
-            addContainerComponentToConfig(configPath, {
-                path: componentPath,
-            });
-
-            frameworksDetected.backend = frameworksDetected.backend || [];
-            frameworksDetected.backend.push("container");
             continue;
         }
 


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Reverting containers detection because it's not used now (we cannot build docker images in the build machine).

Detecting containers is confusing and buggy until we implement a decision tree/graph of choice for detecting components.
This algorithm will come in a subsequent PR in the future.


## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
