### PR TITLE
Prevent sending a runtime default to the backend

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -33,7 +33,11 @@ import {
     packageManagers,
     PYTHON_DEFAULT_PACKAGE_MANAGER,
 } from "../../packageManagers/packageManager.js";
-import { DEFAULT_PYTHON_RUNTIME, SSRFrameworkComponentType } from "../../models/projectOptions.js";
+import {
+    DEFAULT_NODE_RUNTIME,
+    DEFAULT_PYTHON_RUNTIME,
+    SSRFrameworkComponentType,
+} from "../../models/projectOptions.js";
 import { RawYamlProjectConfiguration, YAMLLanguage } from "../../projectConfiguration/yaml/v2.js";
 import {
     addBackendComponentToConfig,
@@ -263,6 +267,7 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 language: {
                     // TODO: Add support for detecting and building typescript backends
                     name: Language.js,
+                    runtime: DEFAULT_NODE_RUNTIME,
                 } as YAMLLanguage,
                 scripts: {
                     deploy: [`${packageManager.command} install`],
@@ -366,6 +371,7 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 language: {
                     // TODO: Add support for detecting and building typescript backends
                     name: Language.js,
+                    runtime: DEFAULT_NODE_RUNTIME,
                 } as YAMLLanguage,
                 environment: mapEnvironmentVariableToConfig(
                     resultEnvironmentAnalysis.get(componentPath)?.environmentVariables,
@@ -410,6 +416,7 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 language: {
                     // TODO: Add support for detecting and building typescript backends
                     name: Language.js,
+                    runtime: DEFAULT_NODE_RUNTIME,
                 } as YAMLLanguage,
                 scripts: {
                     deploy: [`${packageManager.command} install`],
@@ -849,6 +856,7 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
                 // TODO: Add support for detecting the language of the backend
                 language: {
                     name: Language.ts,
+                    runtime: DEFAULT_NODE_RUNTIME,
                 } as YAMLLanguage,
                 scripts: {
                     deploy: [`${packageManager.command} install`],

--- a/src/commands/deploy/command.ts
+++ b/src/commands/deploy/command.ts
@@ -13,6 +13,8 @@ import { nestJsDeploy } from "./nestjs/deploy.js";
 import { zipDeploy } from "./zip/deploy.js";
 import { remixDeploy } from "./remix/deploy.js";
 import { streamlitDeploy } from "./streamlit/deploy.js";
+import { YAMLLanguageRuntime } from "../../projectConfiguration/yaml/v2.js";
+
 export type SSRFrameworkComponent = {
     path: string;
     packageManager: PackageManagerType;
@@ -25,7 +27,7 @@ export type SSRFrameworkComponent = {
         [key: string]: string;
     };
     subdomain?: string;
-    runtime?: string;
+    runtime?: YAMLLanguageRuntime;
     entryFile?: string;
 };
 

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -78,7 +78,10 @@ import {
     packageManagers,
     PYTHON_DEFAULT_PACKAGE_MANAGER,
 } from "../../packageManagers/packageManager.js";
-import { DEFAULT_PYTHON_VERSION_INSTALL } from "../../models/projectOptions.js";
+import {
+    DEFAULT_PYTHON_RUNTIME,
+    DEFAULT_PYTHON_VERSION_INSTALL,
+} from "../../models/projectOptions.js";
 import { detectPythonVersion } from "../../utils/detectPythonCommand.js";
 
 export async function genezioDeploy(options: GenezioDeployOptions) {
@@ -643,7 +646,7 @@ export async function functionToCloudInput(
             const pathForDependencies = path.join(tmpFolderPath, "packages");
             const packageManager = packageManagers[PYTHON_DEFAULT_PACKAGE_MANAGER];
             let installCommand;
-            const versionMatch = runtime!.match(/\d+\.\d+/);
+            const versionMatch = (runtime || DEFAULT_PYTHON_RUNTIME).match(/\d+\.\d+/);
             const pythonVersion = versionMatch ? versionMatch[0] : DEFAULT_PYTHON_VERSION_INSTALL;
 
             // check pythonVersion matches with local python version

--- a/src/commands/deploy/nestjs/deploy.ts
+++ b/src/commands/deploy/nestjs/deploy.ts
@@ -19,7 +19,6 @@ import {
 } from "../../../packageManagers/packageManager.js";
 import {
     DEFAULT_ARCHITECTURE,
-    DEFAULT_NODE_RUNTIME,
     SSRFrameworkComponentType,
 } from "../../../models/projectOptions.js";
 import { UserError } from "../../../errors.js";
@@ -137,9 +136,9 @@ async function deployFunction(
             path: cwdRelative,
             language: {
                 name: Language.js,
-                runtime: DEFAULT_NODE_RUNTIME,
                 architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
+                ...(config.nestjs?.runtime !== undefined && { runtime: config.nestjs.runtime }),
             },
             functions: [serverFunction],
         },

--- a/src/commands/deploy/nestjs/deploy.ts
+++ b/src/commands/deploy/nestjs/deploy.ts
@@ -17,7 +17,11 @@ import {
     NODE_DEFAULT_PACKAGE_MANAGER,
     PackageManagerType,
 } from "../../../packageManagers/packageManager.js";
-import { SSRFrameworkComponentType } from "../../../models/projectOptions.js";
+import {
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_NODE_RUNTIME,
+    SSRFrameworkComponentType,
+} from "../../../models/projectOptions.js";
 import { UserError } from "../../../errors.js";
 import { YamlProjectConfiguration } from "../../../projectConfiguration/yaml/v2.js";
 import { getCloudProvider } from "../../../requests/getCloudProvider.js";
@@ -133,8 +137,8 @@ async function deployFunction(
             path: cwdRelative,
             language: {
                 name: Language.js,
-                runtime: "nodejs20.x",
-                architecture: "x86_64",
+                runtime: DEFAULT_NODE_RUNTIME,
+                architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
             },
             functions: [serverFunction],

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -45,7 +45,11 @@ import {
     uploadUserCode,
 } from "../utils.js";
 import { readOrAskConfig } from "../utils.js";
-import { SSRFrameworkComponentType } from "../../../models/projectOptions.js";
+import {
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_NODE_RUNTIME,
+    SSRFrameworkComponentType,
+} from "../../../models/projectOptions.js";
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
 export async function nextJsDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
@@ -370,8 +374,8 @@ async function deployFunction(
             path: ".",
             language: {
                 name: Language.ts,
-                runtime: "nodejs20.x",
-                architecture: "x86_64",
+                runtime: DEFAULT_NODE_RUNTIME,
+                architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
             },
             functions: [serverFunction],

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -47,7 +47,6 @@ import {
 import { readOrAskConfig } from "../utils.js";
 import {
     DEFAULT_ARCHITECTURE,
-    DEFAULT_NODE_RUNTIME,
     SSRFrameworkComponentType,
 } from "../../../models/projectOptions.js";
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
@@ -374,9 +373,9 @@ async function deployFunction(
             path: ".",
             language: {
                 name: Language.ts,
-                runtime: DEFAULT_NODE_RUNTIME,
-                architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
+                architecture: DEFAULT_ARCHITECTURE,
+                ...(config.nextjs?.runtime !== undefined && { runtime: config.nextjs.runtime }),
             },
             functions: [serverFunction],
         },

--- a/src/commands/deploy/nuxt/deploy.ts
+++ b/src/commands/deploy/nuxt/deploy.ts
@@ -36,7 +36,11 @@ import {
 } from "../../../requests/createFrontendProject.js";
 import { DeployCodeFunctionResponse } from "../../../models/deployCodeResponse.js";
 import { DeployType } from "../command.js";
-import { SSRFrameworkComponentType } from "../../../models/projectOptions.js";
+import {
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_NODE_RUNTIME,
+    SSRFrameworkComponentType,
+} from "../../../models/projectOptions.js";
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
 import { DASHBOARD_URL } from "../../../constants.js";
 
@@ -167,8 +171,8 @@ async function deployFunction(
             path: cwdRelative,
             language: {
                 name: Language.js,
-                runtime: "nodejs20.x",
-                architecture: "x86_64",
+                runtime: DEFAULT_NODE_RUNTIME,
+                architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
             },
             functions,

--- a/src/commands/deploy/nuxt/deploy.ts
+++ b/src/commands/deploy/nuxt/deploy.ts
@@ -38,7 +38,6 @@ import { DeployCodeFunctionResponse } from "../../../models/deployCodeResponse.j
 import { DeployType } from "../command.js";
 import {
     DEFAULT_ARCHITECTURE,
-    DEFAULT_NODE_RUNTIME,
     SSRFrameworkComponentType,
 } from "../../../models/projectOptions.js";
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
@@ -171,9 +170,9 @@ async function deployFunction(
             path: cwdRelative,
             language: {
                 name: Language.js,
-                runtime: DEFAULT_NODE_RUNTIME,
                 architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
+                ...(config.nuxt?.runtime !== undefined && { runtime: config.nuxt.runtime }),
             },
             functions,
         },

--- a/src/commands/deploy/remix/deploy.ts
+++ b/src/commands/deploy/remix/deploy.ts
@@ -17,7 +17,11 @@ import {
     NODE_DEFAULT_PACKAGE_MANAGER,
     PackageManagerType,
 } from "../../../packageManagers/packageManager.js";
-import { SSRFrameworkComponentType } from "../../../models/projectOptions.js";
+import {
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_NODE_RUNTIME,
+    SSRFrameworkComponentType,
+} from "../../../models/projectOptions.js";
 import { UserError } from "../../../errors.js";
 import { YamlProjectConfiguration } from "../../../projectConfiguration/yaml/v2.js";
 import { getCloudProvider } from "../../../requests/getCloudProvider.js";
@@ -236,8 +240,8 @@ async function deployFunction(
             path: cwd,
             language: {
                 name: Language.js,
-                runtime: "nodejs20.x",
-                architecture: "x86_64",
+                runtime: DEFAULT_NODE_RUNTIME,
+                architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
             },
             functions: [serverFunction],
@@ -270,7 +274,7 @@ async function deployFunction(
 const serverRemixViteContent = `
 import express from "express";
 import { createRequestHandler } from "@remix-run/express";
-import * as build from "./server/index.js"; 
+import * as build from "./server/index.js";
 
 const app = express();
 

--- a/src/commands/deploy/remix/deploy.ts
+++ b/src/commands/deploy/remix/deploy.ts
@@ -19,7 +19,6 @@ import {
 } from "../../../packageManagers/packageManager.js";
 import {
     DEFAULT_ARCHITECTURE,
-    DEFAULT_NODE_RUNTIME,
     SSRFrameworkComponentType,
 } from "../../../models/projectOptions.js";
 import { UserError } from "../../../errors.js";
@@ -240,9 +239,9 @@ async function deployFunction(
             path: cwd,
             language: {
                 name: Language.js,
-                runtime: DEFAULT_NODE_RUNTIME,
                 architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.npm,
+                ...(config.remix?.runtime !== undefined && { runtime: config.remix.runtime }),
             },
             functions: [serverFunction],
         },

--- a/src/commands/deploy/streamlit/deploy.ts
+++ b/src/commands/deploy/streamlit/deploy.ts
@@ -1,6 +1,7 @@
 import { YamlProjectConfiguration } from "../../../projectConfiguration/yaml/v2.js";
 import { GenezioDeployOptions } from "../../../models/commandOptions.js";
 import {
+    DEFAULT_ARCHITECTURE,
     DEFAULT_PYTHON_RUNTIME,
     PythonRuntime,
     SSRFrameworkComponentType,
@@ -153,7 +154,7 @@ async function deployFunction(
             language: {
                 name: Language.python,
                 runtime: runtime,
-                architecture: "x86_64",
+                architecture: DEFAULT_ARCHITECTURE,
                 packageManager: PackageManagerType.pip,
             },
             functions: [serverFunction],

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -2,13 +2,7 @@
 import { getAstSummary } from "../generateSdk/utils/getAstSummary.js";
 import { AstSummary } from "./astSummary.js";
 import { CloudProviderIdentifier } from "./cloudProviderIdentifier.js";
-import {
-    DEFAULT_ARCHITECTURE,
-    DEFAULT_NODE_RUNTIME,
-    DEFAULT_PYTHON_RUNTIME,
-    NodeOptions,
-    PythonOptions,
-} from "./projectOptions.js";
+import { NodeOptions, PythonOptions } from "./projectOptions.js";
 import { SdkHandlerResponse } from "./sdkGeneratorResponse.js";
 import {
     DatabaseType,
@@ -230,17 +224,14 @@ export class ProjectConfiguration {
             case Language.ts:
             case Language.js:
                 this.options = {
-                    nodeRuntime: yamlConfiguration.backend.language.runtime || DEFAULT_NODE_RUNTIME,
-                    architecture:
-                        yamlConfiguration.backend.language.architecture || DEFAULT_ARCHITECTURE,
+                    nodeRuntime: yamlConfiguration.backend.language.runtime,
+                    architecture: yamlConfiguration.backend.language.architecture,
                 } as NodeOptions;
                 break;
             case Language.python:
                 this.options = {
-                    pythonRuntime:
-                        yamlConfiguration.backend.language.runtime || DEFAULT_PYTHON_RUNTIME,
-                    architecture:
-                        yamlConfiguration.backend.language.architecture || DEFAULT_ARCHITECTURE,
+                    pythonRuntime: yamlConfiguration.backend.language.runtime,
+                    architecture: yamlConfiguration.backend.language.architecture,
                 } as PythonOptions;
                 break;
         }

--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -7,7 +7,7 @@ export type PythonRuntime =
     | "python3.13.x";
 export type Architecture = "arm64" | "x86_64";
 export const DEFAULT_NODE_RUNTIME: NodeRuntime = "nodejs20.x";
-export const DEFAULT_ARCHITECTURE: Architecture = "arm64";
+export const DEFAULT_ARCHITECTURE: Architecture = "x86_64";
 export const DEFAULT_PYTHON_RUNTIME: PythonRuntime = "python3.11.x";
 export const DEFAULT_PYTHON_VERSION_INSTALL: string = "3.11";
 
@@ -61,6 +61,7 @@ export const supportedPythonRuntimes = [
     "python3.12.x",
     "python3.13.x",
 ] as const;
+
 export const supportedArchitectures = ["arm64", "x86_64"] as const;
 export const supportedSSRFrameworks = ["nextjs", "nitro", "nuxt", "streamlit"] as const;
 export const supportedPythonDepsInstallVersion = ["3.9", "3.10", "3.11", "3.12", "3.13"] as const;

--- a/src/projectConfiguration/yaml/models.ts
+++ b/src/projectConfiguration/yaml/models.ts
@@ -8,6 +8,7 @@ export enum Language {
     dart = "dart",
     kt = "kt",
     go = "go",
+    container = "container",
 }
 
 export enum AuthenticationDatabaseType {

--- a/src/projectConfiguration/yaml/v2.ts
+++ b/src/projectConfiguration/yaml/v2.ts
@@ -29,6 +29,7 @@ export type RawYamlProjectConfiguration = ReturnType<typeof parseGenezioConfig>;
 export type YAMLBackend = NonNullable<YamlProjectConfiguration["backend"]>;
 export type YAMLService = NonNullable<YamlProjectConfiguration["services"]>;
 export type YAMLLanguage = NonNullable<YAMLBackend["language"]>;
+export type YAMLLanguageRuntime = NonNullable<YAMLLanguage["runtime"]>;
 export type YamlClass = NonNullable<YAMLBackend["classes"]>[number];
 export type YamlFunction = NonNullable<YAMLBackend["functions"]>[number];
 export type YamlServices = NonNullable<YamlProjectConfiguration["services"]>;
@@ -326,7 +327,7 @@ function parseGenezioConfig(config: unknown) {
             .optional(),
         environment: environmentSchema.optional(),
         subdomain: zod.string().optional(),
-        runtime: zod.string().optional(),
+        runtime: zod.enum([...supportedNodeRuntimes, ...supportedPythonRuntimes]).optional(),
         entryFile: zod.string().optional(),
     });
 
@@ -406,7 +407,6 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
         typeof defaultConfig,
         | "region"
         | "backend.language.packageManager"
-        | "backend.language.runtime"
         | "backend.language.architecture"
     > & {
         frontend: typeof defaultConfig.frontend;

--- a/src/projectConfiguration/yaml/v2.ts
+++ b/src/projectConfiguration/yaml/v2.ts
@@ -12,9 +12,6 @@ import {
     Language,
 } from "./models.js";
 import {
-    DEFAULT_ARCHITECTURE,
-    DEFAULT_NODE_RUNTIME,
-    DEFAULT_PYTHON_RUNTIME,
     FUNCTION_EXTENSIONS,
     supportedArchitectures,
     supportedNodeRuntimes,
@@ -394,13 +391,9 @@ function fillDefaultGenezioConfig(config: RawYamlProjectConfiguration) {
             case Language.ts:
             case Language.js:
                 defaultConfig.backend.language.packageManager ??= PackageManagerType.npm;
-                defaultConfig.backend.language.runtime ??= DEFAULT_NODE_RUNTIME;
-                defaultConfig.backend.language.architecture ??= DEFAULT_ARCHITECTURE;
                 break;
             case Language.python:
                 defaultConfig.backend.language.packageManager ??= PackageManagerType.pip;
-                defaultConfig.backend.language.runtime ??= DEFAULT_PYTHON_RUNTIME;
-                defaultConfig.backend.language.architecture ??= DEFAULT_ARCHITECTURE;
                 break;
         }
     }


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

To allow the backend to handle backwards compatibility issues related to latest `language.runtime` we should prevent pushing `nodeRuntime` and `pythonRuntime` to the backend. These should be set only when the user specifically sets them in the `genezio.yaml`.

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

## Checklist

-   [ ] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [ ] New and existing unit tests pass locally with my changes;
