### PR TITLE
feat: add support typescript backends on genezio analyze

### DIFF
--- a/src/commands/analyze/command.ts
+++ b/src/commands/analyze/command.ts
@@ -262,10 +262,23 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             debugLogger.debug("Is Serverless HTTP typescript:", isTypescriptFlag);
 
             let entryFileBuildOut = entryFile;
-            if (isTypescriptFlag) {
-                const tsconfigJsonContent = JSON.parse(
-                    await retrieveFileContent(path.join(componentPath, "tsconfig.json")),
+            if (
+                isTypescriptFlag &&
+                (entryFile.endsWith(".ts") ||
+                    entryFile.endsWith(".mts") ||
+                    entryFile.endsWith(".cts"))
+            ) {
+                const tsconfigContent = await retrieveFileContent(
+                    path.join(componentPath, "tsconfig.json"),
                 );
+
+                // Remove comments before parsing JSON
+                const tsconfigJsonString = tsconfigContent
+                    .replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "$1") // Remove comments
+                    .replace(/\s*\n\s*/g, "") // Remove newlines and whitespace
+                    .trim();
+
+                const tsconfigJsonContent = JSON.parse(tsconfigJsonString);
                 entryFileBuildOut = getEntryFileTypescript(entryFile, tsconfigJsonContent);
                 debugLogger.debug("Serverless HTTP entry file build out:", entryFileBuildOut);
             }
@@ -380,10 +393,22 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             debugLogger.debug("Is Express typescript:", isTypescriptFlag);
 
             let entryFileBuildOut = entryFile;
-            if (isTypescriptFlag) {
-                const tsconfigJsonContent = JSON.parse(
-                    await retrieveFileContent(path.join(componentPath, "tsconfig.json")),
+            if (
+                isTypescriptFlag &&
+                (entryFile.endsWith(".ts") ||
+                    entryFile.endsWith(".mts") ||
+                    entryFile.endsWith(".cts"))
+            ) {
+                const tsconfigContent = await retrieveFileContent(
+                    path.join(componentPath, "tsconfig.json"),
                 );
+                // Remove comments before parsing JSON
+                const tsconfigJsonString = tsconfigContent
+                    .replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "$1") // Remove comments
+                    .replace(/\s*\n\s*/g, "") // Remove newlines and whitespace
+                    .trim();
+
+                const tsconfigJsonContent = JSON.parse(tsconfigJsonString);
                 entryFileBuildOut = getEntryFileTypescript(entryFile, tsconfigJsonContent);
                 debugLogger.debug("Express entry file build out:", entryFileBuildOut);
             }
@@ -394,7 +419,6 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             await addBackendComponentToConfig(configPath, {
                 path: componentPath,
                 language: {
-                    // TODO: Add support for detecting and building typescript backends
                     name: Language.js,
                     runtime: DEFAULT_NODE_RUNTIME,
                 } as YAMLLanguage,
@@ -440,10 +464,22 @@ export async function analyzeCommand(options: GenezioAnalyzeOptions) {
             const isTypescriptFlag = await isTypescript(contents);
             debugLogger.debug("Is Fastify typescript:", isTypescriptFlag);
             let entryFileBuildOut = entryFile;
-            if (isTypescriptFlag) {
-                const tsconfigJsonContent = JSON.parse(
-                    await retrieveFileContent(path.join(componentPath, "tsconfig.json")),
+            if (
+                isTypescriptFlag &&
+                (entryFile.endsWith(".ts") ||
+                    entryFile.endsWith(".mts") ||
+                    entryFile.endsWith(".cts"))
+            ) {
+                const tsconfigContent = await retrieveFileContent(
+                    path.join(componentPath, "tsconfig.json"),
                 );
+                // Remove comments before parsing JSON
+                const tsconfigJsonString = tsconfigContent
+                    .replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "$1") // Remove comments
+                    .replace(/\s*\n\s*/g, "") // Remove newlines and whitespace
+                    .trim();
+
+                const tsconfigJsonContent = JSON.parse(tsconfigJsonString);
                 entryFileBuildOut = getEntryFileTypescript(entryFile, tsconfigJsonContent);
                 debugLogger.debug("Fastify entry file build out:", entryFileBuildOut);
             }

--- a/src/commands/analyze/constants.ts
+++ b/src/commands/analyze/constants.ts
@@ -11,10 +11,7 @@ export const FASTIFY_PATTERN = [
     /import\s+Fastify\s+from\s+['"]fastify['"]|import\s+fastify\s+from\s+['"]fastify['"]|require\(['"]fastify['"]\)/,
 ];
 
-export const EXPRESS_PATTERN = [
-    /app\.listen/,
-    /import\s+express\s+from\s+['"]express['"]|require\(['"]express['"]\)/,
-];
+export const EXPRESS_PATTERN = [/app\.listen/, /import.*from\s+['"]express['"]/];
 
 export const SERVERLESS_HTTP_PATTERN = [
     /import\s+Serverless\s+from\s+['"]serverless-http['"]|import\s+serverless\s+from\s+['"]serverless-http['"]|require\(['"]serverless-http['"]\)/,

--- a/src/commands/analyze/frameworks.ts
+++ b/src/commands/analyze/frameworks.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { EXCLUDED_DIRECTORIES, KEY_DEPENDENCY_FILES } from "./command.js";
-import { FUNCTION_EXTENSIONS } from "../../models/projectOptions.js";
 import { debugLogger } from "../../utils/logging.js";
 
 export interface PackageJSON {
@@ -69,7 +68,7 @@ export async function findEntryFile(
         return candidateFile;
     }
 
-    const FUNCTION_EXTENSIONS_WITH_TS = FUNCTION_EXTENSIONS.concat(".ts");
+    const FUNCTION_EXTENSIONS_WITH_TS = ["js", "mjs", "cjs", "py", "ts", "mts", "cts"];
     const entryFile = await findFileByPatterns(
         componentPath,
         patterns,

--- a/src/commands/analyze/frameworks.ts
+++ b/src/commands/analyze/frameworks.ts
@@ -69,7 +69,12 @@ export async function findEntryFile(
         return candidateFile;
     }
 
-    const entryFile = await findFileByPatterns(componentPath, patterns, FUNCTION_EXTENSIONS);
+    const FUNCTION_EXTENSIONS_WITH_TS = FUNCTION_EXTENSIONS.concat(".ts");
+    const entryFile = await findFileByPatterns(
+        componentPath,
+        patterns,
+        FUNCTION_EXTENSIONS_WITH_TS,
+    );
     if (entryFile) {
         return path.relative(componentPath, entryFile);
     }

--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -17,7 +17,7 @@ export const DEFAULT_NODE_RUNTIME_IMAGE = CONTAINER_IMAGE_NODE20;
 
 // Note: ts and tsx are not included in the list of FUNCTION_EXTENSIONS intentionally
 // A typescript function will be compiled to javascript before being deployed
-export const FUNCTION_EXTENSIONS = ["js", "mjs", "cjs", "py"];
+export const FUNCTION_EXTENSIONS = ["js", "mjs", "cjs", "py", "ts"];
 
 export type NodeOptions = {
     nodeRuntime: NodeRuntime;

--- a/src/models/projectOptions.ts
+++ b/src/models/projectOptions.ts
@@ -17,7 +17,7 @@ export const DEFAULT_NODE_RUNTIME_IMAGE = CONTAINER_IMAGE_NODE20;
 
 // Note: ts and tsx are not included in the list of FUNCTION_EXTENSIONS intentionally
 // A typescript function will be compiled to javascript before being deployed
-export const FUNCTION_EXTENSIONS = ["js", "mjs", "cjs", "py", "ts"];
+export const FUNCTION_EXTENSIONS = ["js", "mjs", "cjs", "py"];
 
 export type NodeOptions = {
     nodeRuntime: NodeRuntime;


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Improves how we handle TypeScript compilation output paths by properly respecting `tsconfig.json` settings. This ensures we correctly reference the compiled files during deployment, taking into account the project's TypeScript configuration.

```
// tsconfig.json
{
"compilerOptions": {
"outDir": "./build",
"rootDir": "./src",
"module": "esnext"
}
}
```

For an entry file at `src/api/index.ts`, the system will now correctly resolve to `build/api/index.mjs`.

### Default Behavior
If no tsconfig.json is found or settings are missing:
- `outDir`: defaults to "dist"
- `rootDir`: defaults to "."
- `module`: defaults to "commonjs"


## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
