### PR TITLE
fix: Handle None and non-dict responses in Python AWS handler

### DIFF
--- a/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
+++ b/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
@@ -289,7 +289,15 @@ def handler(event):
     }
 
     result = genezio_deploy(req)
-
+    
+    # Ensure we always have a dict result with headers
+    if result is None:
+        result = {"headers": {}}
+    elif not isinstance(result, dict):
+        result = {"headers": {}, "body": str(result)}
+    elif "headers" not in result:
+        result["headers"] = {}
+    
     if 'cookies' in result:
         result['headers']['Set-Cookie'] = result['cookies']
 

--- a/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
+++ b/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
@@ -330,6 +330,15 @@ class RequestHandler(BaseHTTPRequestHandler):
         try:
             jsonParsedBody = json.loads(post_data)
             response = userHandler(jsonParsedBody)
+            
+            # Ensure we always have a dict result with headers
+            if response is None:
+                response = {"headers": {}}
+            elif not isinstance(response, dict):
+                response = {"headers": {}, "body": str(response)}
+            elif "headers" not in response:
+                response["headers"] = {}
+
             self.wfile.write(json.dumps(response).encode('utf-8'))
             sys.stdout.flush()
         except Exception as e:


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

This PR fixes an issue where the Python AWS handler would fail when:
- The handler function returns None
- The handler function returns a non-dictionary value
- The response object lacks a headers dictionary

Changes:
- Added proper handling for None responses
- Added conversion of non-dict responses to a valid response format
- Ensured headers dictionary is always present in the response
- Added string conversion for non-dict responses

This prevents errors like "TypeError: argument of type 'NoneType' is not iterable" and "Invalid response type" from occurring when handlers don't return the expected response format.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
