### PR TITLE
Remove set Cors from node.js local wrapper

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -1647,26 +1647,6 @@ const originalCreateServer = http.createServer;
 let server;
 
 http.createServer = function(...args) {
-    // If there's a request handler provided, wrap it with CORS headers
-    if (args[0] && typeof args[0] === 'function') {
-        const originalHandler = args[0];
-        args[0] = function(req, res) {
-            // Set CORS headers
-            res.setHeader('Access-Control-Allow-Origin', '*');
-            res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-            res.setHeader('Access-Control-Allow-Headers', '*');
-
-            // Handle OPTIONS requests for CORS preflight
-            if (req.method === 'OPTIONS') {
-                res.writeHead(204);
-                res.end();
-                return;
-            }
-
-            return originalHandler(req, res);
-        };
-    }
-
     server = originalCreateServer(...args);
 
     // Store the original listen method


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Remove set Cors from node.js local wrapper

Context: In the local environment, we configure CORS with a wildcard (`*`) to simplify development. However, when the application is deployed, the user is responsible for setting the appropriate CORS configuration themselves. This current setup may lead to issues, such as a conflict when the wildcard (`*`) is set twice, resulting in errors.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
