### PR TITLE
[getenv] Escape env vars content when revealing them

### DIFF
--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -32,7 +32,7 @@ export async function revealEnvironmentVariables(options: GenezioEnvOptions) {
     if (options.format === "json") {
         content = JSON.stringify(envVarList, null, 2);
     } else {
-        content = envVarList.map((envVar) => `${envVar.name}=${envVar.value}`).join("\n");
+        content = envVarList.map((envVar) => `${envVar.name}="${envVar.value}"`).join("\n");
     }
 
     try {


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [x] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Adding quotes to escape special characters in the env var value when revealing them.

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
