### PR TITLE
chore: update default Python runtime to 3.13

### DIFF
--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -8,8 +8,8 @@ export type PythonRuntime =
 export type Architecture = "arm64" | "x86_64";
 export const DEFAULT_NODE_RUNTIME: NodeRuntime = "nodejs20.x";
 export const DEFAULT_ARCHITECTURE: Architecture = "arm64";
-export const DEFAULT_PYTHON_RUNTIME: PythonRuntime = "python3.11.x";
-export const DEFAULT_PYTHON_VERSION_INSTALL: string = "3.11";
+export const DEFAULT_PYTHON_RUNTIME: PythonRuntime = "python3.13.x";
+export const DEFAULT_PYTHON_VERSION_INSTALL: string = "3.13";
 
 export const CONTAINER_IMAGE_NODE20 = "node:20.11.1-alpine3.19";
 


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Updates the default Python version from 3.11 to 3.13.

## Changes
- Changed `DEFAULT_PYTHON_RUNTIME` to "python3.13.x"
- Updated `DEFAULT_PYTHON_VERSION_INSTALL` to "3.13"

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
