### PR TITLE
Allow Users to Set the Port for SSR Frameworks

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -1857,15 +1857,15 @@ async function startSsrFramework(
         switch (frameworkName.toLowerCase()) {
             case "next.js":
                 command = "next";
-                args = ["dev", "--port", ssrPort.toString()];
+                args = ["dev", "--port", process.env[portEnvKey]];
                 break;
             case "nuxt":
                 command = "nuxt";
-                args = ["dev", "--port", ssrPort.toString()];
+                args = ["dev", "--port", process.env[portEnvKey]];
                 break;
             case "nitro":
                 command = "nitropack";
-                args = ["dev", "--port", ssrPort.toString()];
+                args = ["dev", "--port", process.env[portEnvKey]];
                 break;
             case "nest.js":
                 command = "nest";
@@ -1874,8 +1874,8 @@ async function startSsrFramework(
             case "remix":
                 command = "remix";
                 args = isViteConfigExists
-                    ? ["vite:dev", "--port", ssrPort.toString()]
-                    : ["dev", "--port", ssrPort.toString()];
+                    ? ["vite:dev", "--port", process.env[portEnvKey]]
+                    : ["dev", "--port", process.env[portEnvKey]];
                 break;
             default:
                 throw new Error(`Unknown SSR framework: ${frameworkName}`);

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -1831,12 +1831,20 @@ async function startSsrFramework(
 
     const ssrPort = await findAvailablePort();
 
-    if (frameworkName.toLowerCase() === "nest.js") {
-        throw new UserError("Nest.js is not supported in local mode");
+    const portEnvKey = `GENEZIO_PORT_${frameworkName.replace(/[^a-zA-Z0-9]/g, "_").toUpperCase()}`;
+    if (!process.env[portEnvKey]) {
+        if (frameworkName.toLowerCase() === "nest.js") {
+            throw new UserError(
+                `You need to specify the port for Nest.js. You can do this by:
+1. Running \`GENEZIO_PORT_NEST_JS=<port> genezio local\` - for linux and macos
+2. Running \`set GENEZIO_PORT_NEST_JS=<port> && genezio local\` - for windows
+3. Adding \`GENEZIO_PORT_NEST_JS=<port>\` to your \`.env\` file.
+                `,
+            );
+        }
+        process.env[portEnvKey] = ssrPort.toString();
+        debugLogger.debug(`Set ${portEnvKey} to ${ssrPort}`);
     }
-
-    process.env[`GENEZIO_PORT_${frameworkName.replace(/[^a-zA-Z0-9]/g, "_").toUpperCase()}`] =
-        ssrPort.toString();
 
     try {
         let command: string;
@@ -1858,6 +1866,10 @@ async function startSsrFramework(
             case "nitro":
                 command = "nitropack";
                 args = ["dev", "--port", ssrPort.toString()];
+                break;
+            case "nest.js":
+                command = "nest";
+                args = ["start", "--watch", "--debug"];
                 break;
             case "remix":
                 command = "remix";


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

### Allow Users to Set the Port for SSR Frameworks

Updated logic to let users configure the port via an environment variable for frameworks like Nest.js. If the port is not explicitly set, it falls back to a default. For Nest.js, a user-friendly error is thrown if the port is missing.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
