### PR TITLE
fix: preserve existing port environment variables

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -1974,6 +1974,7 @@ async function startSsrFramework(
             stdio: "pipe",
             env: {
                 ...process.env,
+                ...loadedEnvVars,
                 ...newEnvObject,
                 CI: "1", // Forces CI mode
                 TERM: "dumb", // Simplifies terminal output

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -1551,7 +1551,10 @@ async function startLocalUnitProcess(
 
     // Store the port in the environment variables
     const modifyLocalUnitName = localUnitName.replace(/-/g, "_").toUpperCase();
-    process.env[`GENEZIO_PORT_${modifyLocalUnitName}`] = availablePort.toString();
+    const portEnvKey = `GENEZIO_PORT_${modifyLocalUnitName}`;
+    if (!process.env[portEnvKey]) {
+        process.env[portEnvKey] = availablePort.toString();
+    }
     const processParameters = [...parameters, availablePort.toString()];
     const localUnitProcess = spawn(startingCommand, processParameters, {
         stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

Modifies port setting logic to preserve existing environment variable values.

- Adds check before setting port environment variable
- Prevents overwriting manually configured ports
- Improves predictability for custom configurations

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
