### PR TITLE
allow 5GB bundle size for persistent functions

### DIFF
--- a/src/cloudAdapter/genezio/genezioAdapter.ts
+++ b/src/cloudAdapter/genezio/genezioAdapter.ts
@@ -32,6 +32,7 @@ import { EnvironmentVariable } from "../../models/environmentVariables.js";
 
 // The maximum size of a bundle is 1.524e9 bytes approx 1.5GB.
 const BUNDLE_SIZE_LIMIT = 1.524e9;
+const PERSISTENT_BUNDLE_SIZE_LIMIT = 5.0e9; // 5GB
 
 async function handleBigElementSizeError(
     element: GenezioCloudInput,
@@ -140,7 +141,11 @@ export class GenezioCloudAdapter implements CloudAdapter {
         );
 
         const promisesDeploy = input.map(async (element) => {
-            await handleBigElementSizeError(element, projectConfiguration, BUNDLE_SIZE_LIMIT);
+            await handleBigElementSizeError(
+                element,
+                projectConfiguration,
+                element.persistent ? PERSISTENT_BUNDLE_SIZE_LIMIT : BUNDLE_SIZE_LIMIT,
+            );
 
             debugLogger.debug(
                 `Get the presigned URL for ${element.type}: ${element.name} ${element.archiveName}.`,


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🧑‍💻 Improvement

## Description

Allow bigger bundle size (5GB) for persistent functions

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [x] New and existing unit tests pass locally with my changes;
