### PR TITLE
Display deployment auth tokens on success

### DIFF
--- a/src/cloudAdapter/cloudAdapter.ts
+++ b/src/cloudAdapter/cloudAdapter.ts
@@ -71,6 +71,7 @@ export type GenezioCloudResultClass = {
     methods: DeployCodeMethodResponse[];
     functionUrl: string;
     projectId?: string;
+    authToken?: string;
 };
 
 export type GenezioCloudResultFunctions = {

--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -195,6 +195,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
                 c.name,
             ),
             projectId: response.projectId,
+            authToken: c.authToken,
         }));
 
         return {

--- a/src/models/deployCodeResponse.ts
+++ b/src/models/deployCodeResponse.ts
@@ -10,6 +10,7 @@ export type DeployCodeClassResponse = {
     name: string;
     path: string;
     type: string;
+    authToken?: string;
     methods: DeployCodeMethodResponse[];
 };
 
@@ -17,6 +18,7 @@ export type DeployCodeFunctionResponse = {
     cloudUrl: string;
     id: string;
     name: string;
+    authToken?: string;
 };
 
 export type DeployCodeResponse = {

--- a/src/utils/reporter.ts
+++ b/src/utils/reporter.ts
@@ -27,6 +27,11 @@ export function reportSuccess(classesInfo: GenezioCloudResultClass[]) {
                     "\n";
             }
         });
+        if (classInfo.authToken) {
+            printHttpString +=
+                `  - ${classInfo.className} authentication token: ${colors.green(classInfo.authToken)}` +
+                "\n";
+        }
     });
 
     if (printHttpString !== "") {
@@ -41,11 +46,15 @@ export function reportSuccessFunctions(functions: DeployCodeFunctionResponse[]) 
 
     functions.forEach((func) => {
         functionDeploymentsString += `  - ${func.name}: ${colors.yellow(func.cloudUrl)}` + "\n";
+        if (func.authToken) {
+            functionDeploymentsString +=
+                `  - ${func.name} authentication token: ${colors.green(func.authToken)}` + "\n";
+        }
     });
 
     if (functionDeploymentsString !== "") {
         log.info("");
-        log.info("Functions Deployed:");
+        log.info("Functions Deployed: ");
         log.info(functionDeploymentsString);
     }
 }


### PR DESCRIPTION
-   [X] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Newer deployments return an authentication token needed to query for individual logs, directly from our runtime, through a yet undocumented API. This token should be shown at deployment in the CLI.

This PR makes sure to capture the auth token from the backend, and then print it alongside the individual URLs of the deployment.
