### PR TITLE
fix: process was unable to locate the file 'next.config.undefined' 

### DIFF
--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -451,13 +451,14 @@ async function deployFunction(
  */
 function writeNextConfig(cwd: string, region: string) {
     const configExtensions = ["js", "cjs", "mjs", "ts"];
-    const existingConfig = configExtensions.find((ext) =>
+    let existingConfig = configExtensions.find((ext) =>
         fs.existsSync(path.join(cwd, `next.config.${ext}`)),
     );
 
     if (!existingConfig) {
         const extension = determineFileExtension(cwd);
         writeConfigFiles(cwd, extension, region);
+        existingConfig = extension;
     }
 
     const genezioConfigPath = path.join(cwd, `next.config.${existingConfig}`);


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

When no Next.js config file exists and a new one is created, the code need to attempt to reassign the file extension to `existingConfig`

### Error

```
The build failed due to an error related to a missing file or directory when renaming a file in the '/tmp/genezio-147/wex0mj/src' directory. The build process was unable to locate the file 'next.config.undefined' while trying to rename it to 'base-next.undefined'.
```

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
