### PR TITLE
Fix entry warning on extensions to allow ./path/to/main.js

### DIFF
--- a/src/projectConfiguration/yaml/v2.ts
+++ b/src/projectConfiguration/yaml/v2.ts
@@ -24,6 +24,7 @@ import { tryV2Migration } from "./migration.js";
 import yaml, { YAMLParseError } from "yaml";
 import { DeepRequired } from "../../utils/types.js";
 import { isUnique } from "../../utils/yaml.js";
+import path from "path";
 
 export type RawYamlProjectConfiguration = ReturnType<typeof parseGenezioConfig>;
 export type YAMLBackend = NonNullable<YamlProjectConfiguration["backend"]>;
@@ -135,9 +136,10 @@ function parseGenezioConfig(config: unknown) {
             // handler is mandatory only if type is AWS
             handler: zod.string().optional(),
             entry: zod.string().refine((value) => {
+                const filename = path.basename(value);
                 return (
-                    value.split(".").length === 2 &&
-                    FUNCTION_EXTENSIONS.includes(value.split(".")[1])
+                    filename.split(".").length === 2 &&
+                    FUNCTION_EXTENSIONS.includes(filename.split(".")[1])
                 );
             }, "The handler should be in the format 'file.extension'. example: index.js / index.mjs / index.cjs / index.py"),
             type: zod.nativeEnum(FunctionType).default(FunctionType.aws),


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Fix entry checking format to allow paths that start with ".":
```
entry: ./dist/main.js
```

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
