### PR TITLE
Add support Remix.js

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -23,6 +23,7 @@ import {
     hasPostgresDependency,
     hasMongoDependency,
     isNestjsComponent,
+    isRemixComponent,
 } from "./frameworks.js";
 import { generateDatabaseName, readOrAskConfig } from "../deploy/utils.js";
 import {
@@ -288,6 +289,36 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             frameworksDetected.ssr = frameworksDetected.ssr || [];
             frameworksDetected.ssr.push({
                 component: "nestjs",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isRemixComponent(contents)) {
+            const packageManagerType =
+                genezioConfig.remix?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addSSRComponentToConfig(
+                options.config,
+                {
+                    path: componentPath,
+                    packageManager: packageManagerType,
+                    environment: mapEnvironmentVariableToConfig(
+                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+                    ),
+                    scripts: {
+                        build: [`${packageManager.command} run build`],
+                        deploy: [
+                            `${packageManager.command} install`,
+                            `${packageManager.command} run build`,
+                        ],
+                    },
+                },
+                SSRFrameworkComponentType.remix,
+            );
+            frameworksDetected.ssr = frameworksDetected.ssr || [];
+            frameworksDetected.ssr.push({
+                component: "remix",
                 environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
             });
             continue;

--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -550,36 +550,6 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
         }
 
         if (await isViteComponent(contents)) {
-            if (await isRemixComponent(contents)) {
-                const packageManagerType =
-                    genezioConfig.remix?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
-                const packageManager = packageManagers[packageManagerType];
-                await addSSRComponentToConfig(
-                    options.config,
-                    {
-                        path: componentPath,
-                        packageManager: packageManagerType,
-                        environment: mapEnvironmentVariableToConfig(
-                            resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-                        ),
-                        scripts: {
-                            build: [`${packageManager.command} run build`],
-                            deploy: [
-                                `${packageManager.command} install`,
-                                `${packageManager.command} run build`,
-                            ],
-                        },
-                    },
-                    SSRFrameworkComponentType.remix,
-                );
-                frameworksDetected.ssr = frameworksDetected.ssr || [];
-                frameworksDetected.ssr.push({
-                    component: "remix",
-                    environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-                });
-                continue;
-            }
-
             const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
             const packageManager = packageManagers[packageManagerType];
             await addFrontendComponentToConfig(configPath, {

--- a/src/commands/analyze/frameworks.ts
+++ b/src/commands/analyze/frameworks.ts
@@ -367,6 +367,19 @@ export async function isSvelteComponent(contents: Record<string, string>): Promi
         : false;
 }
 
+// Checks if the project is a Remix component
+export async function isRemixComponent(contents: Record<string, string>): Promise<boolean> {
+    if (!contents["package.json"]) {
+        return false;
+    }
+
+    const packageJsonContent = JSON.parse(contents["package.json"]) as PackageJSON;
+
+    return Object.keys(packageJsonContent.dependencies || {}).some((key) =>
+        key.startsWith("@remix-run"),
+    );
+}
+
 // Checks if the project is a Python component (presence of 'requirements.txt' or 'pyproject.toml')
 export function isPythonComponent(contents: Record<string, string>): boolean {
     return contents["requirements.txt"] !== undefined || contents["pyproject.toml"] !== undefined;

--- a/src/commands/deploy/command.ts
+++ b/src/commands/deploy/command.ts
@@ -191,7 +191,7 @@ async function decideDeployType(options: GenezioDeployOptions): Promise<DeployTy
         }
         if (
             Object.keys({ ...packageJson.dependencies, ...packageJson.devDependencies }).some(
-                (dep) => dep.startsWith("@remix-run/"),
+                (dep) => dep.startsWith("@remix-run"),
             )
         ) {
             return [DeployType.Remix];

--- a/src/commands/deploy/remix/deploy.ts
+++ b/src/commands/deploy/remix/deploy.ts
@@ -1,0 +1,280 @@
+import path from "path";
+import fs from "fs";
+import colors from "colors";
+import { $ } from "execa";
+import { GenezioDeployOptions } from "../../../models/commandOptions.js";
+import { debugLogger, log } from "../../../utils/logging.js";
+import {
+    attemptToInstallDependencies,
+    prepareServicesPostBackendDeployment,
+    prepareServicesPreBackendDeployment,
+    readOrAskConfig,
+    uploadEnvVarsFromFile,
+    uploadUserCode,
+} from "../utils.js";
+import { addSSRComponentToConfig } from "../../analyze/utils.js";
+import {
+    NODE_DEFAULT_PACKAGE_MANAGER,
+    PackageManagerType,
+} from "../../../packageManagers/packageManager.js";
+import { SSRFrameworkComponentType } from "../../../models/projectOptions.js";
+import { UserError } from "../../../errors.js";
+import { YamlProjectConfiguration } from "../../../projectConfiguration/yaml/v2.js";
+import { getCloudProvider } from "../../../requests/getCloudProvider.js";
+import { functionToCloudInput, getCloudAdapter } from "../genezio.js";
+import { FunctionType, Language } from "../../../projectConfiguration/yaml/models.js";
+import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
+import { createTemporaryFolder } from "../../../utils/file.js";
+
+export async function remixDeploy(options: GenezioDeployOptions) {
+    const genezioConfig = await readOrAskConfig(options.config);
+    const packageManagerType = genezioConfig.remix?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
+
+    const cwd = process.cwd();
+    const componentPath = genezioConfig.remix?.path
+        ? path.resolve(cwd, genezioConfig.remix.path)
+        : cwd;
+
+    // Prepare services before deploying (database, authentication, etc)
+    await prepareServicesPreBackendDeployment(
+        genezioConfig,
+        genezioConfig.name,
+        options.stage,
+        options.env,
+    );
+
+    // Install dependencies
+    const installDependenciesCommand = await attemptToInstallDependencies(
+        [],
+        componentPath,
+        packageManagerType,
+    );
+
+    // Check if the project uses remix vite by looking for vite.config.* files
+    const isRemixVite =
+        fs.existsSync(path.join(componentPath, "vite.config.ts")) ||
+        fs.existsSync(path.join(componentPath, "vite.config.js")) ||
+        fs.existsSync(path.join(componentPath, "vite.config.mjs")) ||
+        fs.existsSync(path.join(componentPath, "vite.config.cjs"));
+
+    if (isRemixVite) {
+        debugLogger.debug("Building the project using: remix vite:build");
+        // Build the project using remix vite
+        await $({
+            stdio: "inherit",
+            cwd: componentPath,
+        })`remix vite:build`.catch(() => {
+            throw new UserError("Failed to build the Remix project. Check the logs above.");
+        });
+    } else {
+        debugLogger.debug("Building the project using: npx remix build");
+        // Build the project using remix build
+        await $({
+            stdio: "inherit",
+            cwd: componentPath,
+        })`npx remix build`.catch(() => {
+            throw new UserError("Failed to build the Remix project. Check the logs above.");
+        });
+    }
+
+    const remixBuildCommand = isRemixVite ? "remix vite:build" : "npx remix build";
+
+    // Add remix component to config
+    await addSSRComponentToConfig(
+        options.config,
+        {
+            path: componentPath,
+            packageManager: packageManagerType,
+            scripts: {
+                build: [remixBuildCommand],
+                deploy: [`${installDependenciesCommand.command}`, remixBuildCommand],
+            },
+        },
+        SSRFrameworkComponentType.remix,
+    );
+
+    // Copy the build folder to /tmp
+    const tempBuildCwd = await createTemporaryFolder();
+    debugLogger.debug(`Copying project files to ${tempBuildCwd}`);
+
+    // Check and copy build folder
+    const buildPath = path.join(componentPath, "build");
+    await fs.promises
+        .cp(buildPath, tempBuildCwd, { recursive: true, force: true, dereference: true })
+        .catch(() => {
+            throw new UserError("Failed to copy project build folder to temporary directory");
+        });
+
+    if (!isRemixVite) {
+        // Copy public folder
+        const publicPath = path.join(componentPath, "public");
+        await fs.promises
+            .mkdir(path.join(tempBuildCwd, "public"), { recursive: true })
+            .catch(() => {
+                throw new UserError("Failed to create public folder in temporary directory");
+            });
+        await fs.promises
+            .cp(publicPath, path.join(tempBuildCwd, "public"), {
+                recursive: true,
+                force: true,
+                dereference: true,
+            })
+            .catch(() => {
+                throw new UserError("Failed to copy public folder to temporary directory");
+            });
+    }
+
+    // Check and copy file package.json
+    const packageJsonPath = path.join(componentPath, "package.json");
+    if (!fs.existsSync(packageJsonPath)) {
+        throw new UserError("package.json not found in the project directory: " + packageJsonPath);
+    }
+
+    // Copy package.json to tempBuildCwd with proper destination path
+    const destPackageJsonPath = path.join(tempBuildCwd, "package.json");
+    await fs.promises
+        .cp(packageJsonPath, destPackageJsonPath, {
+            recursive: true,
+            force: true,
+            dereference: true,
+        })
+        .catch(() => {
+            throw new UserError("Failed to copy package.json to temporary directory");
+        });
+
+    if (isRemixVite) {
+        const serverIndexPath = path.join(tempBuildCwd, "server", "index.js");
+        const serverIndexContent = await fs.promises.readFile(serverIndexPath, "utf-8");
+        const packageJsonPathServer = path.join(tempBuildCwd, "server", "package.json");
+
+        // Check if server/index.js use import syntax if use and dont have package.json with type: module create one
+        const hasEsModules = /^[\s\n]*import\s+(?:[\w*\s{},]*\s+from\s+)?['"]/m.test(
+            serverIndexContent,
+        );
+        if (hasEsModules && !fs.existsSync(packageJsonPathServer)) {
+            await fs.promises.writeFile(
+                packageJsonPathServer,
+                JSON.stringify({ type: "module" }, null, 2),
+            );
+        }
+    }
+
+    // Install express and @remix-run/express
+    await attemptToInstallDependencies(
+        ["express", "@remix-run/express"],
+        tempBuildCwd,
+        packageManagerType,
+    );
+
+    const serverMjsPath = path.join(tempBuildCwd, "server.mjs");
+    await fs.promises.writeFile(
+        serverMjsPath,
+        isRemixVite ? serverRemixViteContent : serverRemixClassicContent,
+    );
+
+    const result = await deployFunction(genezioConfig, options, tempBuildCwd);
+
+    await uploadEnvVarsFromFile(
+        options.env,
+        result.projectId,
+        result.projectEnvId,
+        componentPath,
+        options.stage || "prod",
+        genezioConfig,
+        SSRFrameworkComponentType.remix,
+    );
+
+    await uploadUserCode(genezioConfig.name, genezioConfig.region, options.stage, componentPath);
+
+    const functionUrl = result.functions.find((f) => f.name === "function-remix")?.cloudUrl;
+
+    await prepareServicesPostBackendDeployment(genezioConfig, genezioConfig.name, options.stage);
+
+    if (functionUrl) {
+        log.info(
+            `The app is being deployed at ${colors.cyan(functionUrl)}. It might take a few moments to be available worldwide.`,
+        );
+    } else {
+        log.warn("No deployment URL was returned.");
+    }
+}
+
+async function deployFunction(
+    config: YamlProjectConfiguration,
+    options: GenezioDeployOptions,
+    cwd: string,
+) {
+    const cloudProvider = await getCloudProvider(config.name);
+    const cloudAdapter = getCloudAdapter(cloudProvider);
+
+    const serverFunction = {
+        path: ".",
+        name: "remix",
+        entry: "server.mjs",
+        type: FunctionType.httpServer,
+    };
+
+    const deployConfig: YamlProjectConfiguration = {
+        ...config,
+        backend: {
+            path: cwd,
+            language: {
+                name: Language.js,
+                runtime: "nodejs20.x",
+                architecture: "x86_64",
+                packageManager: PackageManagerType.npm,
+            },
+            functions: [serverFunction],
+        },
+    };
+
+    const projectConfiguration = new ProjectConfiguration(
+        deployConfig,
+        await getCloudProvider(deployConfig.name),
+        {
+            generatorResponses: [],
+            classesInfo: [],
+        },
+    );
+
+    const cloudInputs = await Promise.all(
+        projectConfiguration.functions.map((f) => functionToCloudInput(f, cwd)),
+    );
+
+    const result = await cloudAdapter.deploy(
+        cloudInputs,
+        projectConfiguration,
+        { stage: options.stage },
+        ["remix"],
+    );
+
+    return result;
+}
+
+const serverRemixViteContent = `
+import express from "express";
+import { createRequestHandler } from "@remix-run/express";
+import * as build from "./server/index.js"; 
+
+const app = express();
+
+app.use(express.static("client"));
+
+app.all("*", createRequestHandler({ build }));
+
+app.listen(8080, () => {
+  console.log("Server is running on http://localhost:8080");
+});`;
+
+const serverRemixClassicContent = `
+import express from "express";
+import { createRequestHandler } from "@remix-run/express";
+import * as build from "./index.js";
+const app = express();
+
+app.use(express.static('public'));
+app.all('*', createRequestHandler({ build }));
+
+app.listen(8080, () => {
+  console.log('Server running at http://localhost:8080');
+});`;

--- a/src/commands/deploy/remix/deploy.ts
+++ b/src/commands/deploy/remix/deploy.ts
@@ -63,21 +63,25 @@ export async function remixDeploy(options: GenezioDeployOptions) {
         await $({
             stdio: "inherit",
             cwd: componentPath,
-        })`remix vite:build`.catch(() => {
-            throw new UserError("Failed to build the Remix project. Check the logs above.");
+        })`remix vite:build`.catch((error) => {
+            throw new UserError(
+                `Failed to build the Remix project. Check the logs above. ${error}`,
+            );
         });
     } else {
-        debugLogger.debug("Building the project using: npx remix build");
+        debugLogger.debug("Building the project using:remix build");
         // Build the project using remix build
         await $({
             stdio: "inherit",
             cwd: componentPath,
-        })`npx remix build`.catch(() => {
-            throw new UserError("Failed to build the Remix project. Check the logs above.");
+        })`remix build`.catch((error) => {
+            throw new UserError(
+                `Failed to build the Remix project. Check the logs above. ${error}`,
+            );
         });
     }
 
-    const remixBuildCommand = isRemixVite ? "remix vite:build" : "npx remix build";
+    const remixBuildCommand = isRemixVite ? "remix vite:build" : "remix build";
 
     // Add remix component to config
     await addSSRComponentToConfig(
@@ -101,8 +105,10 @@ export async function remixDeploy(options: GenezioDeployOptions) {
     const buildPath = path.join(componentPath, "build");
     await fs.promises
         .cp(buildPath, tempBuildCwd, { recursive: true, force: true, dereference: true })
-        .catch(() => {
-            throw new UserError("Failed to copy project build folder to temporary directory");
+        .catch((error) => {
+            throw new UserError(
+                `Failed to copy project build folder to temporary directory. ${error}`,
+            );
         });
 
     if (!isRemixVite) {
@@ -110,8 +116,10 @@ export async function remixDeploy(options: GenezioDeployOptions) {
         const publicPath = path.join(componentPath, "public");
         await fs.promises
             .mkdir(path.join(tempBuildCwd, "public"), { recursive: true })
-            .catch(() => {
-                throw new UserError("Failed to create public folder in temporary directory");
+            .catch((error) => {
+                throw new UserError(
+                    `Failed to create public folder in temporary directory. ${error}`,
+                );
             });
         await fs.promises
             .cp(publicPath, path.join(tempBuildCwd, "public"), {
@@ -119,8 +127,10 @@ export async function remixDeploy(options: GenezioDeployOptions) {
                 force: true,
                 dereference: true,
             })
-            .catch(() => {
-                throw new UserError("Failed to copy public folder to temporary directory");
+            .catch((error) => {
+                throw new UserError(
+                    `Failed to copy public folder to temporary directory. ${error}`,
+                );
             });
     }
 
@@ -138,8 +148,8 @@ export async function remixDeploy(options: GenezioDeployOptions) {
             force: true,
             dereference: true,
         })
-        .catch(() => {
-            throw new UserError("Failed to copy package.json to temporary directory");
+        .catch((error) => {
+            throw new UserError(`Failed to copy package.json to temporary directory. ${error}`);
         });
 
     if (isRemixVite) {

--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -980,6 +980,7 @@ export async function uploadEnvVarsFromFile(
             [SSRFrameworkComponentType.nuxt]: configuration.nitro?.environment,
             [SSRFrameworkComponentType.nitro]: configuration.nuxt?.environment,
             [SSRFrameworkComponentType.nestjs]: configuration.nuxt?.environment,
+            [SSRFrameworkComponentType.remix]: configuration.remix?.environment,
             backend: configuration.backend?.environment,
         }[componentType] ?? configuration.backend?.environment;
 

--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -28,6 +28,7 @@ export enum SSRFrameworkComponentType {
     nitro = "nitro",
     nuxt = "nuxt",
     nestjs = "nestjs",
+    remix = "remix",
 }
 
 export enum ContainerComponentType {

--- a/src/projectConfiguration/yaml/v2.ts
+++ b/src/projectConfiguration/yaml/v2.ts
@@ -320,6 +320,7 @@ function parseGenezioConfig(config: unknown) {
         nuxt: ssrFrameworkSchema.optional(),
         nitro: ssrFrameworkSchema.optional(),
         container: containerSchema.optional(),
+        remix: ssrFrameworkSchema.optional(),
     });
 
     const parsedConfig = v2Schema.parse(config);


### PR DESCRIPTION
## Type of change

-   [x] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

# Add Remix Framework Deployment Support

## Technical Overview
This PR implements Remix deployment support, handling both Remix Vite and Classic Remix architectures.

### Build System Detection & Handling
The implementation dynamically identifies and manages two distinct build patterns:

1. **Remix Vite Build**
   - Uses the modern Vite bundler
   - Output structure:
     ```
     build/
     ├── client/        # Client-side assets
     └── server/        # Server-side bundle
         └── index.js   # Server entry point
     ```
 
2. **Classic Remix Build**
   - Traditional Remix bundler
   - Output structure:
     ```
     build/
     ├── index.js      # Server entry point
     └── public/       # Static assets
     ```

In both cases index.js will always be a module bundle.

### Server Implementation

Both variants are served through an Express.js server with specific configurations:

```
import express from "express";
import { createRequestHandler } from "@remix-run/express";
import * as build from "./index.js";
const app = express();

app.use(express.static('public'));
app.all('*', createRequestHandler({ build }));

app.listen(8080, () => {
  console.log('Server running at http://localhost:8080');
});
```

### Example 

https://d68cc551-3b9b-4d08-b0cd-50fa15300aa9.dev-fkt.cloud.genez.io/

### References

https://remix.run/docs/en/main/start/quickstart#bring-your-own-server

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
