### PR TITLE
fix: convert hyphens to underscores in Python module imports

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -1719,7 +1719,8 @@ async function getLocalFunctionHttpServerPythonWrapper(
         .replace(/\//g, ".") // Convert slashes to dots (Unix)
         .replace(/^\.+/, "") // Remove leading dots
         .replace(/\.+/g, ".") // Remove duplicate dots
-        .replace(/\.py$/, ""); // Remove extension
+        .replace(/\.py$/, "") // Remove extension
+        .replace(/-/g, "_"); // Convert hyphens to underscores for Python module compatibility
 
     return `
 import asyncio

--- a/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
+++ b/src/functionHandlerProvider/providers/AwsFunctionHandlerProvider.ts
@@ -251,7 +251,8 @@ export class AwsPythonFunctionHandlerProvider implements FunctionHandlerProvider
             .replace(/\//g, ".") // Convert slashes to dots (Unix)
             .replace(/^\.+/, "") // Remove leading dots
             .replace(/\.+/g, ".") // Remove duplicate dots
-            .replace(/\.py$/, ""); // Remove extension
+            .replace(/\.py$/, "") // Remove extension
+            .replace(/-/g, "_"); // Convert hyphens to underscores for Python module compatibility
 
         const handlerContent = `
 from setupLambdaGlobals_${randomFileId} import AwsLambda
@@ -342,7 +343,8 @@ def handler(event):
             .replace(/\//g, ".") // Convert slashes to dots (Unix)
             .replace(/^\.+/, "") // Remove leading dots
             .replace(/\.+/g, ".") // Remove duplicate dots
-            .replace(/\.py$/, ""); // Remove extension
+            .replace(/\.py$/, "") // Remove extension
+            .replace(/-/g, "_"); // Convert hyphens to underscores for Python module compatibility;
 
         return `
 import sys


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description
This PR fixes an issue with Python module imports where paths containing hyphens would cause import errors. The fix converts hyphens to underscores in module names to ensure Python import compatibility.

## Changes
- Added conversion of hyphens to underscores in Python module path processing
- Ensures module names follow Python naming conventions

## Example
Before:
`genezio-python-executor/index.py` -> `genezio-python-executor.index` (invalid)

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
