### PR TITLE
feature: add healthcheckPath field to yaml for persistent functions

### DIFF
--- a/src/cloudAdapter/cloudAdapter.ts
+++ b/src/cloudAdapter/cloudAdapter.ts
@@ -14,7 +14,7 @@ export enum GenezioCloudInputType {
     FUNCTION = "function",
 }
 
-export type GenezioFunctionMetadata = ContainerMetadata | PythonMetadata;
+export type GenezioFunctionMetadata = ContainerMetadata | FunctionMetadata | PythonMetadata;
 export enum GenezioFunctionMetadataType {
     Container = "container",
     Python = "python",
@@ -25,9 +25,14 @@ export type ContainerMetadata = {
     cmd?: string;
     cwd?: string;
     http_port?: string;
+    healthcheck_path?: string;
 };
 
-export type PythonMetadata = {
+export type FunctionMetadata = {
+    healthcheck_path?: string;
+};
+
+export type PythonMetadata = FunctionMetadata & {
     type: GenezioFunctionMetadataType.Python;
     app_name?: string;
 };

--- a/src/commands/deploy/docker/deploy.ts
+++ b/src/commands/deploy/docker/deploy.ts
@@ -155,6 +155,16 @@ export async function dockerDeploy(options: GenezioDeployOptions) {
             /*language:*/ "container",
             /*entry*/ "",
             /*type:*/ FunctionType.aws,
+            /*timeout:*/ undefined,
+            /*storageSize:*/ undefined,
+            /*instanceSize:*/ undefined,
+            /*vcpuCount:*/ undefined,
+            /*memoryMb:*/ undefined,
+            /*maxConcurrentRequestsPerInstance:*/ undefined,
+            /*maxConcurrentInstances:*/ undefined,
+            /*cooldownTime:*/ undefined,
+            /*persistent:*/ undefined,
+            /*healthcheckPath:*/ config.container?.healthcheckPath,
         ),
     );
 
@@ -187,6 +197,7 @@ export async function dockerDeploy(options: GenezioDeployOptions) {
         cmd: cmdEntryFile,
         cwd: dockerWorkingDir,
         http_port: port,
+        healthcheck_path: config.container?.healthcheckPath,
     };
     const result = await cloudAdapter.deploy(
         [

--- a/src/commands/deploy/genezio.ts
+++ b/src/commands/deploy/genezio.ts
@@ -694,7 +694,9 @@ export async function functionToCloudInput(
         }
     }
 
-    let metadata: GenezioFunctionMetadata | undefined;
+    let metadata: GenezioFunctionMetadata | undefined = {
+        healthcheck_path: functionElement.healthcheckPath,
+    };
 
     // Handle Python projects dependencies
     // asgilinux-3.13
@@ -706,6 +708,7 @@ export async function functionToCloudInput(
         metadata = {
             type: GenezioFunctionMetadataType.Python,
             app_name: functionElement.handler,
+            healthcheck_path: functionElement.healthcheckPath,
         };
 
         const requirementsPath = path.join(backendPath, functionElement.path, "requirements.txt");

--- a/src/models/projectConfiguration.ts
+++ b/src/models/projectConfiguration.ts
@@ -128,6 +128,7 @@ export class FunctionConfiguration {
     maxConcurrentInstances?: number;
     cooldownTime?: number;
     persistent?: boolean;
+    healthcheckPath?: string;
 
     constructor(
         name: string,
@@ -145,6 +146,7 @@ export class FunctionConfiguration {
         maxConcurrentInstances?: number,
         cooldownTime?: number,
         persistent?: boolean,
+        healthcheckPath?: string,
     ) {
         this.name = name;
         this.path = path;
@@ -161,6 +163,7 @@ export class FunctionConfiguration {
         this.maxConcurrentInstances = maxConcurrentInstances;
         this.cooldownTime = cooldownTime;
         this.persistent = persistent;
+        this.healthcheckPath = healthcheckPath;
     }
 }
 
@@ -333,6 +336,7 @@ export class ProjectConfiguration {
                     maxConcurrentRequestsPerInstance: f.maxConcurrentRequestsPerInstance,
                     maxConcurrentInstances: f.maxConcurrentInstances,
                     cooldownTime: f.cooldownTime,
+                    healthcheckPath: f.healthcheckPath,
                 };
             }) || [];
     }


### PR DESCRIPTION
## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] 🍕 New feature

## Description

The `healthcheckPath` field is used during the deployment of persistent functions to validate that the new deployment is healthy before returning a status.

