### PR TITLE
Temporarily disable next detection

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -571,6 +571,12 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
         }
 
         if (await isNextjsComponent(contents)) {
+            // TODO: Remove this check when we support SSR with backends
+            // We are not currently supporting ssr with backends such as express, fastify, etc.
+            if (frameworksDetected.backend && frameworksDetected.backend.length > 0) {
+                continue;
+            }
+
             const packageManagerType =
                 genezioConfig.nestjs?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
             const packageManager = packageManagers[packageManagerType];
@@ -597,6 +603,12 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
         }
 
         if (await isNuxtComponent(contents)) {
+            // TODO: Remove this check when we support SSR with backends
+            // We are not currently supporting ssr with backends such as express, fastify, etc.
+            if (frameworksDetected.backend && frameworksDetected.backend.length > 0) {
+                continue;
+            }
+
             const packageManagerType =
                 genezioConfig.nuxt?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
             const packageManager = packageManagers[packageManagerType];
@@ -624,6 +636,12 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
         }
 
         if (await isRemixComponent(contents)) {
+            // TODO: Remove this check when we support SSR with backends
+            // We are not currently supporting ssr with backends such as express, fastify, etc.
+            if (frameworksDetected.backend && frameworksDetected.backend.length > 0) {
+                continue;
+            }
+
             const packageManagerType =
                 genezioConfig.remix?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
             const packageManager = packageManagers[packageManagerType];

--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -297,36 +297,6 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             continue;
         }
 
-        if (await isRemixComponent(contents)) {
-            const packageManagerType =
-                genezioConfig.remix?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addSSRComponentToConfig(
-                options.config,
-                {
-                    path: componentPath,
-                    packageManager: packageManagerType,
-                    environment: mapEnvironmentVariableToConfig(
-                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-                    ),
-                    scripts: {
-                        build: [`${packageManager.command} run build`],
-                        deploy: [
-                            `${packageManager.command} install`,
-                            `${packageManager.command} run build`,
-                        ],
-                    },
-                },
-                SSRFrameworkComponentType.remix,
-            );
-            frameworksDetected.ssr = frameworksDetected.ssr || [];
-            frameworksDetected.ssr.push({
-                component: "remix",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
         if (await isExpressBackend(contents)) {
             const entryFile = await findEntryFile(
                 componentPath,
@@ -412,214 +382,6 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 component: "fastify",
                 environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
             });
-            continue;
-        }
-
-        if (await isNextjsComponent(contents)) {
-            const packageManagerType =
-                genezioConfig.nestjs?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addSSRComponentToConfig(
-                options.config,
-                {
-                    path: componentPath,
-                    packageManager: packageManagerType,
-                    environment: mapEnvironmentVariableToConfig(
-                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-                    ),
-                    scripts: {
-                        deploy: [`${packageManager.command} install`],
-                    },
-                },
-                SSRFrameworkComponentType.next,
-            );
-            frameworksDetected.ssr = frameworksDetected.ssr || [];
-            frameworksDetected.ssr.push({
-                component: "next",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isNuxtComponent(contents)) {
-            const packageManagerType =
-                genezioConfig.nuxt?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-
-            await addSSRComponentToConfig(
-                options.config,
-                {
-                    path: componentPath,
-                    packageManager: packageManagerType,
-                    environment: mapEnvironmentVariableToConfig(
-                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-                    ),
-                    scripts: {
-                        deploy: [`${packageManager.command} install`],
-                    },
-                },
-                SSRFrameworkComponentType.nuxt,
-            );
-            frameworksDetected.ssr = frameworksDetected.ssr || [];
-            frameworksDetected.ssr.push({
-                component: "nuxt",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isNitroComponent(contents)) {
-            const packageManagerType =
-                genezioConfig.nitro?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-
-            await addSSRComponentToConfig(
-                options.config,
-                {
-                    path: componentPath,
-                    packageManager: packageManagerType,
-                    environment: mapEnvironmentVariableToConfig(
-                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-                    ),
-                    scripts: {
-                        deploy: [`${packageManager.command} install`],
-                    },
-                },
-                SSRFrameworkComponentType.nitro,
-            );
-            frameworksDetected.ssr = frameworksDetected.ssr || [];
-            frameworksDetected.ssr.push({
-                component: "nitro",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isVueComponent(contents)) {
-            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addFrontendComponentToConfig(configPath, {
-                path: componentPath,
-                publish: path.join(componentPath, "dist"),
-                scripts: {
-                    deploy: [`${packageManager.command} install`],
-                    build: [`${packageManager.command} run build`],
-                    start: [
-                        `${packageManager.command} install`,
-                        `${packageManager.command} run dev`,
-                    ],
-                },
-            });
-            frameworksDetected.frontend = frameworksDetected.frontend || [];
-            frameworksDetected.frontend.push({
-                component: "vue",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isAngularComponent(contents)) {
-            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addFrontendComponentToConfig(configPath, {
-                path: componentPath,
-                publish: path.join("dist", "browser"),
-                scripts: {
-                    deploy: [`${packageManager.command} install`],
-                    build: [`${packageManager.command} run build`],
-                    start: [`${packageManager.command} install`, `${packageManager.command} start`],
-                },
-            });
-            frameworksDetected.frontend = frameworksDetected.frontend || [];
-            frameworksDetected.frontend.push({
-                component: "angular",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isSvelteComponent(contents)) {
-            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addFrontendComponentToConfig(configPath, {
-                path: componentPath,
-                publish: "dist",
-                scripts: {
-                    deploy: [`${packageManager.command} install`],
-                    build: [`${packageManager.command} run build`],
-                    start: [
-                        `${packageManager.command} install`,
-                        `${packageManager.command} run dev`,
-                    ],
-                },
-            });
-            frameworksDetected.frontend = frameworksDetected.frontend || [];
-            frameworksDetected.frontend.push({
-                component: "svelte",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isViteComponent(contents)) {
-            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addFrontendComponentToConfig(configPath, {
-                path: componentPath,
-                publish: "dist",
-                scripts: {
-                    deploy: [`${packageManager.command} install`],
-                    build: [`${packageManager.command} run build`],
-                    start: [
-                        `${packageManager.command} install`,
-                        `${packageManager.command} run dev`,
-                    ],
-                },
-            });
-            frameworksDetected.frontend = frameworksDetected.frontend || [];
-            frameworksDetected.frontend.push({
-                component: "vite",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isReactComponent(contents)) {
-            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addFrontendComponentToConfig(configPath, {
-                path: componentPath,
-                publish: "build",
-                scripts: {
-                    deploy: [`${packageManager.command} install`],
-                    build: [`${packageManager.command} run build`],
-                    start: [`${packageManager.command} install`, `${packageManager.command} start`],
-                },
-            });
-            frameworksDetected.frontend = frameworksDetected.frontend || [];
-            frameworksDetected.frontend.push({
-                component: "react",
-                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
-            });
-            continue;
-        }
-
-        if (await isGenezioTypesafe(contents)) {
-            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
-            const packageManager = packageManagers[packageManagerType];
-            await addBackendComponentToConfig(configPath, {
-                path: componentPath,
-                // TODO: Add support for detecting the language of the backend
-                language: {
-                    name: Language.ts,
-                } as YAMLLanguage,
-                scripts: {
-                    deploy: [`${packageManager.command} install`],
-                    local: [`${packageManager.command} install`],
-                },
-            });
-            frameworksDetected.backend = frameworksDetected.backend || [];
-            frameworksDetected.backend.push({ component: "genezio-typesafe" });
             continue;
         }
 
@@ -778,6 +540,244 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 component: "python-lambda",
                 environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
             });
+            continue;
+        }
+
+        if (await isNitroComponent(contents)) {
+            const packageManagerType =
+                genezioConfig.nitro?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+
+            await addSSRComponentToConfig(
+                options.config,
+                {
+                    path: componentPath,
+                    packageManager: packageManagerType,
+                    environment: mapEnvironmentVariableToConfig(
+                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+                    ),
+                    scripts: {
+                        deploy: [`${packageManager.command} install`],
+                    },
+                },
+                SSRFrameworkComponentType.nitro,
+            );
+            frameworksDetected.ssr = frameworksDetected.ssr || [];
+            frameworksDetected.ssr.push({
+                component: "nitro",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isNextjsComponent(contents)) {
+            const packageManagerType =
+                genezioConfig.nestjs?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addSSRComponentToConfig(
+                options.config,
+                {
+                    path: componentPath,
+                    packageManager: packageManagerType,
+                    environment: mapEnvironmentVariableToConfig(
+                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+                    ),
+                    scripts: {
+                        deploy: [`${packageManager.command} install`],
+                    },
+                },
+                SSRFrameworkComponentType.next,
+            );
+            frameworksDetected.ssr = frameworksDetected.ssr || [];
+            frameworksDetected.ssr.push({
+                component: "next",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isNuxtComponent(contents)) {
+            const packageManagerType =
+                genezioConfig.nuxt?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+
+            await addSSRComponentToConfig(
+                options.config,
+                {
+                    path: componentPath,
+                    packageManager: packageManagerType,
+                    environment: mapEnvironmentVariableToConfig(
+                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+                    ),
+                    scripts: {
+                        deploy: [`${packageManager.command} install`],
+                    },
+                },
+                SSRFrameworkComponentType.nuxt,
+            );
+            frameworksDetected.ssr = frameworksDetected.ssr || [];
+            frameworksDetected.ssr.push({
+                component: "nuxt",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isRemixComponent(contents)) {
+            const packageManagerType =
+                genezioConfig.remix?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addSSRComponentToConfig(
+                options.config,
+                {
+                    path: componentPath,
+                    packageManager: packageManagerType,
+                    environment: mapEnvironmentVariableToConfig(
+                        resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+                    ),
+                    scripts: {
+                        build: [`${packageManager.command} run build`],
+                        deploy: [
+                            `${packageManager.command} install`,
+                            `${packageManager.command} run build`,
+                        ],
+                    },
+                },
+                SSRFrameworkComponentType.remix,
+            );
+            frameworksDetected.ssr = frameworksDetected.ssr || [];
+            frameworksDetected.ssr.push({
+                component: "remix",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isVueComponent(contents)) {
+            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addFrontendComponentToConfig(configPath, {
+                path: componentPath,
+                publish: path.join(componentPath, "dist"),
+                scripts: {
+                    deploy: [`${packageManager.command} install`],
+                    build: [`${packageManager.command} run build`],
+                    start: [
+                        `${packageManager.command} install`,
+                        `${packageManager.command} run dev`,
+                    ],
+                },
+            });
+            frameworksDetected.frontend = frameworksDetected.frontend || [];
+            frameworksDetected.frontend.push({
+                component: "vue",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isAngularComponent(contents)) {
+            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addFrontendComponentToConfig(configPath, {
+                path: componentPath,
+                publish: path.join("dist", "browser"),
+                scripts: {
+                    deploy: [`${packageManager.command} install`],
+                    build: [`${packageManager.command} run build`],
+                    start: [`${packageManager.command} install`, `${packageManager.command} start`],
+                },
+            });
+            frameworksDetected.frontend = frameworksDetected.frontend || [];
+            frameworksDetected.frontend.push({
+                component: "angular",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isSvelteComponent(contents)) {
+            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addFrontendComponentToConfig(configPath, {
+                path: componentPath,
+                publish: "dist",
+                scripts: {
+                    deploy: [`${packageManager.command} install`],
+                    build: [`${packageManager.command} run build`],
+                    start: [
+                        `${packageManager.command} install`,
+                        `${packageManager.command} run dev`,
+                    ],
+                },
+            });
+            frameworksDetected.frontend = frameworksDetected.frontend || [];
+            frameworksDetected.frontend.push({
+                component: "svelte",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isViteComponent(contents)) {
+            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addFrontendComponentToConfig(configPath, {
+                path: componentPath,
+                publish: "dist",
+                scripts: {
+                    deploy: [`${packageManager.command} install`],
+                    build: [`${packageManager.command} run build`],
+                    start: [
+                        `${packageManager.command} install`,
+                        `${packageManager.command} run dev`,
+                    ],
+                },
+            });
+            frameworksDetected.frontend = frameworksDetected.frontend || [];
+            frameworksDetected.frontend.push({
+                component: "vite",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isReactComponent(contents)) {
+            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addFrontendComponentToConfig(configPath, {
+                path: componentPath,
+                publish: "build",
+                scripts: {
+                    deploy: [`${packageManager.command} install`],
+                    build: [`${packageManager.command} run build`],
+                    start: [`${packageManager.command} install`, `${packageManager.command} start`],
+                },
+            });
+            frameworksDetected.frontend = frameworksDetected.frontend || [];
+            frameworksDetected.frontend.push({
+                component: "react",
+                environment: resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
+            });
+            continue;
+        }
+
+        if (await isGenezioTypesafe(contents)) {
+            const packageManagerType = NODE_DEFAULT_PACKAGE_MANAGER;
+            const packageManager = packageManagers[packageManagerType];
+            await addBackendComponentToConfig(configPath, {
+                path: componentPath,
+                // TODO: Add support for detecting the language of the backend
+                language: {
+                    name: Language.ts,
+                } as YAMLLanguage,
+                scripts: {
+                    deploy: [`${packageManager.command} install`],
+                    local: [`${packageManager.command} install`],
+                },
+            });
+            frameworksDetected.backend = frameworksDetected.backend || [];
+            frameworksDetected.backend.push({ component: "genezio-typesafe" });
             continue;
         }
     }


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

This PR:
- Reorders the detection rules to make sure we are detecting any possible backend (python, node, express, flask etc.) then SSR frameworks, then frontend frameworks.
- Reordering I'm making sure that I detected backends and I can stop detecting any SSR because a cross-deployment (fullstack) with these 2 types of component won't work

Note: It's best to review each commit because I ordered the changes to make sense.

This is a temporary fix (for this release) to not break projects like the one below which have backend with express and frontend with next:
https://github.com/andreia-oca/FullstackEcommerce

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
