### PR TITLE
feat: add prepare request before actual deployment

### DIFF
--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -95,7 +95,7 @@ import {
 } from "../../models/projectOptions.js";
 import { detectPythonVersion } from "../../utils/detectPythonCommand.js";
 import { isCI } from "../../utils/process.js";
-import { setEnvironmentVariables } from "../../requests/setEnvironmentVariables.js";
+import { deployRequest } from "../../requests/deployCode.js";
 
 export async function genezioDeploy(options: GenezioDeployOptions) {
     const configIOController = new YamlConfigurationIOController(options.config, {
@@ -190,23 +190,6 @@ export async function genezioDeploy(options: GenezioDeployOptions) {
         });
 
         if (deployClassesResult) {
-            if (configuration.backend?.environment) {
-                const environmentVariablesFromRemote = await createBackendEnvVarListFromRemote(
-                    configuration.backend?.environment,
-                    configuration,
-                    options.stage || "prod",
-                );
-
-                debugLogger.debug(
-                    `Environment variables set from remote resources ${JSON.stringify(environmentVariablesFromRemote)}`,
-                );
-                setEnvironmentVariables(
-                    deployClassesResult?.projectId,
-                    deployClassesResult?.projectEnvId,
-                    environmentVariablesFromRemote,
-                );
-            }
-
             await warningMissingEnvironmentVariables(
                 backendCwd,
                 deployClassesResult?.projectId,
@@ -572,11 +555,33 @@ export async function deployClasses(
         (r) => r.remote === "origin",
     )?.url;
 
+    debugLogger.debug(`Sending prepare request`);
+    const prepareResult = await deployRequest(
+        projectConfiguration,
+        cloudAdapterDeployInput,
+        options.stage,
+        stack,
+        projectGitRepositoryUrl,
+        undefined,
+        true,
+    );
+
     const environmentVariables = await createBackendEnvVarList(
         options.env,
         options.stage,
         configuration,
     );
+
+    if (prepareResult.projectId) {
+        if (configuration.backend?.environment) {
+            const environmentVariablesFromRemote = await createBackendEnvVarListFromRemote(
+                configuration.backend?.environment,
+                configuration,
+                options.stage || "prod",
+            );
+            environmentVariables.push(...environmentVariablesFromRemote);
+        }
+    }
 
     // TODO: Enable cloud adapter setting for every class
     const cloudAdapter = getCloudAdapter(cloudProvider);

--- a/src/requests/deployCode.ts
+++ b/src/requests/deployCode.ts
@@ -20,6 +20,7 @@ export async function deployRequest(
     stack: string[] = [],
     sourceRepository?: string,
     environmentVariables?: EnvironmentVariable[],
+    prepareOnly: boolean = false,
 ): Promise<DeployCodeResponse> {
     // auth token
     printAdaptiveLog("Checking your credentials", "start");
@@ -73,9 +74,14 @@ export async function deployRequest(
 
     const controller = new AbortController();
     const messagePromise = printUninformativeLog(controller);
+    const method = prepareOnly ? "POST" : "PUT";
+    const url = prepareOnly
+        ? `${BACKEND_ENDPOINT}/core/deployment/prepare`
+        : `${BACKEND_ENDPOINT}/core/deployment`;
+
     const response: AxiosResponse<StatusOk<DeployCodeResponse>> = await axios({
-        method: "PUT",
-        url: `${BACKEND_ENDPOINT}/core/deployment`,
+        method: method,
+        url: url,
         data: json,
         headers: {
             Authorization: `Bearer ${authToken}`,


### PR DESCRIPTION
## Type of change

-   [x] 🍕 New feature

## Description

In order to have the function IDs and URLs when the deploy is performed, in case they are used in environment variables, do a prepare request to save the project in the backend before the actual deploy.