### PR TITLE
fix/streamlit-event-loop-requirement

### DIFF
--- a/src/commands/deploy/streamlit/deploy.ts
+++ b/src/commands/deploy/streamlit/deploy.ts
@@ -192,11 +192,15 @@ async function deployFunction(
 function getStartFileContent(entryFile: string) {
     const startFileContent = `
 import streamlit.web.bootstrap as bootstrap
+import asyncio
 
 flags = {
     'server_port': 8080,
     'global_developmentMode': False
 }
+
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
 
 bootstrap.load_config_options(flag_options=flags)
 bootstrap.run('${entryFile}', False, [], flags)


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

This PR adds explicit event loop support for Streamlit, required starting with version 1.42.0.

## Changes

- Added `asyncio.new_event_loop()` and `set_event_loop()` in the Streamlit bootstrap file
- Ensures compatibility with newer Streamlit versions (>=1.42.0)

## # Technical Context

Starting with Streamlit 1.42.0, the framework requires an explicit event loop for proper operation. This change doesn't affect previous Streamlit versions.

### Testing

- [x] Tested with Streamlit 1.42.0+
- [x] Verified backwards compatibility

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
