### PR TITLE
fix: properly quote commands in docker container execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "@babel/preset-typescript": "^7.26.0",
                 "@babel/traverse": "^7.27.0",
                 "@genezio/test-interface-component": "^2.4.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.40.1",
                 "@sentry/node": "^7.120.3",
                 "@sentry/profiling-node": "~7.120.0",
                 "@types/adm-zip": "^0.5.6",

--- a/src/commands/deploy/docker/deploy.ts
+++ b/src/commands/deploy/docker/deploy.ts
@@ -143,7 +143,8 @@ export async function dockerDeploy(options: GenezioDeployOptions) {
     }
 
     if (cmd) {
-        cmdEntryFile += cmd.join(" ");
+        // Always quote the command when using /bin/sh -c to ensure proper argument handling
+        cmdEntryFile += `'${cmd.join(" ")}'`;
     }
 
     projectConfiguration.functions.push(


### PR DESCRIPTION
## Type of change

-   [ ] 🍕 New feature
-   [x] 🐛 Bug Fix
-   [ ] 🔥 Breaking change
-   [ ] 🧑‍💻 Improvement
-   [ ] 📝 Documentation Update

## Description

This PR fixes an issue with command execution in Docker containers where commands with multiple arguments were not being properly quoted when using `/bin/sh -c`.

### Changes
- Modified the command construction to always quote the entire command when using `/bin/sh -c`
- This ensures proper execution of commands with multiple arguments (e.g. `python app.py`, `node server.js`, etc.)

## Checklist

-   [x] My code follows the contributor guidelines of this project;
-   [ ] I have updated the documentation;
-   [ ] I have added tests;
-   [x] New and existing unit tests pass locally with my changes;
