### PR TITLE
Remove .ts extension from Next.js config imports

### DIFF
--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -439,11 +439,13 @@ function writeNextConfig(cwd: string, region: string) {
     const isCommonJS = existingConfig === "js" || existingConfig === "cjs";
     // Remove .ts extension for TypeScript imports
     const importPath = existingConfig === "ts" ? "./base-next" : `./base-next.${existingConfig}`;
+    const importPathCacheHandler =
+        existingConfig === "ts" ? "./cache-handler.js" : `./cache-handler.${existingConfig}`;
 
     const genezioConfigContent = `
 import userConfig from '${importPath}';
 
-userConfig.cacheHandler = process.env.NODE_ENV === "production" ? "./cache-handler.${existingConfig}" : undefined;
+userConfig.cacheHandler = process.env.NODE_ENV === "production" ? "${importPathCacheHandler}" : undefined;
 userConfig.cacheMaxMemorySize = 0;
 
 ${isCommonJS ? "module.exports = userConfig;" : "export default userConfig;"}
@@ -451,10 +453,14 @@ ${isCommonJS ? "module.exports = userConfig;" : "export default userConfig;"}
 
     fs.writeFileSync(genezioConfigPath, genezioConfigContent);
 
-    fs.writeFileSync(
-        path.join(cwd, `cache-handler.${existingConfig}`),
-        getCacheHandlerContent(existingConfig as "js" | "ts" | "mjs", region),
-    );
+    if (existingConfig === "ts") {
+        fs.writeFileSync(path.join(cwd, `cache-handler.js`), getCacheHandlerContent("js", region));
+    } else {
+        fs.writeFileSync(
+            path.join(cwd, `cache-handler.${existingConfig}`),
+            getCacheHandlerContent(existingConfig as "js" | "ts" | "mjs", region),
+        );
+    }
 }
 
 function determineFileExtension(cwd: string): "js" | "mjs" | "ts" {

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -437,8 +437,11 @@ function writeNextConfig(cwd: string, region: string) {
     fs.renameSync(genezioConfigPath, userConfigPath);
 
     const isCommonJS = existingConfig === "js" || existingConfig === "cjs";
+    // Remove .ts extension for TypeScript imports
+    const importPath = existingConfig === "ts" ? "./base-next" : `./base-next.${existingConfig}`;
+
     const genezioConfigContent = `
-import userConfig from './base-next.${existingConfig}';
+import userConfig from '${importPath}';
 
 userConfig.cacheHandler = process.env.NODE_ENV === "production" ? "./cache-handler.${existingConfig}" : undefined;
 userConfig.cacheMaxMemorySize = 0;


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

This PR fixes an issue where Next.js deployments were failing for TypeScript projects due to direct imports of `.ts` files in the generated configuration. TypeScript doesn't allow importing `.ts` files directly without enabling the `allowImportingTsExtensions` compiler flag.

```
Failed to compile.
./next.config.ts:2:24
  File "/home/runner/work/genezio-tests/genezio-tests/test_genezio_create.py", line 1[50](https://github.com/Genez-io/genezio-tests/actions/runs/12700753372/job/35426649464#step:17:51), in <module>
    test_genezio_create()
  File "/home/runner/work/genezio-tests/genezio-tests/test_genezio_create.py", line 144, in test_genezio_create
    create_and_test_project(project)
  File "/home/runner/work/genezio-tests/genezio-tests/test_genezio_create.py", line 89, in create_and_test_project
    assert deploy_result.return_code == 0, f"genezio deploy failed for {project_name}"
AssertionError: genezio deploy failed for test-nextjs
Type error: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
  1 |
> 2 | import userConfig from './base-next.ts';
    |                        ^
  3 |
  4 | userConfig.cacheHandler = process.env.NODE_ENV === "production" ? "./cache-handler.ts" : undefined;
  5 | userConfig.cacheMaxMemorySize = 0;
Static worker exited with code: 1 and signal: null
```

### Changes
- Modified the `writeNextConfig` function to omit the `.ts` extension when importing base config files in TypeScript projects
- Use cache-handler.js on typescript next.js projects

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
