### PR TITLE
Fix persistent configuration for classes decorators

### DIFF
--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -106,6 +106,11 @@ export async function scanClassesForDecorators(
                         type = getTriggerTypeFromString(classType);
                     }
 
+                    let persistentDecorator = false;
+                    if ((deployDecoratorFound.arguments["persistent"] as string) === "true") {
+                        persistentDecorator = true;
+                    }
+
                     timeout = deployDecoratorFound.arguments["timeout"] as number | undefined;
                     storageSize = deployDecoratorFound.arguments["storageSize"] as
                         | number
@@ -124,9 +129,7 @@ export async function scanClassesForDecorators(
                     cooldownTime = deployDecoratorFound.arguments["cooldownTime"] as
                         | number
                         | undefined;
-                    persistent = deployDecoratorFound.arguments["persistent"] as
-                        | boolean
-                        | undefined;
+                    persistent = persistentDecorator;
                 }
 
                 classes.push({


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

It seems that use `persistent` as boolean in the decorator `GenezioDeploy` doesn't work. I am not exactly sure why.

The current fix is to use `persistent` as a string and later cast it to a boolean in the codebase.

Usage example:
```
@GenezioDeploy({
  type: "jsonrpc",
  persistent: "true"
})
```

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
