### PR TITLE
Add --no-user to pip install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "@babel/preset-typescript": "^7.26.0",
                 "@babel/traverse": "^7.26.4",
                 "@genezio/test-interface-component": "^2.4.3",
-                "@rollup/rollup-android-arm64": "4.30.0",
                 "@sentry/node": "^7.120.2",
                 "@sentry/profiling-node": "~7.120.0",
                 "@types/adm-zip": "^0.5.6",

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -615,7 +615,7 @@ export async function functionToCloudInput(
                         .readFileSync(requirementsOutputPath, "utf8")
                         .trim();
                     if (requirementsContent) {
-                        installCommand = `${packageManager.command} install -r ${requirementsOutputPath} --platform manylinux2014_x86_64 --only-binary=:all: --python-version ${supportedPythonDepsInstallVersion} -t ${pathForDependencies}`;
+                        installCommand = `${packageManager.command} install -r ${requirementsOutputPath} --platform manylinux2014_x86_64 --only-binary=:all: --python-version ${supportedPythonDepsInstallVersion} -t ${pathForDependencies} --no-user`;
                     }
                 } else if (fs.existsSync(pyProjectTomlPath)) {
                     installCommand = `${packageManager.command} install . --platform manylinux2014_x86_64 --only-binary=:all: --python-version ${supportedPythonDepsInstallVersion} -t ${pathForDependencies}`;


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

If the user have a pip.config like this:

```
[global]
user = yes
```

need to install with --no-user

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
