### PR TITLE
fix: handle ESM/CommonJS module syntax correctly in Next.js config

### DIFF
--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -448,13 +448,22 @@ function writeNextConfig(cwd: string, region: string) {
     const importPathCacheHandler =
         existingConfig === "ts" ? "./cache-handler.js" : `./cache-handler.${existingConfig}`;
 
-    const genezioConfigContent = `
+    const genezioConfigContent = isCommonJS
+        ? `
+const userConfig = require('${importPath}');
+
+userConfig.cacheHandler = process.env.NODE_ENV === "production" ? require.resolve("${importPathCacheHandler}") : undefined;
+userConfig.cacheMaxMemorySize = 0;
+
+module.exports = userConfig;
+`
+        : `
 import userConfig from '${importPath}';
 
 userConfig.cacheHandler = process.env.NODE_ENV === "production" ? "${importPathCacheHandler}" : undefined;
 userConfig.cacheMaxMemorySize = 0;
 
-${isCommonJS ? "module.exports = userConfig;" : "export default userConfig;"}
+export default userConfig;
 `;
 
     fs.writeFileSync(genezioConfigPath, genezioConfigContent);


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

This PR resolves an edge case where Next.js deployments could fail due to incorrect module syntax in generated configuration files. Specifically, the issue arose when our generated next.config.js always included an import statement, even in projects configured to use CommonJS.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
