### PR TITLE
Fix backwards compatibility for ssr

### DIFF
--- a/src/commands/deploy/command.ts
+++ b/src/commands/deploy/command.ts
@@ -28,7 +28,9 @@ export type SSRFrameworkComponent = {
 export async function deployCommand(options: GenezioDeployOptions) {
     await interruptLocalProcesses();
     const deployableComponentsType = await decideDeployType(options);
-    debugLogger.debug(`Deployable components: ${deployableComponentsType}`);
+    debugLogger.debug(
+        `The following components will be build and deployed: ${deployableComponentsType.join(", ")}`,
+    );
 
     // The deployment actions are not called concurrently to avoid race conditions
     for (const type of deployableComponentsType) {
@@ -59,12 +61,12 @@ export async function deployCommand(options: GenezioDeployOptions) {
 }
 
 export enum DeployType {
-    Classic,
-    NextJS,
-    Nitro,
-    Nuxt,
-    Docker,
-    Nest,
+    Classic = "typesafe",
+    NextJS = "next",
+    Nitro = "nitro",
+    Nuxt = "nuxt",
+    Docker = "docker",
+    Nest = "nest",
 }
 
 /**
@@ -85,7 +87,6 @@ async function decideDeployType(options: GenezioDeployOptions): Promise<DeployTy
         return [DeployType.Docker];
     }
 
-    // Check if it's a genezio-containerized project
     if (fs.existsSync(path.join(cwd, "genezio.yaml"))) {
         const configIOController = new YamlConfigurationIOController(options.config);
         const config = await configIOController.read();
@@ -151,7 +152,7 @@ async function decideDeployType(options: GenezioDeployOptions): Promise<DeployTy
         return [DeployType.Nest];
     }
 
-    // Check if "next" package is present in the project dependencies
+    // Check if package.json exists and has next/nuxt/nitro dependencies
     if (fs.existsSync(path.join(cwd, "package.json"))) {
         const packageJson = JSON.parse(fs.readFileSync(path.join(cwd, "package.json"), "utf-8"));
         if (packageJson.dependencies?.next) {
@@ -179,5 +180,6 @@ async function decideDeployType(options: GenezioDeployOptions): Promise<DeployTy
         return [DeployType.Docker];
     }
 
+    // Default to classic genezio app
     return [DeployType.Classic];
 }

--- a/src/commands/deploy/command.ts
+++ b/src/commands/deploy/command.ts
@@ -109,7 +109,11 @@ async function decideDeployType(options: GenezioDeployOptions): Promise<DeployTy
             deployableComponents.push(DeployType.Classic);
         }
 
-        return deployableComponents;
+        // This ensures backwards compatibility for next/nuxt projects
+        // that have a simple (only name and region) genezio.yaml
+        if (deployableComponents.length > 0) {
+            return deployableComponents;
+        }
     }
 
     // Check if next.config.js exists


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Some ssr framework have a simple `genezio.yaml` (slightly outdated):
```yaml
name: genezio-nextjs-getting-started
region: eu-central-1
yamlVersion: 2
```

We should also support deploying those - so if nextjs | nuxt | nitro is not present in the `genezio.yaml`, we continue with detecting for a deployable component. 

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
