### PR TITLE
Support mongo dedicated clusters

### DIFF
--- a/src/commands/deploy/utils.ts
+++ b/src/commands/deploy/utils.ts
@@ -117,12 +117,22 @@ export async function prepareServicesPreBackendDeployment(
             if (!database.region) {
                 database.region = configuration.region;
             }
+            let createdDatabaseRequest: CreateDatabaseRequest = {
+                name: database.name,
+                region: database.region,
+                type: database.type,
+            };
+            if (database.type === DatabaseType.mongo) {
+                createdDatabaseRequest = {
+                    ...createdDatabaseRequest,
+                    clusterType: database.clusterType,
+                    clusterName: database.clusterName,
+                    clusterTier: database.clusterTier,
+                };
+            }
+
             await getOrCreateDatabase(
-                {
-                    name: database.name,
-                    region: database.region,
-                    type: database.type,
-                },
+                createdDatabaseRequest,
                 environment || "prod",
                 projectDetails.projectId,
                 projectDetails.projectEnvId,
@@ -701,12 +711,23 @@ export async function enableAuthentication(
         if (!configDatabase.region) {
             configDatabase.region = configuration.region;
         }
+
+        let createdDatabaseRequest: CreateDatabaseRequest = {
+            name: configDatabase.name,
+            region: configDatabase.region,
+            type: configDatabase.type,
+        };
+        if (configDatabase.type === DatabaseType.mongo) {
+            createdDatabaseRequest = {
+                ...createdDatabaseRequest,
+                clusterType: configDatabase.clusterType,
+                clusterName: configDatabase.clusterName,
+                clusterTier: configDatabase.clusterTier,
+            };
+        }
+
         const database: GetDatabaseResponse | undefined = await getOrCreateDatabase(
-            {
-                name: configDatabase.name,
-                region: configDatabase.region,
-                type: configDatabase.type,
-            },
+            createdDatabaseRequest,
             stage,
             projectId,
             projectEnvId,

--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -42,6 +42,7 @@ import { DartBundler } from "../bundlers/dart/localDartBundler.js";
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { findAvailablePort } from "../utils/findAvailablePort.js";
 import {
+    DatabaseType,
     entryFileFunctionMap,
     FunctionType,
     Language,
@@ -103,6 +104,7 @@ import { getFunctionEntryFilename } from "../utils/getFunctionEntryFilename.js";
 import { SSRFrameworkComponent } from "./deploy/command.js";
 import fs from "fs";
 import { detectPythonCommand } from "../utils/detectPythonCommand.js";
+import { CreateDatabaseRequest } from "../models/requests.js";
 
 type UnitProcess = {
     process: ChildProcess;
@@ -168,12 +170,22 @@ export async function prepareLocalBackendEnvironment(
                     if (!database.region) {
                         database.region = region;
                     }
+                    let createdDatabaseRequest: CreateDatabaseRequest = {
+                        name: database.name,
+                        region: database.region,
+                        type: database.type,
+                    };
+                    if (database.type === DatabaseType.mongo) {
+                        createdDatabaseRequest = {
+                            ...createdDatabaseRequest,
+                            clusterType: database.clusterType,
+                            clusterName: database.clusterName,
+                            clusterTier: database.clusterTier,
+                        };
+                    }
+
                     const remoteDatabase = await getOrCreateDatabase(
-                        {
-                            name: database.name,
-                            region: database.region,
-                            type: database.type,
-                        },
+                        createdDatabaseRequest,
                         options.stage || "prod",
                         projectDetails.projectId,
                         projectDetails.projectEnvId,

--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -5,10 +5,26 @@ import {
 } from "../projectConfiguration/yaml/models.js";
 import { ProjectDetailsEnvElement } from "../requests/models.js";
 
+export enum MongoClusterType {
+    SHARED = "sharedCluster",
+    DEDICATED = "dedicatedCluster",
+}
+
+export enum MongoClusterTier {
+    M10 = "M10",
+    M20 = "M20",
+    M30 = "M30",
+    M40 = "M40",
+    M50 = "M50",
+}
+
 export interface CreateDatabaseRequest {
     name: string;
     region: string;
     type: DatabaseType;
+    clusterType?: MongoClusterType;
+    clusterName?: string;
+    clusterTier?: MongoClusterTier;
 }
 
 export interface CreateDatabaseResponse {

--- a/src/projectConfiguration/yaml/v2.ts
+++ b/src/projectConfiguration/yaml/v2.ts
@@ -25,6 +25,7 @@ import yaml, { YAMLParseError } from "yaml";
 import { DeepRequired } from "../../utils/types.js";
 import { isUnique } from "../../utils/yaml.js";
 import path from "path";
+import { MongoClusterTier, MongoClusterType } from "../../models/requests.js";
 
 export type RawYamlProjectConfiguration = ReturnType<typeof parseGenezioConfig>;
 export type YAMLBackend = NonNullable<YamlProjectConfiguration["backend"]>;
@@ -188,6 +189,9 @@ function parseGenezioConfig(config: unknown) {
                 region: zod
                     .enum(mongoDatabaseRegions.map((r) => r.value) as [string, ...string[]])
                     .optional(),
+                clusterType: zod.nativeEnum(MongoClusterType).optional(),
+                clusterName: zod.string().optional(),
+                clusterTier: zod.nativeEnum(MongoClusterTier).optional(),
             }),
         );
 

--- a/src/requests/database.ts
+++ b/src/requests/database.ts
@@ -25,6 +25,9 @@ export async function createDatabase(
         name: name,
         region: region,
         type: type,
+        clusterType: request.clusterType,
+        clusterName: request.clusterName,
+        clusterTier: request.clusterTier,
     });
 
     const databaseResponse = (await sendRequest(


### PR DESCRIPTION
# Pull Request Template

<!--
  Before submitting a Pull Request, please ensure you've done the following:
  - Read the Genezio Contributing Guide: https://github.com/Genez-io/genezio/blob/main/CONTRIBUTING.md
  - Read the Genezio Code of Conduct: https://github.com/Genez-io/genezio/blob/main/CODE_OF_CONDUCT.md
  - Provide tests for your changes.
  - Add comments on your code.
  - Use descriptive commit messages.
  - Update any related documentation and include any relevant screenshots for UI/UX changes.
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 New feature
-   [ ] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

<!--
Please do not leave this blank. Add a small summary of the PR:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

List any dependencies that are required for this change.
-->

Support for dedicated atlas clusters. To activate this, a user should have a custom subscription.

How can one use this:
```yaml
  databases:
    - name: internal-gta-db
      region: eu-central-1
      type: mongo-atlas
      clusterType: dedicated
      clusterName: my-atlas-cluster
      clusterTier: M30
```

[backwards compatibility] For configs that do not explicitly set the `clusterType` to `dedicated`, we will use the shared cluster:
```yaml
  databases:
    - name: internal-gta-db
      region: eu-central-1
      type: mongo-atlas
```
or
```yaml
  databases:
    - name: internal-gta-db
      region: eu-central-1
      type: mongo-atlas
      clusterType: shared
```

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
