### PR TITLE
Show app dashboard url

### DIFF
--- a/src/commands/deploy/docker/deploy.ts
+++ b/src/commands/deploy/docker/deploy.ts
@@ -28,6 +28,8 @@ import { reportSuccessFunctions } from "../../../utils/reporter.js";
 import { addContainerComponentToConfig } from "./utils.js";
 import { statSync } from "fs";
 import { ContainerComponentType } from "../../../models/projectOptions.js";
+import colors from "colors";
+import { DASHBOARD_URL } from "../../../constants.js";
 
 export async function dockerDeploy(options: GenezioDeployOptions) {
     const config = await readOrAskConfig(options.config);
@@ -200,6 +202,11 @@ export async function dockerDeploy(options: GenezioDeployOptions) {
     await prepareServicesPostBackendDeployment(config, config.name, options.stage);
 
     reportSuccessFunctions(result.functions);
+
+    log.info(
+        `\nApp Dashboard URL: ${colors.cyan(`${DASHBOARD_URL}/project/${result.projectId}/${result.projectEnvId}`)}\n` +
+            `${colors.dim("Here you can monitor logs, set up a custom domain, and more.")}\n`,
+    );
 }
 
 function getPort(exposedPort: { [id: string]: string }): string {

--- a/src/commands/deploy/nestjs/deploy.ts
+++ b/src/commands/deploy/nestjs/deploy.ts
@@ -24,6 +24,7 @@ import { getCloudProvider } from "../../../requests/getCloudProvider.js";
 import { functionToCloudInput, getCloudAdapter } from "../genezio.js";
 import { FunctionType, Language } from "../../../projectConfiguration/yaml/models.js";
 import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
+import { DASHBOARD_URL } from "../../../constants.js";
 
 export async function nestJsDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
@@ -91,6 +92,11 @@ export async function nestJsDeploy(options: GenezioDeployOptions) {
     if (functionUrl) {
         log.info(
             `The app is being deployed at ${colors.cyan(functionUrl)}. It might take a few moments to be available worldwide.`,
+        );
+
+        log.info(
+            `\nApp Dashboard URL: ${colors.cyan(`${DASHBOARD_URL}/project/${result.projectId}/${result.projectEnvId}`)}\n` +
+                `${colors.dim("Here you can monitor logs, set up a custom domain, and more.")}\n`,
         );
     } else {
         log.warn("No deployment URL was returned.");

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -28,6 +28,7 @@ import {
 import { setEnvironmentVariables } from "../../../requests/setEnvironmentVariables.js";
 import { GenezioCloudOutput } from "../../../cloudAdapter/cloudAdapter.js";
 import {
+    DASHBOARD_URL,
     GENEZIO_FRONTEND_DEPLOYMENT_BUCKET,
     NEXT_JS_GET_ACCESS_KEY,
     NEXT_JS_GET_SECRET_ACCESS_KEY,
@@ -154,6 +155,11 @@ export async function nextJsDeploy(options: GenezioDeployOptions) {
 
     log.info(
         `The app is being deployed at ${colors.cyan(cdnUrl)}. It might take a few moments to be available worldwide.`,
+    );
+
+    log.info(
+        `\nApp Dashboard URL: ${colors.cyan(`${DASHBOARD_URL}/project/${deploymentResult.projectId}/${deploymentResult.projectEnvId}`)}\n` +
+            `${colors.dim("Here you can monitor logs, set up a custom domain, and more.")}\n`,
     );
 }
 

--- a/src/commands/deploy/nuxt/deploy.ts
+++ b/src/commands/deploy/nuxt/deploy.ts
@@ -38,6 +38,7 @@ import { DeployCodeFunctionResponse } from "../../../models/deployCodeResponse.j
 import { DeployType } from "../command.js";
 import { SSRFrameworkComponentType } from "../../../models/projectOptions.js";
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
+import { DASHBOARD_URL } from "../../../constants.js";
 
 export async function nuxtNitroDeploy(
     options: GenezioDeployOptions,
@@ -133,6 +134,11 @@ Note: If your Nuxt project was not migrated to Nuxt 3, please visit https://v2.n
 
     log.info(
         `The app is being deployed at ${colors.cyan(cdnUrl)}. It might take a few moments to be available worldwide.`,
+    );
+
+    log.info(
+        `\nApp Dashboard URL: ${colors.cyan(`${DASHBOARD_URL}/project/${cloudResult.projectId}/${cloudResult.projectEnvId}`)}\n` +
+            `${colors.dim("Here you can monitor logs, set up a custom domain, and more.")}\n`,
     );
 }
 

--- a/src/commands/deploy/remix/deploy.ts
+++ b/src/commands/deploy/remix/deploy.ts
@@ -25,6 +25,7 @@ import { functionToCloudInput, getCloudAdapter } from "../genezio.js";
 import { FunctionType, Language } from "../../../projectConfiguration/yaml/models.js";
 import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
 import { createTemporaryFolder } from "../../../utils/file.js";
+import { DASHBOARD_URL } from "../../../constants.js";
 
 export async function remixDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
@@ -203,6 +204,11 @@ export async function remixDeploy(options: GenezioDeployOptions) {
     if (functionUrl) {
         log.info(
             `The app is being deployed at ${colors.cyan(functionUrl)}. It might take a few moments to be available worldwide.`,
+        );
+
+        log.info(
+            `\nApp Dashboard URL: ${colors.cyan(`${DASHBOARD_URL}/project/${result.projectId}/${result.projectEnvId}`)}\n` +
+                `${colors.dim("Here you can monitor logs, set up a custom domain, and more.")}\n`,
         );
     } else {
         log.warn("No deployment URL was returned.");

--- a/src/commands/deploy/zip/deploy.ts
+++ b/src/commands/deploy/zip/deploy.ts
@@ -10,6 +10,7 @@ import { GenezioCloudInputType } from "../../../cloudAdapter/cloudAdapter.js";
 import { reportSuccessFunctions } from "../../../utils/reporter.js";
 import { log } from "../../../utils/logging.js";
 import colors from "colors";
+import { DASHBOARD_URL } from "../../../constants.js";
 
 export async function zipDeploy(options: GenezioDeployOptions) {
     if (!options.zip) {
@@ -91,4 +92,9 @@ export async function zipDeploy(options: GenezioDeployOptions) {
             log.info(colors.cyan(`Frontend URL: ${frontendUrl}`));
         }
     }
+
+    log.info(
+        `\nApp Dashboard URL: ${colors.cyan(`${DASHBOARD_URL}/project/${result.projectId}/${result.projectEnvId}`)}\n` +
+            `${colors.dim("Here you can monitor logs, set up a custom domain, and more.")}\n`,
+    );
 }


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

This update improves the user experience by displaying the application dashboard URL after deploying an app. Previously, users deploying a cloned repository would not know where to access the dashboard, logs, and other related features. 

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
