### PR TITLE
fix: check if package-lock exists for clean install

### DIFF
--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -87,7 +87,11 @@ export async function nextJsDeploy(options: GenezioDeployOptions) {
     const tempBuildComponentPath = path.resolve(tempBuildCwd, genezioConfig.nextjs?.path || ".");
 
     // Install dependencies with clean install
-    await attemptToInstallDependencies([], tempBuildComponentPath, packageManagerType, true);
+    if (fs.existsSync(path.join(tempBuildComponentPath, "package-lock.json"))) {
+        await attemptToInstallDependencies([], tempBuildComponentPath, packageManagerType, true);
+    } else {
+        await attemptToInstallDependencies([], tempBuildComponentPath, packageManagerType);
+    }
 
     // Install ISR package
     await attemptToInstallDependencies(


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Resolved an issue where running `npm ci` without an existing `package-lock.json` file caused the command to fail with an EUSAGE error. The fix ensures that the script checks for the presence of `package-lock.json` before attempting a clean install.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
