### PR TITLE
Fix entryfile path regression

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -582,7 +582,8 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 FLASK_PATTERN,
                 PYTHON_DEFAULT_ENTRY_FILE,
             );
-            const entryFileContent = await retrieveFileContent(entryFile);
+            const fullpath = path.join(componentPath, entryFile);
+            const entryFileContent = await retrieveFileContent(fullpath);
             const pythonHandler = getPythonHandler(entryFileContent);
 
             const packageManagerType =
@@ -661,8 +662,8 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 FASTAPI_PATTERN,
                 PYTHON_DEFAULT_ENTRY_FILE,
             );
-
-            const entryFileContent = await retrieveFileContent(entryFile);
+            const fullpath = path.join(componentPath, entryFile);
+            const entryFileContent = await retrieveFileContent(fullpath);
             const pythonHandler = getPythonHandler(entryFileContent);
 
             const packageManagerType =


### PR DESCRIPTION
To retrieve the contents we should use the fullpath relative to where the genezio.yaml is

# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
