### PR TITLE
Add support for adding env vars at deploy time

### DIFF
--- a/src/cloudAdapter/cloudAdapter.ts
+++ b/src/cloudAdapter/cloudAdapter.ts
@@ -7,6 +7,7 @@ import { YamlFrontend } from "../projectConfiguration/yaml/v2.js";
 import { Dependency } from "../bundlers/bundler.interface.js";
 import FileDetails from "../models/fileDetails.js";
 import { InstanceSize } from "../projectConfiguration/yaml/models.js";
+import { EnvironmentVariable } from "../models/environmentVariables.js";
 
 export enum GenezioCloudInputType {
     CLASS = "class",
@@ -104,6 +105,7 @@ export interface CloudAdapter {
         cloudAdapterOptions: CloudAdapterOptions,
         stack: string[],
         sourceRepository?: string,
+        environmentVariables?: EnvironmentVariable[],
     ): Promise<GenezioCloudOutput>;
     deployFrontend(
         projectName: string,

--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -28,6 +28,7 @@ import Table from "cli-table";
 import { UserError } from "../../errors.js";
 import { stdout } from "process";
 import { createHash } from "../../utils/strings.js";
+import { EnvironmentVariable } from "../../models/environmentVariables.js";
 
 // The maximum size of a bundle is 1.524e9 bytes approx 1.5GB.
 const BUNDLE_SIZE_LIMIT = 1.524e9;
@@ -123,6 +124,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
         cloudAdapterOptions: CloudAdapterOptions,
         stack: string[] = [],
         sourceRepository?: string,
+        environmentVariables?: EnvironmentVariable[],
     ): Promise<GenezioCloudOutput> {
         const stage: string = cloudAdapterOptions.stage || "";
 
@@ -180,6 +182,7 @@ export class GenezioCloudAdapter implements CloudAdapter {
             stage,
             stack,
             sourceRepository,
+            environmentVariables,
         );
         const classesInfo = response.classes.map((c) => ({
             className: c.name,

--- a/src/commands/deploy/command.ts
+++ b/src/commands/deploy/command.ts
@@ -14,8 +14,6 @@ import { zipDeploy } from "./zip/deploy.js";
 import { remixDeploy } from "./remix/deploy.js";
 import { streamlitDeploy } from "./streamlit/deploy.js";
 import { YAMLLanguageRuntime } from "../../projectConfiguration/yaml/v2.js";
-import { actionDetectedEnvFile } from "./utils.js";
-import { isCI } from "../../utils/process.js";
 
 export type SSRFrameworkComponent = {
     path: string;
@@ -39,11 +37,6 @@ export async function deployCommand(options: GenezioDeployOptions) {
     debugLogger.debug(
         `The following components will be build and deployed: ${deployableComponentsType.join(", ")}`,
     );
-
-    // Give the user another chance if he forgot to add `--env` flag
-    if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile();
-    }
 
     // The deployment actions are not called concurrently to avoid race conditions
     for (const type of deployableComponentsType) {

--- a/src/commands/deploy/command.ts
+++ b/src/commands/deploy/command.ts
@@ -14,6 +14,8 @@ import { zipDeploy } from "./zip/deploy.js";
 import { remixDeploy } from "./remix/deploy.js";
 import { streamlitDeploy } from "./streamlit/deploy.js";
 import { YAMLLanguageRuntime } from "../../projectConfiguration/yaml/v2.js";
+import { actionDetectedEnvFile } from "./utils.js";
+import { isCI } from "../../utils/process.js";
 
 export type SSRFrameworkComponent = {
     path: string;
@@ -37,6 +39,11 @@ export async function deployCommand(options: GenezioDeployOptions) {
     debugLogger.debug(
         `The following components will be build and deployed: ${deployableComponentsType.join(", ")}`,
     );
+
+    // Give the user another chance if he forgot to add `--env` flag
+    if (!isCI() && !options.env) {
+        options.env = await actionDetectedEnvFile();
+    }
 
     // The deployment actions are not called concurrently to avoid race conditions
     for (const type of deployableComponentsType) {

--- a/src/commands/deploy/docker/deploy.ts
+++ b/src/commands/deploy/docker/deploy.ts
@@ -32,6 +32,7 @@ import colors from "colors";
 import { DASHBOARD_URL } from "../../../constants.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
 import { ContainerComponentType } from "../../../models/projectOptions.js";
+import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
 
 export async function dockerDeploy(options: GenezioDeployOptions) {
     const config = await readOrAskConfig(options.config);
@@ -205,6 +206,8 @@ export async function dockerDeploy(options: GenezioDeployOptions) {
         /* sourceRepository */ projectGitRepositoryUrl,
         /* environmentVariables */ environmentVariables,
     );
+
+    await warningMissingEnvironmentVariables(config.container?.path || "./", result.projectId, result.projectEnvId);
 
     // Prepare services after deploying (authentication redirect urls)
     await prepareServicesPostBackendDeployment(config, config.name, options.stage);

--- a/src/commands/deploy/docker/deploy.ts
+++ b/src/commands/deploy/docker/deploy.ts
@@ -49,7 +49,7 @@ export async function dockerDeploy(options: GenezioDeployOptions) {
 
     // Give the user another chance if he forgot to add `--env` flag
     if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile(config.container?.path || ".");
+        options.env = await actionDetectedEnvFile(config.container?.path || ".", config.name, options.stage);
     }
 
     // Prepare services before deploying (database, authentication, etc)

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -69,6 +69,7 @@ import {
     prepareServicesPreBackendDeployment,
     prepareServicesPostBackendDeployment,
     excludedFiles,
+    actionDetectedEnvFile,
 } from "./utils.js";
 import { expandEnvironmentVariables, warningMissingEnvironmentVariables } from "../../utils/environmentVariables.js";
 import { getFunctionHandlerProvider } from "../../utils/getFunctionHandlerProvider.js";
@@ -84,6 +85,7 @@ import {
     DEFAULT_PYTHON_VERSION_INSTALL,
 } from "../../models/projectOptions.js";
 import { detectPythonVersion } from "../../utils/detectPythonCommand.js";
+import { isCI } from "../../utils/process.js";
 
 export async function genezioDeploy(options: GenezioDeployOptions) {
     const configIOController = new YamlConfigurationIOController(options.config, {
@@ -95,6 +97,11 @@ export async function genezioDeploy(options: GenezioDeployOptions) {
         return;
     }
     const backendCwd = configuration.backend?.path || process.cwd();
+
+    // Give the user another chance if he forgot to add `--env` flag
+    if (!isCI() && !options.env) {
+        options.env = await actionDetectedEnvFile(backendCwd);
+    }
 
     // We need to check if the user is using an older version of @genezio/types
     // because we migrated the decorators implemented in the @genezio/types package to the stage 3 implementation.

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -100,7 +100,7 @@ export async function genezioDeploy(options: GenezioDeployOptions) {
 
     // Give the user another chance if he forgot to add `--env` flag
     if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile(backendCwd);
+        options.env = await actionDetectedEnvFile(backendCwd, configuration.name, options.stage);
     }
 
     // We need to check if the user is using an older version of @genezio/types

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -70,7 +70,7 @@ import {
     prepareServicesPostBackendDeployment,
     excludedFiles,
 } from "./utils.js";
-import { expandEnvironmentVariables } from "../../utils/environmentVariables.js";
+import { expandEnvironmentVariables, warningMissingEnvironmentVariables } from "../../utils/environmentVariables.js";
 import { getFunctionHandlerProvider } from "../../utils/getFunctionHandlerProvider.js";
 import { getFunctionEntryFilename } from "../../utils/getFunctionEntryFilename.js";
 import { CronDetails } from "../../models/requests.js";
@@ -171,6 +171,10 @@ export async function genezioDeploy(options: GenezioDeployOptions) {
             eventType: TelemetryEventTypes.GENEZIO_BACKEND_DEPLOY_END,
             commandOptions: JSON.stringify(options),
         });
+
+        if (deployClassesResult) {
+            await warningMissingEnvironmentVariables(backendCwd, deployClassesResult?.projectId, deployClassesResult?.projectEnvId);
+        }
     }
 
     const frontendUrls = [];

--- a/src/commands/deploy/nestjs/deploy.ts
+++ b/src/commands/deploy/nestjs/deploy.ts
@@ -42,7 +42,7 @@ export async function nestJsDeploy(options: GenezioDeployOptions) {
 
     // Give the user another chance if he forgot to add `--env` flag
     if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile(componentPath);
+        options.env = await actionDetectedEnvFile(componentPath, genezioConfig.name, options.stage);
     }
 
     // Prepare services before deploying (database, authentication, etc)

--- a/src/commands/deploy/nestjs/deploy.ts
+++ b/src/commands/deploy/nestjs/deploy.ts
@@ -27,6 +27,7 @@ import { FunctionType, Language } from "../../../projectConfiguration/yaml/model
 import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
 import { DASHBOARD_URL } from "../../../constants.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
+import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
 
 export async function nestJsDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
@@ -89,6 +90,8 @@ export async function nestJsDeploy(options: GenezioDeployOptions) {
     await uploadUserCode(genezioConfig.name, genezioConfig.region, options.stage, componentPath);
 
     const functionUrl = result.functions.find((f) => f.name === "function-nest")?.cloudUrl;
+
+    await warningMissingEnvironmentVariables(genezioConfig.nestjs?.path || "./", result.projectId, result.projectEnvId);
 
     await prepareServicesPostBackendDeployment(genezioConfig, genezioConfig.name, options.stage);
 

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -48,6 +48,7 @@ import { DEFAULT_ARCHITECTURE, SSRFrameworkComponentType } from "../../../models
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
 import { setEnvironmentVariables } from "../../../requests/setEnvironmentVariables.js";
+import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
 export async function nextJsDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
     const packageManagerType = genezioConfig.nextjs?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
@@ -152,6 +153,8 @@ export async function nextJsDeploy(options: GenezioDeployOptions) {
             tempBuildComponentPath,
         ),
     ]);
+
+    await warningMissingEnvironmentVariables(genezioConfig.nextjs?.path || "./", deploymentResult.projectId, deploymentResult.projectEnvId);
 
     await prepareServicesPostBackendDeployment(genezioConfig, genezioConfig.name, options.stage);
 

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -63,7 +63,7 @@ export async function nextJsDeploy(options: GenezioDeployOptions) {
 
     // Give the user another chance if he forgot to add `--env` flag
     if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile(nextjsComponentPath);
+        options.env = await actionDetectedEnvFile(nextjsComponentPath, genezioConfig.name, options.stage);
     }
 
     // Prepare services before deploying (database, authentication, etc)

--- a/src/commands/deploy/nextjs/deploy.ts
+++ b/src/commands/deploy/nextjs/deploy.ts
@@ -25,7 +25,6 @@ import {
     createFrontendProjectV2,
     CreateFrontendV2Origin,
 } from "../../../requests/createFrontendProject.js";
-import { setEnvironmentVariables } from "../../../requests/setEnvironmentVariables.js";
 import { GenezioCloudOutput } from "../../../cloudAdapter/cloudAdapter.js";
 import {
     DASHBOARD_URL,
@@ -47,6 +46,8 @@ import {
 import { readOrAskConfig } from "../utils.js";
 import { DEFAULT_ARCHITECTURE, SSRFrameworkComponentType } from "../../../models/projectOptions.js";
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
+import { EnvironmentVariable } from "../../../models/environmentVariables.js";
+import { setEnvironmentVariables } from "../../../requests/setEnvironmentVariables.js";
 export async function nextJsDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
     const packageManagerType = genezioConfig.nextjs?.packageManager || NODE_DEFAULT_PACKAGE_MANAGER;
@@ -117,10 +118,16 @@ export async function nextJsDeploy(options: GenezioDeployOptions) {
 
     const cacheToken = randomUUID();
     const sharpInstallFolder = await installSharp(tempBuildComponentPath);
+    const environmentVariables = await uploadEnvVarsFromFile(
+        options.env,
+        options.stage,
+        genezioConfig,
+        SSRFrameworkComponentType.next,
+    );
 
     const [deploymentResult, domainName] = await Promise.all([
         // Deploy NextJs serverless functions
-        deployFunction(genezioConfig, tempBuildComponentPath, options.stage),
+        deployFunction(genezioConfig, tempBuildComponentPath, options.stage, environmentVariables),
         // Deploy NextJs static assets to S3
         deployStaticAssets(genezioConfig, options.stage, cacheToken, tempBuildComponentPath),
     ]);
@@ -143,15 +150,6 @@ export async function nextJsDeploy(options: GenezioDeployOptions) {
             genezioConfig,
             options.stage,
             tempBuildComponentPath,
-        ),
-        uploadEnvVarsFromFile(
-            options.env,
-            deploymentResult.projectId,
-            deploymentResult.projectEnvId,
-            tempBuildComponentPath,
-            options.stage || "prod",
-            genezioConfig,
-            SSRFrameworkComponentType.next,
         ),
     ]);
 
@@ -349,6 +347,7 @@ async function deployFunction(
     config: YamlProjectConfiguration,
     cwd: string,
     stage?: string,
+    environmentVariables?: EnvironmentVariable[],
 ): Promise<GenezioCloudOutput> {
     const cloudProvider = await getCloudProvider(config.name);
     const cloudAdapter = getCloudAdapter(cloudProvider);
@@ -437,6 +436,7 @@ async function deployFunction(
         { stage },
         ["nextjs"],
         projectGitRepositoryUrl,
+        environmentVariables,
     );
     debugLogger.debug(`Deployed functions: ${JSON.stringify(result.functions)}`);
 

--- a/src/commands/deploy/nuxt/deploy.ts
+++ b/src/commands/deploy/nuxt/deploy.ts
@@ -65,7 +65,7 @@ export async function nuxtNitroDeploy(
 
    // Give the user another chance if he forgot to add `--env` flag
     if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile(componentPath);
+        options.env = await actionDetectedEnvFile(componentPath, genezioConfig.name, options.stage);
     }
 
     // Prepare services before deploying (database, authentication, etc)

--- a/src/commands/deploy/nuxt/deploy.ts
+++ b/src/commands/deploy/nuxt/deploy.ts
@@ -41,6 +41,7 @@ import { DEFAULT_ARCHITECTURE, SSRFrameworkComponentType } from "../../../models
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
 import { DASHBOARD_URL } from "../../../constants.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
+import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
 
 export async function nuxtNitroDeploy(
     options: GenezioDeployOptions,
@@ -127,6 +128,8 @@ Note: If your Nuxt project was not migrated to Nuxt 3, please visit https://v2.n
         deployCDN(cloudResult.functions, domain, genezioConfig, options.stage, componentPath),
         uploadUserCode(genezioConfig.name, genezioConfig.region, options.stage, componentPath),
     ]);
+
+    await warningMissingEnvironmentVariables(genezioConfig.nuxt?.path || "./", cloudResult.projectId, cloudResult.projectEnvId);
 
     // Prepare services after deploying (authentication, etc)
     await prepareServicesPostBackendDeployment(genezioConfig, genezioConfig.name, options.stage);

--- a/src/commands/deploy/nuxt/deploy.ts
+++ b/src/commands/deploy/nuxt/deploy.ts
@@ -14,6 +14,7 @@ import {
 import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
 import { debugLogger, log } from "../../../utils/logging.js";
 import {
+    actionDetectedEnvFile,
     attemptToInstallDependencies,
     prepareServicesPostBackendDeployment,
     prepareServicesPreBackendDeployment,
@@ -42,6 +43,7 @@ import { addSSRComponentToConfig } from "../../analyze/utils.js";
 import { DASHBOARD_URL } from "../../../constants.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
 import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
+import { isCI } from "../../../utils/process.js";
 
 export async function nuxtNitroDeploy(
     options: GenezioDeployOptions,
@@ -60,6 +62,11 @@ export async function nuxtNitroDeploy(
     const componentPath = genezioConfig[NitroOrNuxtFlag]?.path
         ? path.resolve(cwd, genezioConfig[NitroOrNuxtFlag].path)
         : cwd;
+
+   // Give the user another chance if he forgot to add `--env` flag
+    if (!isCI() && !options.env) {
+        options.env = await actionDetectedEnvFile(componentPath);
+    }
 
     // Prepare services before deploying (database, authentication, etc)
     await prepareServicesPreBackendDeployment(

--- a/src/commands/deploy/remix/deploy.ts
+++ b/src/commands/deploy/remix/deploy.ts
@@ -28,6 +28,7 @@ import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
 import { createTemporaryFolder } from "../../../utils/file.js";
 import { DASHBOARD_URL } from "../../../constants.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
+import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
 
 export async function remixDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
@@ -195,6 +196,8 @@ export async function remixDeploy(options: GenezioDeployOptions) {
     await uploadUserCode(genezioConfig.name, genezioConfig.region, options.stage, componentPath);
 
     const functionUrl = result.functions.find((f) => f.name === "function-remix")?.cloudUrl;
+
+    await warningMissingEnvironmentVariables(genezioConfig.remix?.path || "./", result.projectId, result.projectEnvId);
 
     await prepareServicesPostBackendDeployment(genezioConfig, genezioConfig.name, options.stage);
 

--- a/src/commands/deploy/remix/deploy.ts
+++ b/src/commands/deploy/remix/deploy.ts
@@ -43,7 +43,7 @@ export async function remixDeploy(options: GenezioDeployOptions) {
 
    // Give the user another chance if he forgot to add `--env` flag
     if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile(componentPath);
+        options.env = await actionDetectedEnvFile(componentPath, genezioConfig.name, options.stage);
     }
 
     // Prepare services before deploying (database, authentication, etc)

--- a/src/commands/deploy/streamlit/deploy.ts
+++ b/src/commands/deploy/streamlit/deploy.ts
@@ -34,6 +34,7 @@ import { FunctionType } from "../../../projectConfiguration/yaml/models.js";
 import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
 import { createTemporaryFolder } from "../../../utils/file.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
+import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
 
 export async function streamlitDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
@@ -112,6 +113,8 @@ export async function streamlitDeploy(options: GenezioDeployOptions) {
     );
 
     const functionUrl = result.functions.find((f) => f.name === "function-streamlit")?.cloudUrl;
+
+    await warningMissingEnvironmentVariables(genezioConfig.streamlit?.path || "./", result.projectId, result.projectEnvId);
 
     await prepareServicesPostBackendDeployment(
         updatedGenezioConfig,

--- a/src/commands/deploy/streamlit/deploy.ts
+++ b/src/commands/deploy/streamlit/deploy.ts
@@ -15,6 +15,7 @@ import { STREAMLIT_PATTERN } from "../../analyze/constants.js";
 import { findEntryFile } from "../../analyze/frameworks.js";
 import { addSSRComponentToConfig } from "../../analyze/utils.js";
 import {
+    actionDetectedEnvFile,
     prepareServicesPostBackendDeployment,
     prepareServicesPreBackendDeployment,
     readOrAskConfig,
@@ -35,6 +36,7 @@ import { ProjectConfiguration } from "../../../models/projectConfiguration.js";
 import { createTemporaryFolder } from "../../../utils/file.js";
 import { EnvironmentVariable } from "../../../models/environmentVariables.js";
 import { warningMissingEnvironmentVariables } from "../../../utils/environmentVariables.js";
+import { isCI } from "../../../utils/process.js";
 
 export async function streamlitDeploy(options: GenezioDeployOptions) {
     const genezioConfig = await readOrAskConfig(options.config);
@@ -45,6 +47,11 @@ export async function streamlitDeploy(options: GenezioDeployOptions) {
     const componentPath = genezioConfig.streamlit?.path
         ? path.resolve(cwd, genezioConfig.streamlit.path)
         : cwd;
+
+   // Give the user another chance if he forgot to add `--env` flag
+    if (!isCI() && !options.env) {
+        options.env = await actionDetectedEnvFile(componentPath);
+    }
 
     // Prepare services before deploying (database, authentication, etc)
     await prepareServicesPreBackendDeployment(

--- a/src/commands/deploy/streamlit/deploy.ts
+++ b/src/commands/deploy/streamlit/deploy.ts
@@ -50,7 +50,7 @@ export async function streamlitDeploy(options: GenezioDeployOptions) {
 
    // Give the user another chance if he forgot to add `--env` flag
     if (!isCI() && !options.env) {
-        options.env = await actionDetectedEnvFile(componentPath);
+        options.env = await actionDetectedEnvFile(componentPath, genezioConfig.name, options.stage);
     }
 
     // Prepare services before deploying (database, authentication, etc)

--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -41,15 +41,10 @@ import {
     zipDirectory,
 } from "../../utils/file.js";
 import { resolveConfigurationVariable } from "../../utils/scripts.js";
-import { GenezioTelemetry, TelemetryEventTypes } from "../../telemetry/telemetry.js";
-import { setEnvironmentVariables } from "../../requests/setEnvironmentVariables.js";
 import { log } from "../../utils/logging.js";
-import { AxiosError } from "axios";
 import colors from "colors";
 import {
-    detectEnvironmentVariablesFile,
     findAnEnvFile,
-    getUnsetEnvironmentVariables,
     parseConfigurationVariable,
     promptToConfirmSettingEnvironmentVariables,
 } from "../../utils/environmentVariables.js";
@@ -71,13 +66,13 @@ import { getPresignedURLForProjectCodePush } from "../../requests/getPresignedUR
 import { uploadContentToS3 } from "../../requests/uploadContentToS3.js";
 import { displayHint, replaceExpression } from "../../utils/strings.js";
 import { packageManagers, PackageManagerType } from "../../packageManagers/packageManager.js";
-import { ContainerComponentType, SSRFrameworkComponentType } from "../../models/projectOptions.js";
 import gitignore from "parse-gitignore";
 import {
     disableEmailIntegration,
     enableEmailIntegration,
     getProjectIntegrations,
 } from "../../requests/integration.js";
+import { ContainerComponentType, SSRFrameworkComponentType } from "../../models/projectOptions.js";
 
 const dnsLookup = promisify(dns.lookup);
 
@@ -901,7 +896,7 @@ export async function evaluateResource(
 
         if (!envFile) {
             throw new UserError(
-                `Environment variable file ${envFile} is missing. Please provide the correct path with genezio deploy --env <envFile>.`,
+                `Environment variable file ${envFile} is missing. Please provide the correct path with genezio deploy \`--env <envFile>\`.`,
             );
         }
         const resourceValue = (await readEnvironmentVariablesFile(envFile)).find(
@@ -920,64 +915,103 @@ export async function evaluateResource(
     return resourceRaw.value;
 }
 
+export async function actionDetectedEnvFile(): Promise<string | undefined> {
+    const envFile = ".env";
+    const envFileFullPath = path.join(process.cwd(), envFile);
+    if (!(await fileExists(envFileFullPath))) {
+        return undefined;
+    }
+
+    const envVars = await readEnvironmentVariablesFile(envFileFullPath);
+    if (envVars.length === 0) {
+        return undefined;
+    }
+
+    const confirmSettingEnvVars = await promptToConfirmSettingEnvironmentVariables(
+        envVars.map((envVar) => envVar.name),
+    );
+
+    if (!confirmSettingEnvVars) {
+        log.info(
+            `Skipping environment variables upload. You can set them later by navigating to the dashboard.`,
+        );
+        return undefined;
+    }
+
+    debugLogger.debug(
+        `Uploading environment variables ${JSON.stringify(envVars)} from ${envFileFullPath}.`,
+    );
+
+    return envFile;
+}
+
 export async function uploadEnvVarsFromFile(
-    envPath: string | undefined,
-    projectId: string,
-    projectEnvId: string,
-    cwd: string,
+    optionsEnvFileFlag: string | undefined,
     stage: string,
     configuration: YamlProjectConfiguration,
     componentType: SSRFrameworkComponentType | ContainerComponentType | "backend" = "backend",
-) {
-    if (envPath) {
-        const envFile = path.join(process.cwd(), envPath);
-        debugLogger.debug(`Loading environment variables from ${envFile}.`);
+): Promise<EnvironmentVariable[]> {
+    if (!optionsEnvFileFlag) {
+        return [];
+    }
+    const envFile = path.join(process.cwd(), optionsEnvFileFlag);
 
-        if (!(await fileExists(envFile))) {
-            // There is no need to exit the process here, as the project has been deployed
-            log.error(`File ${envFile} does not exists. Please provide the correct path.`);
-            await GenezioTelemetry.sendEvent({
-                eventType: TelemetryEventTypes.GENEZIO_DEPLOY_ERROR,
-                errorTrace: `File ${envFile} does not exists`,
-            });
-        } else {
-            // Read environment variables from .env file
-            const envVars = await readEnvironmentVariablesFile(envFile);
-
-            // Upload environment variables to the project
-            await setEnvironmentVariables(projectId, projectEnvId, envVars)
-                .then(async () => {
-                    const envVarKeys = envVars.map((envVar) => envVar.name);
-                    log.info(
-                        `The following environment variables were uploaded successfully: `,
-                        envVarKeys.join(", "),
-                    );
-                    await GenezioTelemetry.sendEvent({
-                        eventType: TelemetryEventTypes.GENEZIO_DEPLOY_LOAD_ENV_VARS,
-                    });
-                })
-                .catch(async (error: AxiosError) => {
-                    log.error(`Loading environment variables failed with: ${error.message}`);
-                    log.error(
-                        `Try to set the environment variables using the dashboard ${colors.cyan(
-                            DASHBOARD_URL,
-                        )}`,
-                    );
-                    await GenezioTelemetry.sendEvent({
-                        eventType: TelemetryEventTypes.GENEZIO_DEPLOY_ERROR,
-                        errorTrace: error.toString(),
-                    });
-                });
-        }
+    if (!(await fileExists(envFile))) {
+        throw new UserError(
+            `File ${envFile} does not exist. Please provide the correct path using \`--env <envFile>\`.`,
+        );
     }
 
-    // This is best effort, we should encourage the user to use `--env <envFile>` to set the correct env file path.
-    // Search for possible .env files in the project directory and use the first
-    const envFile = envPath ? path.join(process.cwd(), envPath) : await findAnEnvFile(cwd);
+    const envVars = await readEnvironmentVariablesFile(envFile);
+    debugLogger.debug(
+        `Found the following variables in the env file: ${envVars.map((envVar) => envVar.name).join(", ")}`,
+    );
 
-    // Select the enviroment object based on the component type (nuxt, nitro, nextjs, container, backend)
-    // "backend" is the default component type
-    const environment =
+    const environment = getEnvironmentConfiguration(configuration, componentType);
+    if (environment) {
+        const environmentVariablesFromConfigFile =
+            await evaluateEnvironmentVariablesFromConfiguration(
+                environment,
+                configuration,
+                stage,
+                envFile,
+            );
+        debugLogger.debug(
+            `Found the following variables in the \`genezio.yaml\` file: ${JSON.stringify(environmentVariablesFromConfigFile)}`,
+        );
+        envVars.push(...environmentVariablesFromConfigFile);
+    }
+
+    return envVars;
+}
+
+async function evaluateEnvironmentVariablesFromConfiguration(
+    environment: Record<string, string>,
+    configuration: YamlProjectConfiguration,
+    stage: string,
+    envFile: string,
+): Promise<EnvironmentVariable[]> {
+    const envVarKeys = Object.keys(environment);
+    return (
+        await Promise.all(
+            envVarKeys.map(async (envVarKey) => {
+                const value = await evaluateResource(
+                    configuration,
+                    environment[envVarKey],
+                    stage,
+                    envFile,
+                );
+                return value ? { name: envVarKey, value } : undefined;
+            }),
+        )
+    ).filter(Boolean) as EnvironmentVariable[];
+}
+
+function getEnvironmentConfiguration(
+    configuration: YamlProjectConfiguration,
+    componentType: SSRFrameworkComponentType | ContainerComponentType | "backend",
+) {
+    return (
         {
             [ContainerComponentType.container]: configuration.container?.environment,
             [SSRFrameworkComponentType.next]: configuration.nextjs?.environment,
@@ -987,97 +1021,8 @@ export async function uploadEnvVarsFromFile(
             [SSRFrameworkComponentType.remix]: configuration.remix?.environment,
             [SSRFrameworkComponentType.streamlit]: configuration.streamlit?.environment,
             backend: configuration.backend?.environment,
-        }[componentType] ?? configuration.backend?.environment;
-
-    if (environment) {
-        const unsetEnvVarKeys = await getUnsetEnvironmentVariables(
-            Object.keys(environment),
-            projectId,
-            projectEnvId,
-        );
-
-        const environmentVariablesToBePushed: EnvironmentVariable[] = (
-            await Promise.all(
-                unsetEnvVarKeys.map(async (envVarKey) => {
-                    const value = await evaluateResource(
-                        configuration,
-                        environment[envVarKey],
-                        stage,
-                        envFile,
-                    );
-                    return value ? { name: envVarKey, value } : undefined;
-                }),
-            )
-        ).filter(Boolean) as EnvironmentVariable[];
-
-        if (environmentVariablesToBePushed.length > 0) {
-            debugLogger.debug(
-                `Uploading environment variables ${JSON.stringify(environmentVariablesToBePushed)} to project ${projectId}`,
-            );
-            await setEnvironmentVariables(projectId, projectEnvId, environmentVariablesToBePushed);
-            debugLogger.debug(
-                `Environment variables uploaded to project ${projectId} successfully.`,
-            );
-        }
-
-        return;
-    }
-
-    if (!envFile) {
-        return;
-    }
-
-    const envVars = await readEnvironmentVariablesFile(envFile);
-    const missingEnvVars = await getUnsetEnvironmentVariables(
-        envVars.map((envVar) => envVar.name),
-        projectId,
-        projectEnvId,
+        }[componentType] ?? configuration.backend?.environment
     );
-
-    if (!isCI() && missingEnvVars.length > 0 && (await detectEnvironmentVariablesFile(envFile))) {
-        debugLogger.debug(`Attempting to upload ${missingEnvVars.join(", ")} from ${envFile}.`);
-
-        // Interactively prompt the user to confirm setting environment variables
-        const confirmSettingEnvVars =
-            await promptToConfirmSettingEnvironmentVariables(missingEnvVars);
-
-        if (!confirmSettingEnvVars) {
-            log.info(
-                `Skipping environment variables upload. You can set them later by navigation to the dashboard ${DASHBOARD_URL}`,
-            );
-        } else {
-            const environmentVariablesToBePushed = envVars.filter((envVar: { name: string }) =>
-                missingEnvVars.includes(envVar.name),
-            );
-
-            debugLogger.debug(
-                `Uploading environment variables ${JSON.stringify(environmentVariablesToBePushed)} from ${envFile} to project ${projectId}`,
-            );
-            await setEnvironmentVariables(
-                projectId,
-                projectEnvId,
-                environmentVariablesToBePushed,
-            ).then(async () => {
-                const envVarKeys = environmentVariablesToBePushed.map((envVar) => envVar.name);
-                log.info(
-                    `The following environment variables were uploaded successfully: `,
-                    envVarKeys.join(", "),
-                );
-                await GenezioTelemetry.sendEvent({
-                    eventType: TelemetryEventTypes.GENEZIO_DEPLOY_LOAD_ENV_VARS,
-                });
-            });
-            debugLogger.debug(
-                `Environment variables uploaded to project ${projectId} successfully.`,
-            );
-        }
-    } else if (missingEnvVars.length > 0) {
-        log.warn(
-            `Environment variables ${missingEnvVars.join(", ")} are not set remotely. Please set them using the dashboard ${colors.cyan(
-                DASHBOARD_URL,
-            )}`,
-        );
-    }
 }
 
 // Variables to be excluded from the zip file for the project code (.genezioignore)

--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -915,9 +915,9 @@ export async function evaluateResource(
     return resourceRaw.value;
 }
 
-export async function actionDetectedEnvFile(): Promise<string | undefined> {
+export async function actionDetectedEnvFile(cwd: string): Promise<string | undefined> {
     const envFile = ".env";
-    const envFileFullPath = path.join(process.cwd(), envFile);
+    const envFileFullPath = path.join(cwd, envFile);
     if (!(await fileExists(envFileFullPath))) {
         return undefined;
     }

--- a/src/models/environmentVariables.ts
+++ b/src/models/environmentVariables.ts
@@ -1,3 +1,8 @@
+export type EnvironmentVariableRequest = {
+    name: string;
+    value: string;
+};
+
 export type EnvironmentVariable = {
     name: string;
     value: string;

--- a/src/requests/deployCode.ts
+++ b/src/requests/deployCode.ts
@@ -11,6 +11,7 @@ import { AxiosResponse } from "axios";
 import { StatusOk } from "./models.js";
 import { GENEZIO_NOT_AUTH_ERROR_MSG, UserError } from "../errors.js";
 import { GenezioCloudInput, GenezioCloudInputType } from "../cloudAdapter/cloudAdapter.js";
+import { EnvironmentVariable } from "../models/environmentVariables.js";
 
 export async function deployRequest(
     projectConfiguration: ProjectConfiguration,
@@ -18,6 +19,7 @@ export async function deployRequest(
     stage: string,
     stack: string[] = [],
     sourceRepository?: string,
+    environmentVariables?: EnvironmentVariable[],
 ): Promise<DeployCodeResponse> {
     // auth token
     printAdaptiveLog("Checking your credentials", "start");
@@ -64,6 +66,7 @@ export async function deployRequest(
         stage: stage,
         stack: stack,
         sourceRepository,
+        environmentVariables,
     });
 
     debugLogger.debug("Deploy request sent with body:", json);


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Support setting environment variables concurrently with the deployment in the same request.

This PR does the following:
- retrieves the environment variables before the deployment to send them in the same request (rather than after the deployment was succesful as it is now)
- reimplements some UX features we have to make sense with the new approach: 

The features:
- set environment variables with `genezio deploy --env .env` - now this atomically sets environment variable in a single request to the backend and cloud provider.
- Proactively ask the user to set `--env` if an `.env` file is detected - this question is now asked before the deployment.
- Warn the user if there are missing environment variables that are not set remotely. The user should add them from the dashboard or redeploy with `genezio deploy --env .env`.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
